### PR TITLE
feat: session resume (protocol primitive; storage is implementer's job)

### DIFF
--- a/.changeset/session-resume-protocol.md
+++ b/.changeset/session-resume-protocol.md
@@ -1,0 +1,49 @@
+---
+"@tesseron/core": minor
+"@tesseron/mcp": minor
+"@tesseron/server": minor
+"@tesseron/web": minor
+---
+
+Add session resume: SDKs can rejoin a previously-claimed session after a
+transport drop (tab refresh, network blip, HMR) without going through the
+6-character claim-code dance again.
+
+**Protocol** (`@tesseron/core`)
+
+- `WelcomeResult.resumeToken` now carries an opaque, cryptographically-random
+  token the caller can stash to rejoin this session later.
+- New `tesseron/resume` method with `{ sessionId, resumeToken }` params plus
+  the same manifest fields as `tesseron/hello` (a fresh app build may have
+  added, removed, or changed actions/resources since last connect).
+- New `TesseronErrorCode.ResumeFailed` (`-32011`) covers unknown session,
+  expired zombie, unclaimed zombie, and bad-token failures.
+
+**Gateway** (`@tesseron/mcp`)
+
+- New `GatewayOptions.resumeTtlMs` (default 90 s). Closed sessions are
+  retained as zombies for this window and can be resumed via
+  `tesseron/resume`. Set to `0` to disable resume entirely.
+- Constant-time token compare via `crypto.timingSafeEqual` with a length
+  pre-check.
+- Tokens are one-shot: every successful resume rotates the token.
+
+**SDK** (`@tesseron/core`, `@tesseron/server`, `@tesseron/web`)
+
+- `TesseronClient.connect(transport, options?)` and the URL-string overloads
+  on `ServerTesseronClient` / `WebTesseronClient` accept a new optional
+  `{ resume: { sessionId, resumeToken } }` argument. When present, the SDK
+  sends `tesseron/resume` instead of `tesseron/hello`.
+- `ConnectOptions` and `ResumeCredentials` exported from `@tesseron/core`.
+
+**Storage policy**
+
+Storage of the `{ sessionId, resumeToken }` pair is the implementer's
+responsibility. The SDK exposes the primitive; apps decide where the token
+lives (localStorage, cookie, Electron store, OS keychain, etc). A four-line
+recipe for the browser sits in `docs/protocol/resume`; it is intentionally
+not a shipped feature of `@tesseron/web`.
+
+Backwards-compatible: older gateways that never populated `resumeToken`
+continue to work, and SDKs that don't pass `{ resume }` send `tesseron/hello`
+exactly as before.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -93,6 +93,7 @@ export default defineConfig({
             { label: 'Wire format (JSON-RPC)', link: '/protocol/wire-format/' },
             { label: 'Transport (WebSocket)', link: '/protocol/transport/' },
             { label: 'Handshake & claiming', link: '/protocol/handshake/' },
+            { label: 'Session resume', link: '/protocol/resume/' },
             { label: 'Action model', link: '/protocol/actions/' },
             { label: 'Progress & cancellation', link: '/protocol/progress-cancellation/' },
             { label: 'Sampling', link: '/protocol/sampling/' },

--- a/docs/src/content/docs/protocol/resume.mdx
+++ b/docs/src/content/docs/protocol/resume.mdx
@@ -73,22 +73,25 @@ All resume failures surface as a `TesseronError` with code `TesseronErrorCode.Re
 | Unclaimed zombie | `<id> was never claimed` |
 | TTL elapsed | Falls under "no resumable session" - the zombie was already evicted |
 | Wrong `resumeToken` | `Invalid resumeToken for session "<id>"` |
+| Malformed params (missing `app`, non-string `sessionId` / `resumeToken`, missing `actions` / `resources` / `capabilities`) | `Invalid tesseron/resume request: expected { protocolVersion, sessionId, resumeToken, app, actions, resources, capabilities }` |
 | Protocol major-version mismatch | Same rules as `tesseron/hello` - throws `ProtocolMismatch` |
 
 Token comparison uses `crypto.timingSafeEqual` with a length pre-check, so a wildly-wrong token doesn't leak timing information about the correct length.
 
 ## Gateway configuration
 
-Pass `resumeTtlMs` to `new TesseronGateway({ ... })` to change how long zombies live:
+Two knobs on `new TesseronGateway({ ... })` shape how aggressive resume is:
 
 ```ts
 const gateway = new TesseronGateway({
   port: 7475,
-  resumeTtlMs: 300_000, // 5 minutes
+  resumeTtlMs: 300_000, // 5 minutes (default: 90_000)
+  maxZombies: 500,      // cap on zombies held simultaneously (default: 100)
 });
 ```
 
-Set to `0` to disable resume entirely - closed sessions drop immediately and any reconnect must start fresh.
+- `resumeTtlMs` — how long a closed session is retained as a resumable zombie. Set to `0` to disable resume entirely: closed sessions drop immediately and any reconnect must start fresh.
+- `maxZombies` — ceiling on the in-memory zombie map. When inserting a new zombie would exceed it, the oldest (longest-retained) zombie is evicted to make room. Keeps a connect/disconnect flood from piling up zombies faster than their TTLs expire. Set to `0` to disable resume entirely (same effect as `resumeTtlMs: 0`).
 
 ## Idiomatic SDK usage
 

--- a/docs/src/content/docs/protocol/resume.mdx
+++ b/docs/src/content/docs/protocol/resume.mdx
@@ -1,0 +1,143 @@
+---
+title: Session resume
+description: How a Tesseron app rejoins a previously-claimed session after a transport drop via tesseron/resume - protocol shape, gateway behaviour, and the 4-line localStorage recipe.
+---
+
+A Tesseron session lives in the gateway's memory. When the underlying WebSocket drops (tab refresh, window close, network blip, HMR reload), the session normally goes away and a reconnecting app would have to go through the full `tesseron/hello` + claim-code dance again - even if the user had already paired it.
+
+The `tesseron/resume` method lets the app rejoin an existing session it paired earlier, skipping the re-claim. Storage of the resume credentials is deliberately **the implementer's responsibility**: different apps have different opinions about where session credentials can live (localStorage, a cookie, an Electron store, the OS keychain), so the SDK exposes the primitive and leaves the choice to you.
+
+## Flow
+
+1. On a fresh `tesseron/hello`, the gateway returns a `resumeToken` in the welcome. Stash it alongside the `sessionId` wherever fits your app.
+2. When the transport drops, the gateway keeps the session's metadata as a "zombie" for `resumeTtlMs` (default 90 seconds).
+3. On reconnect, the app sends `tesseron/resume` with `{ sessionId, resumeToken }`. If the token matches (constant-time compare) and the zombie is still within its TTL, the gateway reattaches the fresh socket to the existing session and rotates the token.
+4. The caller persists the **new** `resumeToken` from the resume response.
+
+Resume tokens are **one-shot**: every successful resume rotates the token and the previous value stops working. This means the freshest welcome is always the one to persist.
+
+## The `tesseron/resume` request
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tesseron/resume",
+  "params": {
+    "protocolVersion": "1.0.0",
+    "sessionId": "s_a1b2c3de1234567",
+    "resumeToken": "Xk9f3nN9kOeGqR7mWpLc2v",
+    "app": { "id": "shop", "name": "Acme Shop", "origin": "http://localhost:3000" },
+    "actions": [ /* same shape as tesseron/hello */ ],
+    "resources": [ /* same shape as tesseron/hello */ ],
+    "capabilities": {
+      "streaming": true,
+      "subscriptions": true,
+      "sampling": true,
+      "elicitation": true
+    }
+  }
+}
+```
+
+`ResumeParams` carries the same `app` / `actions` / `resources` / `capabilities` as `HelloParams` because a fresh app build may have added, removed, or changed them since the previous connect. The gateway replaces the stored manifest with what resume brings in.
+
+## The resume response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "sessionId": "s_a1b2c3de1234567",
+    "protocolVersion": "1.0.0",
+    "capabilities": { "streaming": true, "subscriptions": true, "sampling": true, "elicitation": true },
+    "agent": { "id": "claude-ai", "name": "Claude Desktop" },
+    "resumeToken": "NEW_ROTATED_TOKEN_VALUE"
+  }
+}
+```
+
+- `sessionId` matches the one in the request (same session, reattached to the fresh socket).
+- `resumeToken` is rotated. Overwrite whatever you stashed with this new value.
+- `claimCode` is **omitted** - the session is already claimed, no need for a re-pair.
+
+## Failure modes
+
+All resume failures surface as a `TesseronError` with code `TesseronErrorCode.ResumeFailed` (`-32011`). Callers typically catch the error and fall back to a plain `tesseron/hello`.
+
+| Condition | Message pattern |
+|---|---|
+| Unknown `sessionId` | `No resumable session "<id>"` |
+| Cross-app resume | `Session "<id>" is owned by app "<other>"` |
+| Unclaimed zombie | `<id> was never claimed` |
+| TTL elapsed | Falls under "no resumable session" - the zombie was already evicted |
+| Wrong `resumeToken` | `Invalid resumeToken for session "<id>"` |
+| Protocol major-version mismatch | Same rules as `tesseron/hello` - throws `ProtocolMismatch` |
+
+Token comparison uses `crypto.timingSafeEqual` with a length pre-check, so a wildly-wrong token doesn't leak timing information about the correct length.
+
+## Gateway configuration
+
+Pass `resumeTtlMs` to `new TesseronGateway({ ... })` to change how long zombies live:
+
+```ts
+const gateway = new TesseronGateway({
+  port: 7475,
+  resumeTtlMs: 300_000, // 5 minutes
+});
+```
+
+Set to `0` to disable resume entirely - closed sessions drop immediately and any reconnect must start fresh.
+
+## Idiomatic SDK usage
+
+The SDK exposes a single `resume` field on `ConnectOptions`. You decide where to stash the token:
+
+```ts
+import { tesseron } from '@tesseron/web';
+
+tesseron.app({ id: 'shop', name: 'Acme Shop' });
+tesseron.action('searchProducts').handler(/* ... */);
+
+const saved = localStorage.getItem('tesseron:shop');
+const welcome = await tesseron.connect(
+  'ws://127.0.0.1:7475',
+  saved ? { resume: JSON.parse(saved) } : undefined,
+);
+
+localStorage.setItem('tesseron:shop', JSON.stringify({
+  sessionId: welcome.sessionId,
+  resumeToken: welcome.resumeToken,
+}));
+```
+
+Four lines. The SDK does not do this for you; `localStorage` is one answer among many. A desktop app might stash the pair in the OS keychain. A server process might put it in a file next to its config. An iframe-embedded app might have CSP reasons not to persist at all.
+
+### Falling back when resume fails
+
+```ts
+try {
+  await tesseron.connect(url, saved ? { resume: JSON.parse(saved) } : undefined);
+} catch (err) {
+  if (err instanceof TesseronError && err.code === TesseronErrorCode.ResumeFailed) {
+    localStorage.removeItem('tesseron:shop');
+    await tesseron.connect(url); // fresh hello
+  } else {
+    throw err;
+  }
+}
+```
+
+## What resume does **not** do
+
+- It does not replay in-flight actions. An action the agent invoked just before the socket dropped is cancelled on the gateway; the agent sees an error (see [lifecycle](/protocol/lifecycle/)) and can retry at its own layer.
+- It does not resurrect resource subscriptions. The SDK re-subscribes on reconnect as it does after any handshake.
+- It does not persist across a gateway restart. Zombies live in gateway process memory; stopping the gateway evicts them. A fresh `tesseron/hello` is required after any gateway restart.
+- It does not work for sessions that were never claimed. The gateway surfaces `ResumeFailed` with `never claimed` so the SDK can fall back to `tesseron/hello` without ambiguity.
+
+## See also
+
+- [Handshake & claiming](/protocol/handshake/) - the `tesseron/hello` flow resume complements.
+- [Lifecycle & failure modes](/protocol/lifecycle/) - how the gateway behaves during drops, retries, and gateway restarts.
+- [Errors & capabilities](/protocol/errors/) - the full `TesseronErrorCode` table including `ResumeFailed`.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -32,6 +32,7 @@ import {
   type ResourceReadResult,
   type ResourceSubscribeParams,
   type ResourceUnsubscribeParams,
+  type ResumeParams,
   type TesseronCapabilities,
   TesseronErrorCode,
   type WelcomeResult,
@@ -44,6 +45,40 @@ import {
   standardValidate,
 } from './schema-helpers.js';
 import { type Transport, TransportClosedError } from './transport.js';
+
+/**
+ * Credentials returned by a previous {@link WelcomeResult} that let the SDK
+ * rejoin that session via `tesseron/resume` instead of opening a fresh one.
+ * Storage of this pair is the implementer's responsibility — stash it in
+ * localStorage, a cookie, an Electron store, the OS keychain, whatever fits
+ * the app.
+ */
+export interface ResumeCredentials {
+  /** `sessionId` from the prior {@link WelcomeResult}. */
+  sessionId: string;
+  /**
+   * `resumeToken` from the prior {@link WelcomeResult}. Rotated on every
+   * successful resume; persist the value returned in each handshake.
+   */
+  resumeToken: string;
+}
+
+/**
+ * Optional arguments to {@link TesseronClient.connect}. Currently supports
+ * opting into session resume; more may be added in future minor versions.
+ */
+export interface ConnectOptions {
+  /**
+   * If provided, the SDK sends `tesseron/resume` with these credentials
+   * instead of `tesseron/hello`. On a successful resume the returned
+   * {@link WelcomeResult} carries the same `sessionId` and a freshly-rotated
+   * `resumeToken`. On failure (unknown session, TTL elapsed, token mismatch)
+   * the request rejects with a {@link TesseronError} of code
+   * {@link TesseronErrorCode.ResumeFailed}; callers typically fall back to a
+   * plain `connect()` at that point.
+   */
+  resume?: ResumeCredentials;
+}
 
 /**
  * App identity sent to the gateway during the `tesseron/hello` handshake.
@@ -173,12 +208,15 @@ export class TesseronClient implements BuilderRegistry {
   }
 
   /**
-   * Sends `tesseron/hello` over the given transport and installs handlers for
-   * action invocations and resource reads. Resolves with the gateway's
-   * {@link WelcomeResult} (includes the claim code the user enters into their MCP client).
+   * Sends `tesseron/hello` (or `tesseron/resume` if {@link ConnectOptions.resume}
+   * is provided) over the given transport and installs handlers for action
+   * invocations and resource reads. Resolves with the gateway's
+   * {@link WelcomeResult}: includes the claim code the user enters into their
+   * MCP client on fresh handshakes, and a `resumeToken` the caller can stash
+   * for a later reconnect.
    * @throws {Error} If called before {@link TesseronClient.app}.
    */
-  async connect(transport: Transport): Promise<WelcomeResult> {
+  async connect(transport: Transport, options?: ConnectOptions): Promise<WelcomeResult> {
     if (!this.appConfig) {
       throw new Error('Tesseron: call app({ id, name }) before connect().');
     }
@@ -213,14 +251,20 @@ export class TesseronClient implements BuilderRegistry {
       return undefined;
     });
 
-    const hello: HelloParams = {
+    const baseParams = {
       protocolVersion: PROTOCOL_VERSION,
       app: this.appConfig,
       actions: this.actionManifest(),
       resources: this.resourceManifest(),
       capabilities: SDK_CAPABILITIES,
     };
-    const welcome = await dispatcher.request('tesseron/hello', hello);
+    const welcome = options?.resume
+      ? await dispatcher.request('tesseron/resume', {
+          ...baseParams,
+          sessionId: options.resume.sessionId,
+          resumeToken: options.resume.resumeToken,
+        } satisfies ResumeParams)
+      : await dispatcher.request('tesseron/hello', baseParams satisfies HelloParams);
     this.welcome = welcome;
     return welcome;
   }

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -76,6 +76,11 @@ export interface ConnectOptions {
    * the request rejects with a {@link TesseronError} of code
    * {@link TesseronErrorCode.ResumeFailed}; callers typically fall back to a
    * plain `connect()` at that point.
+   *
+   * **Resume does NOT restore resource subscriptions.** `resources/subscribe`
+   * bindings on the prior socket are torn down when the transport closes and
+   * are not replayed; if the app relied on push updates, re-subscribe after
+   * the resume handshake resolves.
    */
   resume?: ResumeCredentials;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,4 +10,9 @@ export * from './context.js';
 export * from './builder.js';
 export * from './errors.js';
 export * from './transport.js';
-export { TesseronClient, type AppConfig } from './client.js';
+export {
+  TesseronClient,
+  type AppConfig,
+  type ConnectOptions,
+  type ResumeCredentials,
+} from './client.js';

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -135,15 +135,22 @@ export interface HelloParams {
  * Result of the `tesseron/hello` handshake (and `tesseron/resume`). Carries the
  * session id, the capabilities the MCP client will honour, the connected
  * agent's identity (filled once a bridge attaches), the `claimCode` the user
- * pastes into their MCP client to link this session (omitted on resume of an
- * already-claimed session), and an opaque `resumeToken` the caller can stash
- * wherever fits their app to rejoin this session after a transport drop.
+ * pastes into their MCP client to link this session, and an opaque
+ * `resumeToken` the caller can stash wherever fits their app to rejoin this
+ * session after a transport drop.
  */
 export interface WelcomeResult {
   sessionId: string;
   protocolVersion: string;
   capabilities: TesseronCapabilities;
   agent: AgentIdentity;
+  /**
+   * 6-character pairing code the user enters in their MCP client. Present on
+   * every `tesseron/hello` response. Always **absent** on a successful
+   * `tesseron/resume` response: the gateway only permits resume for
+   * already-claimed sessions, so re-issuing a pairing code would be a no-op
+   * at best and a UI confusion at worst.
+   */
   claimCode?: string;
   /**
    * Server-issued token that, together with {@link WelcomeResult.sessionId},
@@ -186,8 +193,9 @@ export interface ResumeParams extends HelloParams {
 
 /**
  * Result of the `tesseron/resume` request. Same shape as {@link WelcomeResult}
- * — `sessionId` matches the param, `resumeToken` is rotated, `claimCode` is
- * omitted if the session was already claimed.
+ * — `sessionId` matches the param, `resumeToken` is rotated, and `claimCode`
+ * is always absent (the gateway only permits resume for already-claimed
+ * sessions, so there is no pairing code to re-issue).
  */
 export type ResumeResult = WelcomeResult;
 

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -69,6 +69,7 @@ export const TesseronErrorCode = {
   SamplingDepthExceeded: -32008,
   Unauthorized: -32009,
   TransportClosed: -32010,
+  ResumeFailed: -32011,
 } as const;
 
 export type TesseronErrorCodeValue = (typeof TesseronErrorCode)[keyof typeof TesseronErrorCode];
@@ -131,10 +132,12 @@ export interface HelloParams {
 }
 
 /**
- * Result of the `tesseron/hello` handshake. Carries the session id, the
- * capabilities the MCP client will honour, the connected agent's identity
- * (filled once a bridge attaches), and the `claimCode` the user pastes into
- * their MCP client to link this session.
+ * Result of the `tesseron/hello` handshake (and `tesseron/resume`). Carries the
+ * session id, the capabilities the MCP client will honour, the connected
+ * agent's identity (filled once a bridge attaches), the `claimCode` the user
+ * pastes into their MCP client to link this session (omitted on resume of an
+ * already-claimed session), and an opaque `resumeToken` the caller can stash
+ * wherever fits their app to rejoin this session after a transport drop.
  */
 export interface WelcomeResult {
   sessionId: string;
@@ -142,6 +145,16 @@ export interface WelcomeResult {
   capabilities: TesseronCapabilities;
   agent: AgentIdentity;
   claimCode?: string;
+  /**
+   * Server-issued token that, together with {@link WelcomeResult.sessionId},
+   * lets a reconnecting SDK rejoin this session via `tesseron/resume` after the
+   * transport drops. Rotated on every successful resume (one-shot) — callers
+   * that persist it MUST overwrite with the freshest value from each handshake.
+   *
+   * Optional on the wire for backwards-compatibility with gateways that pre-date
+   * the resume extension; new gateways always populate it.
+   */
+  resumeToken?: string;
 }
 
 /** Identity advertised by the MCP client that claimed this session. */
@@ -149,6 +162,34 @@ export interface AgentIdentity {
   id: string;
   name: string;
 }
+
+/**
+ * Parameters of the `tesseron/resume` request sent by the SDK when it already
+ * has a `sessionId` + `resumeToken` pair from a prior handshake and wants to
+ * rejoin an existing (possibly-claimed) session instead of opening a fresh one.
+ *
+ * Carries the same `app` / `actions` / `resources` / `capabilities` as a
+ * regular `tesseron/hello` because a fresh app build may have added, removed,
+ * or changed them since the previous connect. The gateway updates the session's
+ * registered manifest from these fields on a successful resume.
+ */
+export interface ResumeParams extends HelloParams {
+  /** Opaque session identifier returned in the prior {@link WelcomeResult}. */
+  sessionId: string;
+  /**
+   * Opaque token returned in the prior {@link WelcomeResult}. Gateway compares
+   * against the stored token in constant time and rotates it on success; the
+   * freshly-returned {@link WelcomeResult.resumeToken} is the one to persist.
+   */
+  resumeToken: string;
+}
+
+/**
+ * Result of the `tesseron/resume` request. Same shape as {@link WelcomeResult}
+ * — `sessionId` matches the param, `resumeToken` is rotated, `claimCode` is
+ * omitted if the session was already claimed.
+ */
+export type ResumeResult = WelcomeResult;
 
 export interface ActionInvokeParams {
   name: string;
@@ -233,6 +274,7 @@ export interface LogParams {
 
 export interface TesseronMethods {
   'tesseron/hello': { params: HelloParams; result: WelcomeResult };
+  'tesseron/resume': { params: ResumeParams; result: ResumeResult };
   'sampling/request': { params: SamplingRequestParams; result: SamplingResult };
   'elicitation/request': { params: ElicitationRequestParams; result: ElicitationResult };
   'actions/invoke': { params: ActionInvokeParams; result: ActionResultPayload };

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -158,6 +158,12 @@ export class TesseronGateway extends EventEmitter {
    * rejoin them with `tesseron/resume`. See {@link GatewayOptions.resumeTtlMs}.
    */
   private readonly zombieSessions = new Map<string, ZombieSession>();
+  /**
+   * Flipped true by {@link stop} so in-flight `ws.on('close')` events queued by
+   * `ws.close()` during shutdown skip re-inserting zombies into the map we
+   * just cleared. Reset by {@link start} so the gateway can be restarted.
+   */
+  private stopped = false;
   private samplingHandler?: SamplingHandler;
   private elicitationHandler?: ElicitationHandler;
   private agentCapabilities: AgentCapabilityInfo = { ...DEFAULT_AGENT_CAPABILITIES };
@@ -168,6 +174,7 @@ export class TesseronGateway extends EventEmitter {
 
   /** Binds the WebSocket server. Resolves when `listening` fires; rejects on bind error. */
   async start(): Promise<void> {
+    this.stopped = false;
     const port = this.options.port ?? DEFAULT_GATEWAY_PORT;
     const host = this.options.host ?? DEFAULT_GATEWAY_HOST;
     const allowlist = new Set(this.options.originAllowlist ?? []);
@@ -202,6 +209,10 @@ export class TesseronGateway extends EventEmitter {
 
   /** Closes all sessions and shuts down the WebSocket server. */
   async stop(): Promise<void> {
+    // Mark stopped before closing sockets: ws.close() queues a 'close' event
+    // that runs AFTER this function returns, and without the guard each one
+    // would re-insert a zombie into the map we're about to clear.
+    this.stopped = true;
     for (const session of this.sessions.values()) {
       session.ws.close(1001, 'Gateway shutting down');
     }
@@ -422,9 +433,10 @@ export class TesseronGateway extends EventEmitter {
 
       // Zombify the session so a reconnecting SDK can rejoin via
       // `tesseron/resume` within the TTL. When the feature is disabled
-      // (resumeTtlMs === 0) the session is dropped immediately.
+      // (resumeTtlMs === 0) or the gateway is shutting down, the session
+      // is dropped immediately.
       const resumeTtl = this.options.resumeTtlMs ?? DEFAULT_RESUME_TTL_MS;
-      if (resumeTtl > 0) {
+      if (resumeTtl > 0 && !this.stopped) {
         const closedSession = session;
         const evictTimer = setTimeout(() => {
           this.zombieSessions.delete(closedSession.id);
@@ -526,9 +538,26 @@ export class TesseronGateway extends EventEmitter {
       const resumeParams = params as ResumeParams;
 
       if (session) {
+        // A well-behaved SDK never does this; it's a programming error, not a
+        // recoverable resume failure. InvalidRequest (not ResumeFailed) so any
+        // SDK fallback-on-ResumeFailed logic doesn't loop on a malformed call.
+        throw new TesseronError(
+          TesseronErrorCode.InvalidRequest,
+          'This socket is already attached to a session. Send tesseron/resume on a fresh connection.',
+        );
+      }
+
+      // Guard against malformed params before they reach Buffer.from below:
+      // a non-string resumeToken (e.g. a large integer) would otherwise
+      // allocate a raw buffer of that size; other shapes throw a raw TypeError
+      // that leaks as a generic InternalError instead of a typed ResumeFailed.
+      if (
+        typeof resumeParams.sessionId !== 'string' ||
+        typeof resumeParams.resumeToken !== 'string'
+      ) {
         throw new TesseronError(
           TesseronErrorCode.ResumeFailed,
-          'This socket is already attached to a session. Send tesseron/resume on a fresh connection.',
+          'Invalid tesseron/resume request: sessionId and resumeToken must be strings.',
         );
       }
 
@@ -549,7 +578,17 @@ export class TesseronGateway extends EventEmitter {
         );
       }
 
-      validateAppId(resumeParams.app.id);
+      // Remap validateAppId's plain Error into the typed ResumeFailed the
+      // ConnectOptions.resume contract promises, so SDK fallback logic that
+      // branches on err.code === ResumeFailed catches malformed app ids too.
+      try {
+        validateAppId(resumeParams.app.id);
+      } catch (err) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          err instanceof Error ? err.message : 'Invalid app id on resume.',
+        );
+      }
 
       const zombie = this.zombieSessions.get(resumeParams.sessionId);
       if (!zombie) {

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -447,14 +447,14 @@ export class TesseronGateway extends EventEmitter {
 
       // Zombify the session so a reconnecting SDK can rejoin via
       // `tesseron/resume` within the TTL. When the feature is disabled
-      // (resumeTtlMs === 0) or the gateway is shutting down, the session
-      // is dropped immediately.
+      // (resumeTtlMs <= 0 or maxZombies <= 0) or the gateway is shutting
+      // down, the session is dropped immediately.
       const resumeTtl = this.options.resumeTtlMs ?? DEFAULT_RESUME_TTL_MS;
-      if (resumeTtl > 0 && !this.stopped) {
+      const maxZombies = this.options.maxZombies ?? DEFAULT_MAX_ZOMBIES;
+      if (resumeTtl > 0 && maxZombies > 0 && !this.stopped) {
         // Cap the map to prevent a connect/disconnect flood from piling up
         // zombies until their TTLs elapse. Map iteration order is insertion
         // order, so the first key is the oldest entry.
-        const maxZombies = this.options.maxZombies ?? DEFAULT_MAX_ZOMBIES;
         if (this.zombieSessions.size >= maxZombies) {
           const oldestId = this.zombieSessions.keys().next().value;
           if (oldestId !== undefined) {
@@ -576,17 +576,25 @@ export class TesseronGateway extends EventEmitter {
         );
       }
 
-      // Guard against malformed params before they reach Buffer.from below:
-      // a non-string resumeToken (e.g. a large integer) would otherwise
-      // allocate a raw buffer of that size; other shapes throw a raw TypeError
-      // that leaks as a generic InternalError instead of a typed ResumeFailed.
+      // Guard every field the handler dereferences below. Without this, a
+      // malformed resume (missing `app`, non-string `resumeToken`, absent
+      // `actions`) bails out as a raw TypeError — which the dispatcher
+      // surfaces as a generic InternalError and the SDK's ResumeFailed
+      // fallback path never sees. Validate once, up front, typed.
       if (
         typeof resumeParams.sessionId !== 'string' ||
-        typeof resumeParams.resumeToken !== 'string'
+        typeof resumeParams.resumeToken !== 'string' ||
+        typeof resumeParams.protocolVersion !== 'string' ||
+        !resumeParams.app ||
+        typeof resumeParams.app.id !== 'string' ||
+        !Array.isArray(resumeParams.actions) ||
+        !Array.isArray(resumeParams.resources) ||
+        !resumeParams.capabilities ||
+        typeof resumeParams.capabilities !== 'object'
       ) {
         throw new TesseronError(
           TesseronErrorCode.ResumeFailed,
-          'Invalid tesseron/resume request: sessionId and resumeToken must be strings.',
+          'Invalid tesseron/resume request: expected { protocolVersion, sessionId, resumeToken, app, actions, resources, capabilities }.',
         );
       }
 
@@ -664,6 +672,14 @@ export class TesseronGateway extends EventEmitter {
       this.zombieSessions.delete(zombie.id);
 
       if (origin && resumeParams.app.origin !== origin) {
+        // The socket's Origin header is the authoritative value (it's what the
+        // gateway already allowlisted during the WS upgrade). Log the mismatch
+        // against the zombie's stored origin — a drift here can indicate a
+        // misconfigured build (staging bundle dialing a prod gateway, or a
+        // tenant swap) and otherwise leaves no forensic trail.
+        logToStderr(
+          `[tesseron] resume origin mismatch for session ${zombie.id}: stored=${zombie.app.origin} declared=${resumeParams.app.origin} socket=${origin} — rewriting to socket origin`,
+        );
         resumeParams.app.origin = origin;
       }
 

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -20,6 +20,7 @@ import {
   type Session,
   generateClaimCode,
   generateInvocationId,
+  generateResumeToken,
   generateSessionId,
   validateAppId,
 } from './session.js';
@@ -32,6 +33,13 @@ export interface GatewayOptions {
   host?: string;
   /** Extra origins accepted in addition to localhost/127.0.0.1. Anything else is rejected with 403. */
   originAllowlist?: string[];
+  /**
+   * Milliseconds to retain a closed session as a "zombie" so a reconnecting SDK
+   * can rejoin via `tesseron/resume`. Default {@link DEFAULT_RESUME_TTL_MS}.
+   * Set to `0` to disable session resume entirely — closed sessions drop
+   * immediately and any reconnect must start fresh with `tesseron/hello`.
+   */
+  resumeTtlMs?: number;
 }
 
 /** Options for {@link TesseronGateway.invokeAction}. */
@@ -82,6 +90,12 @@ export type ElicitationHandler = (
 export const DEFAULT_GATEWAY_PORT = 7475;
 /** Default gateway bind host; loopback-only to prevent accidental LAN exposure. */
 export const DEFAULT_GATEWAY_HOST = '127.0.0.1';
+/**
+ * Default zombie-session retention window (90 s). Long enough to cover a
+ * manual tab refresh, a routine HMR cycle, or a brief network blip; short
+ * enough that abandoned sessions don't accumulate.
+ */
+export const DEFAULT_RESUME_TTL_MS = 90_000;
 
 /** Capabilities the connected MCP client advertised to the bridge. */
 export interface AgentCapabilityInfo {
@@ -107,6 +121,25 @@ interface ActiveInvocation {
 }
 
 /**
+ * A recently-closed session retained in memory so a reconnecting SDK can
+ * rejoin it via `tesseron/resume`. Carries only the metadata the resume
+ * handler needs — the dead WebSocket and its dispatcher are deliberately
+ * dropped so we never try to write to them.
+ */
+interface ZombieSession {
+  id: string;
+  app: Session['app'];
+  actions: Session['actions'];
+  resources: Session['resources'];
+  capabilities: Session['capabilities'];
+  resumeToken: string;
+  claimed: boolean;
+  claimedAt?: number;
+  /** Timer that removes this zombie from {@link TesseronGateway.zombieSessions} once the TTL elapses. */
+  evictTimer: ReturnType<typeof setTimeout>;
+}
+
+/**
  * Local WebSocket server that hosts Tesseron sessions. SDK clients connect
  * and send `tesseron/hello`; an {@link McpAgentBridge} consumes the gateway on
  * the MCP-server side to expose claimed sessions as tools and resources. Emits
@@ -117,6 +150,11 @@ export class TesseronGateway extends EventEmitter {
   private readonly sessions = new Map<string, Session>();
   private readonly pendingClaims = new Map<string, string>();
   private readonly activeInvocations = new Map<string, ActiveInvocation>();
+  /**
+   * Recently-closed sessions kept around for a TTL window so the SDK can
+   * rejoin them with `tesseron/resume`. See {@link GatewayOptions.resumeTtlMs}.
+   */
+  private readonly zombieSessions = new Map<string, ZombieSession>();
   private samplingHandler?: SamplingHandler;
   private elicitationHandler?: ElicitationHandler;
   private agentCapabilities: AgentCapabilityInfo = { ...DEFAULT_AGENT_CAPABILITIES };
@@ -167,6 +205,12 @@ export class TesseronGateway extends EventEmitter {
     this.sessions.clear();
     this.pendingClaims.clear();
     this.activeInvocations.clear();
+    // Cancel every outstanding zombie eviction timer; their sessions will never
+    // resume across a gateway restart regardless.
+    for (const zombie of this.zombieSessions.values()) {
+      clearTimeout(zombie.evictTimer);
+    }
+    this.zombieSessions.clear();
     if (!this.wss) return;
     return new Promise<void>((resolve, reject) => {
       this.wss?.close((err) => (err ? reject(err) : resolve()));
@@ -372,6 +416,32 @@ export class TesseronGateway extends EventEmitter {
       dispatcher.rejectAllPending(new TransportClosedError('Session socket closed'));
 
       if (!session) return;
+
+      // Zombify the session so a reconnecting SDK can rejoin via
+      // `tesseron/resume` within the TTL. When the feature is disabled
+      // (resumeTtlMs === 0) the session is dropped immediately.
+      const resumeTtl = this.options.resumeTtlMs ?? DEFAULT_RESUME_TTL_MS;
+      if (resumeTtl > 0) {
+        const closedSession = session;
+        const evictTimer = setTimeout(() => {
+          this.zombieSessions.delete(closedSession.id);
+        }, resumeTtl);
+        // Allow the process to exit even while the zombie waits out its TTL;
+        // the gateway itself doesn't keep Node alive once the WS server stops.
+        evictTimer.unref?.();
+        this.zombieSessions.set(closedSession.id, {
+          id: closedSession.id,
+          app: closedSession.app,
+          actions: closedSession.actions,
+          resources: closedSession.resources,
+          capabilities: closedSession.capabilities,
+          resumeToken: closedSession.resumeToken,
+          claimed: closedSession.claimed,
+          claimedAt: closedSession.claimedAt,
+          evictTimer,
+        });
+      }
+
       this.sessions.delete(session.id);
       this.pendingClaims.delete(session.claimCode);
       // Cancel any active invocations for this session
@@ -410,6 +480,7 @@ export class TesseronGateway extends EventEmitter {
 
       const sessionId = generateSessionId();
       const claimCode = generateClaimCode();
+      const resumeToken = generateResumeToken();
       session = {
         id: sessionId,
         app: helloParams.app,
@@ -420,6 +491,7 @@ export class TesseronGateway extends EventEmitter {
         capabilities: helloParams.capabilities,
         claimCode,
         claimed: false,
+        resumeToken,
       };
       this.sessions.set(sessionId, session);
       this.pendingClaims.set(claimCode, sessionId);
@@ -441,6 +513,7 @@ export class TesseronGateway extends EventEmitter {
           name: this.agentCapabilities.clientName ?? 'Awaiting agent',
         },
         claimCode,
+        resumeToken,
       };
       return welcome;
     });

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -1,4 +1,5 @@
 import { Buffer } from 'node:buffer';
+import { timingSafeEqual } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import {
   type ElicitationRequestParams,
@@ -7,6 +8,7 @@ import {
   PROTOCOL_VERSION,
   type ProgressUpdate,
   type ResourceReadResult,
+  type ResumeParams,
   type SamplingRequestParams,
   type SamplingResult,
   TesseronError,
@@ -133,6 +135,7 @@ interface ZombieSession {
   resources: Session['resources'];
   capabilities: Session['capabilities'];
   resumeToken: string;
+  claimCode: string;
   claimed: boolean;
   claimedAt?: number;
   /** Timer that removes this zombie from {@link TesseronGateway.zombieSessions} once the TTL elapses. */
@@ -436,6 +439,7 @@ export class TesseronGateway extends EventEmitter {
           resources: closedSession.resources,
           capabilities: closedSession.capabilities,
           resumeToken: closedSession.resumeToken,
+          claimCode: closedSession.claimCode,
           claimed: closedSession.claimed,
           claimedAt: closedSession.claimedAt,
           evictTimer,
@@ -514,6 +518,126 @@ export class TesseronGateway extends EventEmitter {
         },
         claimCode,
         resumeToken,
+      };
+      return welcome;
+    });
+
+    dispatcher.on('tesseron/resume', async (params): Promise<WelcomeResult> => {
+      const resumeParams = params as ResumeParams;
+
+      if (session) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          'This socket is already attached to a session. Send tesseron/resume on a fresh connection.',
+        );
+      }
+
+      // Same protocol-version policy as hello: hard-reject on major mismatch,
+      // warn on minor. A resuming SDK that upgraded past a major bump must
+      // fall back to a fresh tesseron/hello with its new manifest.
+      const [theirMajor, theirMinor] = parseProtocolVersion(resumeParams.protocolVersion);
+      const [ourMajor, ourMinor] = parseProtocolVersion(PROTOCOL_VERSION);
+      if (theirMajor !== ourMajor) {
+        throw new TesseronError(
+          TesseronErrorCode.ProtocolMismatch,
+          `Gateway speaks protocol ${PROTOCOL_VERSION}; SDK sent ${resumeParams.protocolVersion}. Major version mismatch on resume — pin compatible package versions or start a fresh session.`,
+        );
+      }
+      if (theirMinor !== ourMinor) {
+        logToStderr(
+          `[tesseron] protocol minor version mismatch on resume: gateway=${PROTOCOL_VERSION}, SDK=${resumeParams.protocolVersion}.`,
+        );
+      }
+
+      validateAppId(resumeParams.app.id);
+
+      const zombie = this.zombieSessions.get(resumeParams.sessionId);
+      if (!zombie) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          `No resumable session "${resumeParams.sessionId}". The TTL may have elapsed, the gateway may have restarted, or the session never existed.`,
+        );
+      }
+
+      if (zombie.app.id !== resumeParams.app.id) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          `Session "${resumeParams.sessionId}" is owned by app "${zombie.app.id}", not "${resumeParams.app.id}". Refusing cross-app resume.`,
+        );
+      }
+
+      // Resume is only meaningful for sessions that were actually claimed; an
+      // unclaimed zombie's original claim code is already gone from
+      // pendingClaims and there's nothing user-visible to restore. Surface a
+      // clean error so the SDK knows to fall back to a fresh tesseron/hello.
+      if (!zombie.claimed) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          `Session "${resumeParams.sessionId}" was never claimed; open a fresh session with tesseron/hello instead.`,
+        );
+      }
+
+      // Constant-time token compare. Both tokens are 32-char base64url in the
+      // happy path, but we still check lengths first to avoid a side channel
+      // when a wildly-wrong token is presented.
+      const presented = Buffer.from(resumeParams.resumeToken);
+      const stored = Buffer.from(zombie.resumeToken);
+      if (presented.length !== stored.length || !timingSafeEqual(presented, stored)) {
+        throw new TesseronError(
+          TesseronErrorCode.ResumeFailed,
+          `Invalid resumeToken for session "${resumeParams.sessionId}".`,
+        );
+      }
+
+      // Token validated. Cancel eviction, remove zombie, promote to live
+      // session with the fresh socket + dispatcher, and rotate the token.
+      clearTimeout(zombie.evictTimer);
+      this.zombieSessions.delete(zombie.id);
+
+      if (origin && resumeParams.app.origin !== origin) {
+        resumeParams.app.origin = origin;
+      }
+
+      const rotatedResumeToken = generateResumeToken();
+      session = {
+        id: zombie.id,
+        app: resumeParams.app,
+        ws,
+        dispatcher,
+        actions: resumeParams.actions,
+        resources: resumeParams.resources,
+        capabilities: resumeParams.capabilities,
+        claimCode: zombie.claimCode,
+        claimed: zombie.claimed,
+        claimedAt: zombie.claimedAt,
+        resumeToken: rotatedResumeToken,
+      };
+      this.sessions.set(zombie.id, session);
+
+      logToStderr(
+        `[tesseron] resumed session "${resumeParams.app.name}" (${zombie.id}) — claim preserved`,
+      );
+
+      // The MCP bridge sees the reattached session via sessions-changed and
+      // re-advertises its tools, so the agent gets them back in tools/list.
+      this.emit('sessions-changed');
+
+      const welcome: WelcomeResult = {
+        sessionId: zombie.id,
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: {
+          streaming: true,
+          subscriptions: true,
+          sampling: this.agentCapabilities.sampling,
+          elicitation: this.agentCapabilities.elicitation,
+        },
+        agent: {
+          id: this.agentCapabilities.clientName ?? 'pending',
+          name: this.agentCapabilities.clientName ?? 'Awaiting agent',
+        },
+        // No claimCode on resume: the session is already claimed; re-issuing
+        // a pairing code would only confuse the UI.
+        resumeToken: rotatedResumeToken,
       };
       return welcome;
     });

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -42,6 +42,13 @@ export interface GatewayOptions {
    * immediately and any reconnect must start fresh with `tesseron/hello`.
    */
   resumeTtlMs?: number;
+  /**
+   * Maximum number of zombie sessions retained simultaneously. When adding a
+   * new zombie would exceed this cap, the oldest (longest-retained) zombie is
+   * evicted. Defaults to {@link DEFAULT_MAX_ZOMBIES}. Exists so a peer that
+   * rapidly connects and disconnects can't accumulate unbounded memory.
+   */
+  maxZombies?: number;
 }
 
 /** Options for {@link TesseronGateway.invokeAction}. */
@@ -98,6 +105,13 @@ export const DEFAULT_GATEWAY_HOST = '127.0.0.1';
  * enough that abandoned sessions don't accumulate.
  */
 export const DEFAULT_RESUME_TTL_MS = 90_000;
+/**
+ * Default cap on {@link TesseronGateway.zombieSessions}. A peer that repeatedly
+ * connects and disconnects could otherwise pile up zombies until their TTLs
+ * elapse; when the cap is reached the oldest (longest-retained) zombie is
+ * evicted to make room.
+ */
+export const DEFAULT_MAX_ZOMBIES = 100;
 
 /** Capabilities the connected MCP client advertised to the bridge. */
 export interface AgentCapabilityInfo {
@@ -437,6 +451,21 @@ export class TesseronGateway extends EventEmitter {
       // is dropped immediately.
       const resumeTtl = this.options.resumeTtlMs ?? DEFAULT_RESUME_TTL_MS;
       if (resumeTtl > 0 && !this.stopped) {
+        // Cap the map to prevent a connect/disconnect flood from piling up
+        // zombies until their TTLs elapse. Map iteration order is insertion
+        // order, so the first key is the oldest entry.
+        const maxZombies = this.options.maxZombies ?? DEFAULT_MAX_ZOMBIES;
+        if (this.zombieSessions.size >= maxZombies) {
+          const oldestId = this.zombieSessions.keys().next().value;
+          if (oldestId !== undefined) {
+            const oldest = this.zombieSessions.get(oldestId);
+            if (oldest) clearTimeout(oldest.evictTimer);
+            this.zombieSessions.delete(oldestId);
+            logToStderr(
+              `[tesseron] zombie cap (${maxZombies}) reached — evicted oldest zombie ${oldestId}`,
+            );
+          }
+        }
         const closedSession = session;
         const evictTimer = setTimeout(() => {
           this.zombieSessions.delete(closedSession.id);
@@ -616,9 +645,10 @@ export class TesseronGateway extends EventEmitter {
         );
       }
 
-      // Constant-time token compare. Both tokens are 32-char base64url in the
-      // happy path, but we still check lengths first to avoid a side channel
-      // when a wildly-wrong token is presented.
+      // Constant-time token compare. timingSafeEqual throws on mismatched-
+      // length buffers, so gate it behind an explicit length check first to
+      // return a clean ResumeFailed instead of a raw TypeError. Both tokens
+      // are 32-char base64url in the happy path.
       const presented = Buffer.from(resumeParams.resumeToken);
       const stored = Buffer.from(zombie.resumeToken);
       if (presented.length !== stored.length || !timingSafeEqual(presented, stored)) {

--- a/packages/mcp/src/session.ts
+++ b/packages/mcp/src/session.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto';
 import type {
   ActionManifestEntry,
   AppMetadata,
@@ -18,6 +19,14 @@ export interface Session {
   claimCode: string;
   claimed: boolean;
   claimedAt?: number;
+  /**
+   * Opaque server-issued token returned in the session's {@link WelcomeResult}.
+   * The SDK stashes this alongside {@link Session.id} to rejoin via
+   * `tesseron/resume` after a transport drop. Rotated on every successful
+   * resume (one-shot); the gateway replaces it with a fresh token before the
+   * resume response goes back to the SDK.
+   */
+  resumeToken: string;
   subscriptionCallbacks?: Map<string, (value: unknown) => void>;
 }
 
@@ -37,6 +46,15 @@ export function generateSessionId(): string {
 
 export function generateInvocationId(): string {
   return `inv_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+}
