### PR TITLE
feat(mcp): surface TesseronErrorCode in tool-call errors via structuredContent

### DIFF
--- a/.changeset/errorresult-carry-code.md
+++ b/.changeset/errorresult-carry-code.md
@@ -1,0 +1,39 @@
+---
+"@tesseron/mcp": minor
+---
+
+Surface `TesseronErrorCode` in tool-call error results. The bridge's
+`errorResult` helper now returns an MCP-spec-native `structuredContent`
+object carrying the underlying `TesseronError`'s numeric `code` (and `data`,
+when present), so agents can programmatically branch on `TransportClosed`
+vs `HandlerError` vs `InputValidation` etc. instead of regex-matching the
+text body.
+
+Before:
+
+```jsonc
+// tools/call response for a failed invocation
+{
+  "content": [{ "type": "text", "text": "Invalid input\n[...]" }],
+  "isError": true
+}
+```
+
+After:
+
+```jsonc
+{
+  "content": [{ "type": "text", "text": "Invalid input\n{\n  \"code\": -32004,\n  \"data\": [...]\n}" }],
+  "structuredContent": { "code": -32004, "data": [...] },
+  "isError": true
+}
+```
+
+The text body stays backwards-compatible (it still embeds the same shape
+as `${message}\n${JSON}`), so existing log-scraping / regex assertions
+keep passing. `structuredContent` is an optional field in
+`CallToolResultSchema` from `@modelcontextprotocol/sdk`, so MCP clients
+that ignore it are unaffected.
+
+Call sites in `mcp-bridge.ts` now pass the full `TesseronError` to
+`errorResult` rather than extracting `error.data` at the caller.

--- a/.changeset/errorresult-carry-code.md
+++ b/.changeset/errorresult-carry-code.md
@@ -1,4 +1,5 @@
 ---
+"@tesseron/core": minor
 "@tesseron/mcp": minor
 ---
 
@@ -7,7 +8,8 @@ Surface `TesseronErrorCode` in tool-call error results. The bridge's
 object carrying the underlying `TesseronError`'s numeric `code` (and `data`,
 when present), so agents can programmatically branch on `TransportClosed`
 vs `HandlerError` vs `InputValidation` etc. instead of regex-matching the
-text body.
+text body. The structured shape is exported from `@tesseron/core` as
+`TesseronStructuredError` for typed consumer access.
 
 Before:
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,6 +1,19 @@
 import { TesseronErrorCode } from './protocol.js';
 
 /**
+ * Wire shape of a {@link TesseronError} as surfaced to MCP agents via the
+ * `structuredContent` field of a failed `tools/call` result. Lets agents
+ * branch programmatically on `code` (e.g. retry on `TransportClosed` but not
+ * on `HandlerError`) instead of regex-matching the human-readable text body.
+ */
+export interface TesseronStructuredError {
+  /** Numeric code; compare against {@link TesseronErrorCode} values. */
+  code: number;
+  /** Error-specific payload (same shape as {@link TesseronError.data}); omitted when undefined. */
+  data?: unknown;
+}
+
+/**
  * Base class for all typed errors the SDK surfaces. Maps 1:1 onto JSON-RPC
  * error responses; subclasses narrow to specific {@link TesseronErrorCode} values.
  */

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -400,7 +400,7 @@ export class McpAgentBridge {
         };
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        return errorResult(message, error instanceof TesseronError ? error.data : undefined);
+        return errorResult(message, error instanceof TesseronError ? error : undefined);
       } finally {
         if (progressToken !== undefined) {
           this.progressCursors.delete(progressToken);
@@ -558,7 +558,7 @@ export class McpAgentBridge {
       return { content: [{ type: 'text' as const, text }] };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      return errorResult(message, error instanceof TesseronError ? error.data : undefined);
+      return errorResult(message, error instanceof TesseronError ? error : undefined);
     }
   }
 
@@ -648,17 +648,37 @@ function levelFromString(level: string): 'debug' | 'info' | 'warning' | 'error' 
   }
 }
 
