### PR TITLE
chore: gitignore local reddit-author skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ yarn-error.log*
 # Claude-local state (shared settings are tracked)
 .claude/settings.local.json
 .claude/worktrees/
+.claude/skills/reddit-author/
 
 # Project-specific internals (not for public consumption)
 /outputs/


### PR DESCRIPTION
## Summary

Adds `.claude/skills/reddit-author/` to `.gitignore`. That skill is a per-user wrapper around a private PRAW setup and was showing up as uncommitted files in VS Code's Source Control view in every session.

## Notes

- Mirrors the existing pattern for other per-user `.claude/*` paths (`settings.local.json`, `worktrees/`) directly above it.
- No code / config impact beyond git hygiene.