+
+/**
+ * Cryptographically random session-resume token. 24 bytes (~192 bits) encoded
+ * as URL-safe base64 → 32 characters, enough entropy that guessing attacks are
+ * infeasible within the zombie TTL even under aggressive concurrency.
+ */
+export function generateResumeToken(): string {
+  return randomBytes(24).toString('base64url');
 }
 
 const RESERVED_APP_IDS = new Set(['tesseron', 'mcp', 'system']);

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -716,3 +716,253 @@ describe('Tool surface modes', () => {
     }
   });
 });
+
+describe('Resume options', () => {
+  async function buildResumeBridge(
+    port: number,
+    opts: { resumeTtlMs?: number; maxZombies?: number } = {},
+  ): Promise<{
+    gateway: TesseronGateway;
+    url: string;
+    agentClient: Client;
+    newSdk: () => ServerTesseronClient;
+    cleanup: () => Promise<void>;
+  }> {
+    const gw = new TesseronGateway({ port, ...opts });
+    await gw.start();
+    const br = new McpAgentBridge({ gateway: gw });
+    const [agentSide, gatewaySide] = InMemoryTransport.createLinkedPair();
+    await br.connect(gatewaySide);
+    const c = new Client({ name: 'resume-opts-test', version: '0.0.0' });
+    await c.connect(agentSide);
+    const sdks: ServerTesseronClient[] = [];
+    return {
+      gateway: gw,
+      url: `ws://127.0.0.1:${port}`,
+      agentClient: c,
+      newSdk: () => {
+        const sdk = new ServerTesseronClient();
+        sdks.push(sdk);
+        return sdk;
+      },
+      cleanup: async () => {
+        await Promise.all(sdks.map((s) => s.disconnect().catch(() => {})));
+        await c.close().catch(() => {});
+        await gw.stop().catch(() => {});
+      },
+    };
+  }
+
+  async function claim(agentClient: Client, code: string): Promise<void> {
+    const r = await agentClient.request(
+      { method: 'tools/call', params: { name: 'tesseron__claim_session', arguments: { code } } },
+      CallToolResultSchema,
+    );
+    expect(r.isError).toBeFalsy();
+  }
+
+  it('evicts zombies past their TTL (resume after TTL fails with no-resumable-session)', async () => {
+    const { url, agentClient, newSdk, cleanup } = await buildResumeBridge(7810, {
+      resumeTtlMs: 150,
+    });
+    try {
+      const sdk1 = newSdk();
+      sdk1.app({ id: 'ttl1', name: 'ttl1', origin: 'http://localhost' });
+      sdk1.action('x').handler(() => 'x');
+      const welcome1 = await sdk1.connect(url);
+      await claim(agentClient, welcome1.claimCode!);
+      await sdk1.disconnect();
+      // Wait past the TTL so the eviction timer fires.
+      await new Promise((r) => setTimeout(r, 300));
+
+      const sdk2 = newSdk();
+      sdk2.app({ id: 'ttl1', name: 'ttl1', origin: 'http://localhost' });
+      sdk2.action('x').handler(() => 'x');
+      await expect(
+        sdk2.connect(url, {
+          resume: {
+            sessionId: welcome1.sessionId,
+            resumeToken: welcome1.resumeToken!,
+          },
+        }),
+      ).rejects.toThrow(/no resumable session/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('resumeTtlMs: 0 disables zombification; immediate resume fails', async () => {
+    const { url, agentClient, newSdk, cleanup } = await buildResumeBridge(7811, {
+      resumeTtlMs: 0,
+    });
+    try {
+      const sdk1 = newSdk();
+      sdk1.app({ id: 'ttl0', name: 'ttl0', origin: 'http://localhost' });
+      sdk1.action('x').handler(() => 'x');
+      const welcome1 = await sdk1.connect(url);
+      await claim(agentClient, welcome1.claimCode!);
+      await sdk1.disconnect();
+      await new Promise((r) => setTimeout(r, 100));
+
+      const sdk2 = newSdk();
+      sdk2.app({ id: 'ttl0', name: 'ttl0', origin: 'http://localhost' });
+      sdk2.action('x').handler(() => 'x');
+      await expect(
+        sdk2.connect(url, {
+          resume: {
+            sessionId: welcome1.sessionId,
+            resumeToken: welcome1.resumeToken!,
+          },
+        }),
+      ).rejects.toThrow(/no resumable session/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('maxZombies: 0 disables zombification entirely', async () => {
+    // Regression guard: before the fix, maxZombies=0 was silently ignored —
+    // the cap-eviction branch found an empty map and fell through to insert
+    // the new zombie anyway, so the cap did nothing.
+    const { url, agentClient, newSdk, cleanup } = await buildResumeBridge(7812, {
+      maxZombies: 0,
+    });
+    try {
+      const sdk1 = newSdk();
+      sdk1.app({ id: 'maxz0', name: 'maxz0', origin: 'http://localhost' });
+      sdk1.action('x').handler(() => 'x');
+      const welcome1 = await sdk1.connect(url);
+      await claim(agentClient, welcome1.claimCode!);
+      await sdk1.disconnect();
+      await new Promise((r) => setTimeout(r, 100));
+
+      const sdk2 = newSdk();
+      sdk2.app({ id: 'maxz0', name: 'maxz0', origin: 'http://localhost' });
+      sdk2.action('x').handler(() => 'x');
+      await expect(
+        sdk2.connect(url, {
+          resume: {
+            sessionId: welcome1.sessionId,
+            resumeToken: welcome1.resumeToken!,
+          },
+        }),
+      ).rejects.toThrow(/no resumable session/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('maxZombies: 2 evicts the oldest zombie FIFO when the cap is reached', async () => {
+    const { url, agentClient, newSdk, cleanup } = await buildResumeBridge(7813, {
+      maxZombies: 2,
+    });
+    try {
+      async function spawnAndDrop(id: string) {
+        const sdk = newSdk();
+        sdk.app({ id, name: id, origin: 'http://localhost' });
+        sdk.action('x').handler(() => 'x');
+        const w = await sdk.connect(url);
+        await claim(agentClient, w.claimCode!);
+        await sdk.disconnect();
+        await new Promise((r) => setTimeout(r, 60));
+        return w;
+      }
+      const wa = await spawnAndDrop('cap_a');
+      const wb = await spawnAndDrop('cap_b');
+      const wc = await spawnAndDrop('cap_c');
+
+      // cap_a was oldest; inserting cap_c should have evicted it.
+      const sdkA2 = newSdk();
+      sdkA2.app({ id: 'cap_a', name: 'cap_a', origin: 'http://localhost' });
+      sdkA2.action('x').handler(() => 'x');
+      await expect(
+        sdkA2.connect(url, {
+          resume: { sessionId: wa.sessionId, resumeToken: wa.resumeToken! },
+        }),
+      ).rejects.toThrow(/no resumable session/i);
+
+      // cap_b and cap_c are still within the cap and must resume.
+      const sdkB2 = newSdk();
+      sdkB2.app({ id: 'cap_b', name: 'cap_b', origin: 'http://localhost' });
+      sdkB2.action('x').handler(() => 'x');
+      const wb2 = await sdkB2.connect(url, {
+        resume: { sessionId: wb.sessionId, resumeToken: wb.resumeToken! },
+      });
+      expect(wb2.sessionId).toBe(wb.sessionId);
+
+      const sdkC2 = newSdk();
+      sdkC2.app({ id: 'cap_c', name: 'cap_c', origin: 'http://localhost' });
+      sdkC2.action('x').handler(() => 'x');
+      const wc2 = await sdkC2.connect(url, {
+        resume: { sessionId: wc.sessionId, resumeToken: wc.resumeToken! },
+      });
+      expect(wc2.sessionId).toBe(wc.sessionId);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('rejects malformed resume params (non-string sessionId) with a typed ResumeFailed', async () => {
+    // Before the consolidated input guard, a non-string sessionId reached
+    // `zombieSessions.get(...)` or `Buffer.from(...)` below and escaped as
+    // an untyped InternalError instead of the ResumeFailed the ConnectOptions
+    // contract promises.
+    const { url, newSdk, cleanup } = await buildResumeBridge(7814);
+    try {
+      const sdk = newSdk();
+      sdk.app({ id: 'bad1', name: 'bad1', origin: 'http://localhost' });
+      sdk.action('x').handler(() => 'x');
+      await expect(
+        sdk.connect(url, {
+          resume: {
+            sessionId: 12345 as unknown as string,
+            resumeToken: 'any-value',
+          },
+        }),
+      ).rejects.toThrow(/invalid tesseron\/resume request/i);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it('replaces the session manifest on resume (added tool appears, removed tool disappears)', async () => {
+    const { url, agentClient, newSdk, cleanup } = await buildResumeBridge(7815);
+    try {
+      async function listTools() {
+        const r = await agentClient.request({ method: 'tools/list' }, ListToolsResultSchema);
+        return r.tools.map((t) => t.name);
+      }
+
+      const sdk1 = newSdk();
+      sdk1.app({ id: 'man1', name: 'man1', origin: 'http://localhost' });
+      sdk1.action('keep').handler(() => 'keep');
+      sdk1.action('removeMe').handler(() => 'remove');
+      const welcome1 = await sdk1.connect(url);
+      await claim(agentClient, welcome1.claimCode!);
+      await new Promise((r) => setTimeout(r, 50));
+      let tools = await listTools();
+      expect(tools).toContain('man1__keep');
+      expect(tools).toContain('man1__removeMe');
+
+      await sdk1.disconnect();
+      await new Promise((r) => setTimeout(r, 100));
+
+      // Fresh build: `removeMe` is gone, `newAction` is new.
+      const sdk2 = newSdk();
+      sdk2.app({ id: 'man1', name: 'man1', origin: 'http://localhost' });
+      sdk2.action('keep').handler(() => 'still-here');
+      sdk2.action('newAction').handler(() => 'new');
+      await sdk2.connect(url, {
+        resume: { sessionId: welcome1.sessionId, resumeToken: welcome1.resumeToken! },
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      tools = await listTools();
+      expect(tools).toContain('man1__keep');
+      expect(tools).toContain('man1__newAction');
+      expect(tools).not.toContain('man1__removeMe');
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -275,6 +275,154 @@ describe('Tesseron MCP integration', () => {
     expect(welcome.resumeToken).toMatch(/^[A-Za-z0-9_-]+$/);
   });
 
+  it('resumes a claimed session on a fresh SDK instance', async () => {
+    // First SDK: open + claim.
+    const sdk1 = newSdk();
+    sdk1.app({ id: 'rsm1', name: 'rsm1', origin: 'http://localhost' });
+    sdk1.action('greet').handler(() => 'hi-before');
+    const welcome1 = await sdk1.connect(URL);
+    await callTool('tesseron__claim_session', { code: welcome1.claimCode! });
+    expect(await listToolNames()).toContain('rsm1__greet');
+
+    // Simulate tab refresh: drop the socket.
+    await sdk1.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+    expect(await listToolNames()).not.toContain('rsm1__greet');
+
+    // Fresh SDK, same app, resume with the stashed credentials.
+    const sdk2 = newSdk();
+    sdk2.app({ id: 'rsm1', name: 'rsm1', origin: 'http://localhost' });
+    sdk2.action('greet').handler(() => 'hi-after');
+    const welcome2 = await sdk2.connect(URL, {
+      resume: {
+        sessionId: welcome1.sessionId,
+        resumeToken: welcome1.resumeToken!,
+      },
+    });
+
+    expect(welcome2.sessionId).toBe(welcome1.sessionId);
+    expect(welcome2.resumeToken).toBeTruthy();
+    // Token rotates on every successful resume (one-shot).
+    expect(welcome2.resumeToken).not.toBe(welcome1.resumeToken);
+    // Already claimed, no new claim code issued.
+    expect(welcome2.claimCode).toBeUndefined();
+
+    // Give the bridge a beat to re-advertise.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(await listToolNames()).toContain('rsm1__greet');
+
+    // Handler from the fresh SDK is the one that runs.
+    const result = await callTool('rsm1__greet', {});
+    expect(result.text).toBe('hi-after');
+  });
+
+  it('rejects resume with a bad token', async () => {
+    const sdk1 = newSdk();
+    sdk1.app({ id: 'rsm2', name: 'rsm2', origin: 'http://localhost' });
+    sdk1.action('greet').handler(() => 'hi');
+    const welcome1 = await sdk1.connect(URL);
+    await callTool('tesseron__claim_session', { code: welcome1.claimCode! });
+    await sdk1.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const sdk2 = newSdk();
+    sdk2.app({ id: 'rsm2', name: 'rsm2', origin: 'http://localhost' });
+    sdk2.action('greet').handler(() => 'hi');
+    await expect(
+      sdk2.connect(URL, {
+        resume: {
+          sessionId: welcome1.sessionId,
+          resumeToken: '0000000000000000000000000000000x', // 32 chars, wrong value
+        },
+      }),
+    ).rejects.toThrow(/invalid resumetoken/i);
+  });
+
+  it('rejects resume with an unknown session id', async () => {
+    const sdk = newSdk();
+    sdk.app({ id: 'unk1', name: 'unk1', origin: 'http://localhost' });
+    sdk.action('x').handler(() => 'x');
+    await expect(
+      sdk.connect(URL, {
+        resume: {
+          sessionId: 's_does_not_exist',
+          resumeToken: '00000000000000000000000000000000',
+        },
+      }),
+    ).rejects.toThrow(/no resumable session/i);
+  });
+
+  it('rejects resume of an unclaimed zombie (caller should fall back to hello)', async () => {
+    const sdk1 = newSdk();
+    sdk1.app({ id: 'unc1', name: 'unc1', origin: 'http://localhost' });
+    sdk1.action('x').handler(() => 'x');
+    const welcome1 = await sdk1.connect(URL);
+    // Deliberately don't claim.
+    await sdk1.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const sdk2 = newSdk();
+    sdk2.app({ id: 'unc1', name: 'unc1', origin: 'http://localhost' });
+    sdk2.action('x').handler(() => 'x');
+    await expect(
+      sdk2.connect(URL, {
+        resume: {
+          sessionId: welcome1.sessionId,
+          resumeToken: welcome1.resumeToken!,
+        },
+      }),
+    ).rejects.toThrow(/never claimed/i);
+  });
+
+  it('rotates the resumeToken so the previous one no longer works', async () => {
+    const sdk1 = newSdk();
+    sdk1.app({ id: 'rot1', name: 'rot1', origin: 'http://localhost' });
+    sdk1.action('x').handler(() => 'x');
+    const welcome1 = await sdk1.connect(URL);
+    await callTool('tesseron__claim_session', { code: welcome1.claimCode! });
+    await sdk1.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const sdk2 = newSdk();
+    sdk2.app({ id: 'rot1', name: 'rot1', origin: 'http://localhost' });
+    sdk2.action('x').handler(() => 'x');
+    const welcome2 = await sdk2.connect(URL, {
+      resume: {
+        sessionId: welcome1.sessionId,
+        resumeToken: welcome1.resumeToken!,
+      },
+    });
+    expect(welcome2.resumeToken).not.toBe(welcome1.resumeToken);
+
+    await sdk2.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    // Reusing the OLD token must fail.
+    const sdk3 = newSdk();
+    sdk3.app({ id: 'rot1', name: 'rot1', origin: 'http://localhost' });
+    sdk3.action('x').handler(() => 'x');
+    await expect(
+      sdk3.connect(URL, {
+        resume: {
+          sessionId: welcome1.sessionId,
+          resumeToken: welcome1.resumeToken!,
+        },
+      }),
+    ).rejects.toThrow(/invalid resumetoken/i);
+
+    // But the rotated token (from welcome2) still works.
+    const sdk4 = newSdk();
+    sdk4.app({ id: 'rot1', name: 'rot1', origin: 'http://localhost' });
+    sdk4.action('x').handler(() => 'x');
+    const welcome4 = await sdk4.connect(URL, {
+      resume: {
+        sessionId: welcome1.sessionId,
+        resumeToken: welcome2.resumeToken!,
+      },
+    });
+    expect(welcome4.sessionId).toBe(welcome1.sessionId);
+  });
+
   it('rejects reserved app ids during handshake', async () => {
     const sdk = newSdk();
     sdk.app({ id: 'tesseron', name: 'evil', origin: 'http://localhost' });

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -423,6 +423,32 @@ describe('Tesseron MCP integration', () => {
     expect(welcome4.sessionId).toBe(welcome1.sessionId);
   });
 
+  it('refuses a cross-app resume attempt (app B cannot hijack app A session)', async () => {
+    // Security boundary: the app_id carried in the resume params must match
+    // the app id of the zombie being resumed. Without this check, any app
+    // that learned another app's sessionId + resumeToken (via shared storage,
+    // a bug, or a leak) could inherit its claimed MCP tool surface.
+    const sdkA = newSdk();
+    sdkA.app({ id: 'owner_app', name: 'owner_app', origin: 'http://localhost' });
+    sdkA.action('x').handler(() => 'x');
+    const welcomeA = await sdkA.connect(URL);
+    await callTool('tesseron__claim_session', { code: welcomeA.claimCode! });
+    await sdkA.disconnect();
+    await new Promise((r) => setTimeout(r, 100));
+
+    const sdkB = newSdk();
+    sdkB.app({ id: 'hijacker_app', name: 'hijacker_app', origin: 'http://localhost' });
+    sdkB.action('x').handler(() => 'x');
+    await expect(
+      sdkB.connect(URL, {
+        resume: {
+          sessionId: welcomeA.sessionId,
+          resumeToken: welcomeA.resumeToken!,
+        },
+      }),
+    ).rejects.toThrow(/not "hijacker_app"/i);
+  });
+
   it('rejects reserved app ids during handshake', async () => {
     const sdk = newSdk();
     sdk.app({ id: 'tesseron', name: 'evil', origin: 'http://localhost' });

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -263,6 +263,18 @@ describe('Tesseron MCP integration', () => {
     }
   });
 
+  it('issues a resumeToken in the welcome response', async () => {
+    const sdk = newSdk();
+    sdk.app({ id: 'tok1', name: 'tok', origin: 'http://localhost' });
+    sdk.action('ping').handler(() => 'pong');
+    const welcome = await sdk.connect(URL);
+    expect(welcome.resumeToken).toBeTruthy();
+    expect(typeof welcome.resumeToken).toBe('string');
+    // base64url, 24 bytes → 32 chars, no padding
+    expect(welcome.resumeToken!.length).toBe(32);
+    expect(welcome.resumeToken).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
   it('rejects reserved app ids during handshake', async () => {
     const sdk = newSdk();
     sdk.app({ id: 'tesseron', name: 'evil', origin: 'http://localhost' });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,9 @@
-import { TesseronClient, type Transport, type WelcomeResult } from '@tesseron/core';
+import {
+  type ConnectOptions,
+  TesseronClient,
+  type Transport,
+  type WelcomeResult,
+} from '@tesseron/core';
 import { NodeWebSocketTransport } from './transport.js';
 
 export * from '@tesseron/core';
@@ -11,15 +16,20 @@ export const DEFAULT_GATEWAY_URL = 'ws://localhost:7475';
  * Node-side {@link TesseronClient} with a WebSocket-aware `connect` overload.
  * Pass nothing to use {@link DEFAULT_GATEWAY_URL}, a URL string to connect to
  * another gateway, or a custom {@link Transport} to bypass WebSocket entirely.
+ * The optional second argument forwards {@link ConnectOptions} (e.g. session
+ * resume) to the core client.
  */
 export class ServerTesseronClient extends TesseronClient {
-  override async connect(target?: Transport | string): Promise<WelcomeResult> {
+  override async connect(
+    target?: Transport | string,
+    options?: ConnectOptions,
+  ): Promise<WelcomeResult> {
     if (target && typeof target !== 'string') {
-      return super.connect(target);
+      return super.connect(target, options);
     }
     const transport = new NodeWebSocketTransport(target ?? DEFAULT_GATEWAY_URL);
     await transport.ready();
-    return super.connect(transport);
+    return super.connect(transport, options);
   }
 }
 

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,4 +1,9 @@
-import { TesseronClient, type Transport, type WelcomeResult } from '@tesseron/core';
+import {
+  type ConnectOptions,
+  TesseronClient,
+  type Transport,
+  type WelcomeResult,
+} from '@tesseron/core';
 import { BrowserWebSocketTransport } from './transport.js';
 
 export * from '@tesseron/core';
@@ -11,15 +16,20 @@ export const DEFAULT_GATEWAY_URL = 'ws://localhost:7475';
  * Browser-side {@link TesseronClient} with a WebSocket-aware `connect` overload.
  * Pass nothing to use {@link DEFAULT_GATEWAY_URL}, a URL string to connect to
  * another gateway, or a custom {@link Transport} to bypass WebSocket entirely.
+ * The optional second argument forwards {@link ConnectOptions} (e.g. session
+ * resume) to the core client.
  */
 export class WebTesseronClient extends TesseronClient {
-  override async connect(target?: Transport | string): Promise<WelcomeResult> {
+  override async connect(
+    target?: Transport | string,
+    options?: ConnectOptions,
+  ): Promise<WelcomeResult> {
     if (target && typeof target !== 'string') {
-      return super.connect(target);
+      return super.connect(target, options);
     }
     const transport = new BrowserWebSocketTransport(target ?? DEFAULT_GATEWAY_URL);
     await transport.ready();
-    return super.connect(transport);
+    return super.connect(transport, options);
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #2. Adds session-resume support as a protocol primitive in 5 atomic commits. A reconnecting SDK can rejoin a previously-claimed session within a TTL window, skipping the 6-character claim-code dance. Storage of the resume credentials is deliberately **the implementer's responsibility** — the SDK exposes the primitive, apps decide where the token lives (localStorage, cookie, Electron store, keychain, etc.).

## Commits

| SHA | Layer | Change |
|---|---|---|
| `ad0c8b0` | `@tesseron/core` | Protocol types: `ResumeParams`, `ResumeResult`, `TesseronErrorCode.ResumeFailed` (-32011), `resumeToken` on `WelcomeResult`, `tesseron/resume` in `TesseronMethods`. |
| `ceccd00` | `@tesseron/mcp` | `generateResumeToken` (24 cryptographically-random bytes, base64url), `zombieSessions` map with configurable TTL (default 90 s), `ws.on('close')` zombifies instead of deletes, `stop()` clears zombies. |
| `0481e73` | `@tesseron/mcp` | `tesseron/resume` handler: protocol-version check, app-id cross-check, unclaimed-zombie rejection, constant-time token compare via `crypto.timingSafeEqual`, one-shot token rotation, `sessions-changed` re-emission so tools reappear in the MCP client. |
| `0eaa446` | `@tesseron/core` / `server` / `web` | `ConnectOptions.resume` on `TesseronClient.connect`. Both `ServerTesseronClient` and `WebTesseronClient` forward the new arg through their URL-string overload. `ConnectOptions` + `ResumeCredentials` exported from core. 5 end-to-end tests cover happy path, bad token, unknown session, unclaimed zombie, and token rotation. |
| `921bcb8` | docs + changeset | New `docs/protocol/resume` page with wire shapes, failure-modes table, gateway config, 4-line localStorage recipe. Sidebar entry. Minor-bump changeset covering all four packages. |

## Scope notes

**What ships:** protocol-level primitive + gateway zombie-session infrastructure + `ConnectOptions.resume` pass-through in the SDKs. Backwards-compatible: SDKs that don't pass `{ resume }` still send `tesseron/hello` exactly as before; older gateways that never populate `resumeToken` continue to work against the new SDK (it just can't resume).

**What intentionally does not ship:** no `localStorage` auto-save in `@tesseron/web`, no pluggable `SessionPersistence` interface in `@tesseron/server`, no file-backed store. Different apps have different opinions about where session credentials can live; the SDK keeping that choice would be making it for everyone. Docs show the idiomatic 4-line localStorage recipe as exactly that — a recipe, not a shipped feature.

## Design questions resolved

- **TTL default:** 90 s (configurable via `GatewayOptions.resumeTtlMs`; set to 0 to disable resume entirely).
- **Token lifetime:** one-shot. Rotated on every successful resume, previous token is immediately invalidated. Callers persist the freshest `resumeToken` from each handshake.
- **Protocol version bump:** not required. The addition is backwards-compatible (new method, new optional fields); no existing consumer breaks.
- **Unclaimed-zombie resume:** explicitly refused with a clear message so the SDK can fall back to `tesseron/hello` without ambiguity. Resume is only semantically meaningful for sessions that were already claimed.

## Test plan

- [x] `pnpm typecheck` (all 18 packages)
- [x] `pnpm test` (49/49 in `@tesseron/mcp`, including 5 new resume integration tests)
- [x] `biome format --write` clean
- [x] Changeset added (`@tesseron/core`, `@tesseron/mcp`, `@tesseron/server`, `@tesseron/web` all minor)
- [x] Docs page renders and cross-links resolve (manually checked the sidebar entry)

## Related

- #1 / PR #3 (bug: gateway should fail-fast when socket closes mid-action) is orthogonal but composes well with this change. Once #3 merges, in-flight `actions/invoke` calls reject immediately on the drop that would otherwise zombify the session.
- #5 / PR #6 (surfacing `TesseronErrorCode` via `structuredContent`) applies to resume failures too — after both merge, agents can programmatically branch on `ResumeFailed` without regex.
- Surfaced by [u/goship-tech on r/ClaudeCode](https://reddit.com/r/ClaudeCode/comments/1sswvgu/built_a_plugin_that_lets_claude_drive_your/ohp576u/) asking about tab-refresh recovery behaviour.