+/**
+ * Build the MCP `CallToolResult` payload for a failed tools/call.
+ *
+ * When a {@link TesseronError} is supplied, its `code` (and `data`, when
+ * present) are surfaced in two places: the human-readable `text` body keeps
+ * the existing `${message}\n${JSON}` shape so log scraping stays compatible,
+ * and an MCP-spec-native `structuredContent` object gives agents a
+ * programmatic branch point (e.g. retry on `TransportClosed` but not on
+ * `HandlerError`). Without the `structuredContent` carve-out, the only way
+ * for an agent to tell error codes apart was regex on the text.
+ */
 function errorResult(
   message: string,
-  data?: unknown,
-): { content: Array<{ type: 'text'; text: string }>; isError: true } {
+  error?: TesseronError,
+): {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError: true;
+} {
+  const structured: Record<string, unknown> | undefined = error
+    ? { code: error.code, ...(error.data !== undefined ? { data: error.data } : {}) }
+    : undefined;
+  const textSuffix = structured ? `\n${JSON.stringify(structured, null, 2)}` : '';
   return {
     content: [
       {
         type: 'text' as const,
-        text: data ? `${message}\n${JSON.stringify(data, null, 2)}` : message,
+        text: `${message}${textSuffix}`,
       },
     ],
+    ...(structured ? { structuredContent: structured } : {}),
     isError: true,
   };
 }

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -17,6 +17,7 @@ import {
   SamplingNotAvailableError,
   TesseronError,
   TesseronErrorCode,
+  type TesseronStructuredError,
 } from '@tesseron/core';
 import { assertValidElicitSchema } from '@tesseron/core/internal';
 import type { ResourceSubscription, TesseronGateway } from './gateway.js';
