### PR TITLE
chore(release): run Biome after changeset version to prevent CI format failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,10 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
+          # `changeset version` re-expands short JSON arrays onto multiple lines,
+          # which the repo's Biome formatter then rejects on the release PR's CI.
+          # Running `biome format --write` afterwards re-inlines them.
+          version: pnpm version-packages
           publish: pnpm changeset publish
           createGithubReleases: true
           commit: "chore: release packages"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "turbo run typecheck",
     "lint": "biome check .",
     "format": "biome format --write .",
+    "version-packages": "changeset version && biome format --write .",
     "docs:dev": "pnpm --filter @tesseron/docs start",
     "docs:build": "pnpm --filter @tesseron/docs build"
   },


### PR DESCRIPTION
## Problem

Every release fails CI on the auto-generated `changeset-release/main` PR, requiring a manual `biome format --write` commit to unblock it (see the v1.0.2 release history).

Root cause: the changesets CLI's `version` command rewrites `package.json` files using its own JSON formatter, which re-expands short arrays (`"files": ["dist", "README.md", "LICENSE"]`) onto multiple lines. Biome then rejects that formatting in the `pnpm lint` step of CI.

## Fix

Add a `version-packages` npm script at the root that runs `changeset version` and then `biome format --write .`, and wire it into `changesets/action@v1` via the `version` input. The action commits the combined (version + formatted) result as a single release commit, so the release PR lands already-Biome-clean.

## Test plan

- [ ] CI passes on this PR itself (lint + typecheck + test on the unchanged tree).
- [ ] Next release cycle: add a changeset, push to main, verify the auto-generated release PR's CI passes without manual intervention.

## Notes

- No behavior change outside the release workflow.
- `biome format --write .` only touches files Biome recognizes (JS/TS/JSON), so `CHANGELOG.md` and the `.changeset/` markdown files are untouched.
- Minimal risk: if the override ever breaks, the fallback is the exact manual flow used for v1.0.2.
