### PR TITLE
fix(mcp): reject pending dispatcher requests when session socket closes

### DIFF
--- a/.changeset/reject-pending-on-session-close.md
+++ b/.changeset/reject-pending-on-session-close.md
@@ -1,0 +1,10 @@
+---
+"@tesseron/mcp": patch
+---
+
+Fix hang on session WebSocket disconnect: the gateway now rejects all pending
+dispatcher requests (`actions/invoke`, `resources/read`, `resources/subscribe`,
+`resources/unsubscribe`) with a `TransportClosedError` when a session's socket
+closes, mirroring the SDK-side behaviour. Previously, in-flight requests
+abandoned by a disappearing SDK would hang until the MCP client's own timeout
+kicked in.

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -11,6 +11,7 @@ import {
   type SamplingResult,
   TesseronError,
   TesseronErrorCode,
+  TransportClosedError,
   type WelcomeResult,
 } from '@tesseron/core';
 import { JsonRpcDispatcher } from '@tesseron/core/internal';
@@ -365,6 +366,11 @@ export class TesseronGateway extends EventEmitter {
     });
 
     ws.on('close', () => {
+      // Mirrors the SDK-side rejectAllPending in TesseronClient: without it,
+      // any gateway->SDK request in flight when the socket dies never settles,
+      // and the MCP client's tool call hangs until its own timeout expires.
+      dispatcher.rejectAllPending(new TransportClosedError('Session socket closed'));
+
       if (!session) return;
       this.sessions.delete(session.id);
       this.pendingClaims.delete(session.claimCode);

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -225,6 +225,45 @@ describe('Tesseron MCP integration', () => {
     expect(await listToolNames()).not.toContain('eph1__boop');
   });
 
+  it('rejects in-flight invocations when the session WebSocket closes mid-call', async () => {
+    // Invariant: when a session socket closes mid-call, the gateway must reject
+    // the pending dispatcher request, not just clear its active-invocations map.
+    // Otherwise `tools/call` hangs until the MCP client's own timeout expires.
+    let release!: () => void;
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const { sdk } = await setupAndClaim('flight1', (s) => {
+      s.action('hang').handler(async () => {
+        await blocker;
+        return 'never';
+      });
+    });
+
+    try {
+      const callPromise = callTool('flight1__hang', {});
+      // Give the call a beat to land on the SDK side before we yank the socket.
+      await new Promise((r) => setTimeout(r, 50));
+
+      await sdk.disconnect();
+
+      // Should reject (surface as an error tool-call), not hang.
+      const result = await Promise.race([
+        callPromise,
+        new Promise<CallOutcome>((_, reject) =>
+          setTimeout(() => reject(new Error('callTool hung past 2s')), 2000),
+        ),
+      ]);
+      expect(result.isError).toBe(true);
+      expect(result.text.toLowerCase()).toMatch(/transport|socket|closed|disconnect/);
+    } finally {
+      // Release the handler so the awaiting promise in the SDK can finalize,
+      // regardless of whether the assertions above passed or the race timed out.
+      release();
+    }
+  });
+
   it('rejects reserved app ids during handshake', async () => {
     const sdk = newSdk();
     sdk.app({ id: 'tesseron', name: 'evil', origin: 'http://localhost' });

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -248,7 +248,6 @@ describe('Tesseron MCP integration', () => {
 
       await sdk.disconnect();
 
-      // Should reject (surface as an error tool-call), not hang.
       const result = await Promise.race([
         callPromise,
         new Promise<CallOutcome>((_, reject) =>


### PR DESCRIPTION
## Summary

Fixes #1. Before this patch, if a Tesseron app's WebSocket disappeared mid-call (tab refresh, window close, network blip, SDK crash), the gateway cleared its internal `activeInvocations` tracking map but never rejected the Promises in the underlying `JsonRpcDispatcher`. Any request the gateway had in flight against the SDK (`actions/invoke`, `resources/read`, `resources/subscribe`, `resources/unsubscribe`) would hang until the MCP client's own timeout kicked in, surfacing as a stuck `tools/call` on the agent side.

## Fix

One call in `gateway.ts`'s `ws.on('close')` handler, mirroring the SDK-side behaviour at `client.ts:190-192`:

```ts
dispatcher.rejectAllPending(new TransportClosedError('Session socket closed'));
```

## Test

Added an integration test that:

1. Registers an action whose handler awaits a never-released promise.
2. Invokes it through the MCP client.
3. Disconnects the SDK mid-call.
4. Asserts the `tools/call` returns an error tool result (not hangs) within 2 s.

Without the fix, the test hangs forever. With it, all 44 tests pass (`pnpm --filter @tesseron/mcp test`).

## Test plan

- [x] `pnpm --filter @tesseron/mcp test`
- [x] `pnpm --filter @tesseron/mcp typecheck`
- [x] `biome format --write` clean

## Notes

- Uses the existing `TransportClosedError` already exported from `@tesseron/core` (no public-API surface change).
- Patch-level changeset included.
- Surfaced by a r/ClaudeCode user asking about tab-refresh recovery; a separate v1.1 feature for pairing persistence is tracked in #2 / PR #4.
- A follow-up improvement to surface the typed error code via `structuredContent` (so agents can programmatically branch on `TransportClosed` instead of regex-matching text) is tracked in #5 / PR #6.