@@ -664,10 +665,10 @@ function errorResult(
   error?: TesseronError,
 ): {
   content: Array<{ type: 'text'; text: string }>;
-  structuredContent?: Record<string, unknown>;
+  structuredContent?: TesseronStructuredError;
   isError: true;
 } {
-  const structured: Record<string, unknown> | undefined = error
+  const structured: TesseronStructuredError | undefined = error
     ? { code: error.code, ...(error.data !== undefined ? { data: error.data } : {}) }
     : undefined;
   const textSuffix = structured ? `\n${JSON.stringify(structured, null, 2)}` : '';

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -2,6 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
+import { TesseronErrorCode } from '@tesseron/core';
 import { ServerTesseronClient } from '@tesseron/server';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { McpAgentBridge, TesseronGateway } from '../src/index.js';
@@ -56,6 +57,7 @@ async function listToolNames(): Promise<string[]> {
 interface CallOutcome {
   text: string;
   isError: boolean;
+  structuredContent?: Record<string, unknown>;
 }
 
 async function callTool(name: string, args: unknown): Promise<CallOutcome> {
@@ -64,7 +66,11 @@ async function callTool(name: string, args: unknown): Promise<CallOutcome> {
     CallToolResultSchema,
   );
   const text = result.content.map((c) => (c.type === 'text' ? c.text : `[${c.type}]`)).join('');
-  return { text, isError: result.isError === true };
+  return {
+    text,
+    isError: result.isError === true,
+    structuredContent: result.structuredContent,
+  };
 }
 
 async function setupAndClaim(
@@ -164,6 +170,9 @@ describe('Tesseron MCP integration', () => {
     const result = await callTool('val1__greet', { name: 42 });
     expect(result.isError).toBe(true);
     expect(result.text.toLowerCase()).toContain('invalid input');
+    // Structured content lets agents programmatically branch on the specific
+    // error code rather than regex-matching the human-readable text.
+    expect(result.structuredContent?.code).toBe(TesseronErrorCode.InputValidation);
   });
 
   it('surfaces handler errors with their original message', async () => {
@@ -176,6 +185,10 @@ describe('Tesseron MCP integration', () => {
     const result = await callTool('err1__boom', {});
     expect(result.isError).toBe(true);
     expect(result.text).toContain('something broke in the handler');
+    // A plain handler throw propagates as InternalError via the dispatcher's
+    // toErrorPayload fallback. HandlerError is reserved for the SDK's own
+    // schema-validation failures (see core/src/client.ts lines 322/370/393).
+    expect(result.structuredContent?.code).toBe(TesseronErrorCode.InternalError);
   });
 
   it('rejects unknown claim codes', async () => {

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -2,7 +2,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import type { StandardSchemaV1 } from '@standard-schema/spec';
-import { TesseronErrorCode } from '@tesseron/core';
+import { TesseronError, TesseronErrorCode, type TesseronStructuredError } from '@tesseron/core';
 import { ServerTesseronClient } from '@tesseron/server';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { McpAgentBridge, TesseronGateway } from '../src/index.js';
@@ -57,7 +57,7 @@ async function listToolNames(): Promise<string[]> {
 interface CallOutcome {
   text: string;
   isError: boolean;
-  structuredContent?: Record<string, unknown>;
+  structuredContent?: TesseronStructuredError;
 }
 
 async function callTool(name: string, args: unknown): Promise<CallOutcome> {
@@ -69,7 +69,10 @@ async function callTool(name: string, args: unknown): Promise<CallOutcome> {
   return {
     text,
     isError: result.isError === true,
-    structuredContent: result.structuredContent,
+    // The MCP SDK types this as an opaque Record; our gateway only emits
+    // TesseronStructuredError-shaped payloads, so the cast enables typed
+    // access to .code and .data in assertions.
+    structuredContent: result.structuredContent as TesseronStructuredError | undefined,
   };
 }
 
@@ -170,8 +173,6 @@ describe('Tesseron MCP integration', () => {
     const result = await callTool('val1__greet', { name: 42 });
     expect(result.isError).toBe(true);
     expect(result.text.toLowerCase()).toContain('invalid input');
-    // Structured content lets agents programmatically branch on the specific
-    // error code rather than regex-matching the human-readable text.
     expect(result.structuredContent?.code).toBe(TesseronErrorCode.InputValidation);
   });
 
@@ -185,10 +186,26 @@ describe('Tesseron MCP integration', () => {
     const result = await callTool('err1__boom', {});
     expect(result.isError).toBe(true);
     expect(result.text).toContain('something broke in the handler');
-    // A plain handler throw propagates as InternalError via the dispatcher's
-    // toErrorPayload fallback. HandlerError is reserved for the SDK's own
-    // schema-validation failures (see core/src/client.ts lines 322/370/393).
+    // Plain handler throws become InternalError via the dispatcher's
+    // toErrorPayload fallback. HandlerError is reserved for SDK-internal
+    // schema failures (sampling result, elicitation content, strict output).
     expect(result.structuredContent?.code).toBe(TesseronErrorCode.InternalError);
+  });
+
+  it('propagates TesseronError.data into structuredContent', async () => {
+    // Guards the conditional `.data` spread in errorResult: .code alone would
+    // pass even if a refactor silently dropped the data branch.
+    const issues = [{ message: 'name required', path: ['name'] }];
+    await setupAndClaim('propagate1', (s) => {
+      s.action('boom').handler(() => {
+        throw new TesseronError(TesseronErrorCode.InputValidation, 'bad input', issues);
+      });
+    });
+
+    const result = await callTool('propagate1__boom', {});
+    expect(result.isError).toBe(true);
+    expect(result.structuredContent?.code).toBe(TesseronErrorCode.InputValidation);
+    expect(result.structuredContent?.data).toEqual(issues);
   });
 
   it('rejects unknown claim codes', async () => {


### PR DESCRIPTION
## Summary

Closes #5. The bridge's `errorResult` helper dropped the `TesseronError`'s numeric `code` when building the MCP `tools/call` failure payload, leaving agents to regex-match the human-readable text to tell `TransportClosed` from `HandlerError` from `InputValidation` etc.

## Change

`errorResult` now takes the full `TesseronError` (instead of just its `.data`) and emits an MCP-spec-native `structuredContent` object carrying `{ code, data? }` alongside the existing text content. Call sites at `mcp-bridge.ts:403` (actions/invoke) and `:561` (resources/read) pass the full error rather than pre-extracting `.data`.

**Before:**

```jsonc
{
  "content": [{ "type": "text", "text": "Invalid input\n[...]" }],
  "isError": true
}
```

**After:**

```jsonc
{
  "content": [{ "type": "text", "text": "Invalid input\n{\n  \"code\": -32004,\n  \"data\": [...]\n}" }],
  "structuredContent": { "code": -32004, "data": [...] },
  "isError": true
}
```

## Backwards-compatibility

- Text body stays the same shape (`${message}\n${JSON}`), so existing log scrapes / regex assertions keep passing.
- `structuredContent` is an optional field in `CallToolResultSchema` from `@modelcontextprotocol/sdk` (verified at `types.d.ts:2601`). Clients that ignore it are unaffected.

## Tests

Existing integration tests for validation errors and handler errors now also assert on `result.structuredContent?.code`:

- `'surfaces a validation error when input does not match the schema'` → `InputValidation` (-32004)
- `'surfaces handler errors with their original message'` → `InternalError` (-32603)

The handler-error assertion is `InternalError`, not `HandlerError`, because a plain `throw new Error(...)` in user code propagates through `dispatcher.ts:201`'s `toErrorPayload` `Error`-fallback. `HandlerError` is reserved for the SDK's own schema-validation failures (see `core/src/client.ts:322/370/393`). There's an inline comment calling this out so a future reader isn't misled.

43/43 tests pass. Typecheck clean. Biome format clean.

## Test plan

- [x] `pnpm --filter @tesseron/mcp typecheck`
- [x] `pnpm --filter @tesseron/mcp test`
- [x] Biome format applied
- [x] Minor-bump changeset at `.changeset/errorresult-carry-code.md` (`@tesseron/mcp` gains a field on the tool-call error shape)

## Related

- #1 / PR #3 (hang on disconnect) — once merged, its regression test can be tightened to assert on `structuredContent.code === TesseronErrorCode.TransportClosed` instead of the current `/transport|socket|closed|disconnect/` regex on text.
- #2 / PR #4 (session resume) — `ResumeFailed` benefits too: agents can branch on it without regex after both merge.
- Surfaced by the silent-failure-hunter review on #3.
