### PR TITLE
feat(claude): inject docs index on every prompt, add update-docs skill

### DIFF
--- a/.claude/hooks/inject-docs-index.py
+++ b/.claude/hooks/inject-docs-index.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""
+UserPromptSubmit hook: inject a generated index of the Tesseron docs.
+
+Walks `docs/src/content/docs/**/*.{md,mdx}`, pulls `title` / `description`
+from YAML frontmatter, and emits a grouped table-of-contents as
+`additionalContext`. No static INDEX file to drift: the index is
+re-derived on every prompt.
+
+If the docs tree is missing or unreadable, exit 0 silently.
+"""
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+DOCS_SUBPATH = Path("docs") / "src" / "content" / "docs"
+# Order matters - controls the section order in the injected index.
+SECTION_ORDER = ["overview", "protocol", "sdk", "examples"]
+SECTION_LABELS = {
+    "overview": "Overview",
+    "protocol": "Protocol (wire format, transport, lifecycle, security)",
+    "sdk": "SDK (TypeScript packages, Python plans, porting guide)",
+    "examples": "Examples (runnable apps demonstrating each adapter)",
+}
+
+
+def parse_frontmatter(text: str) -> dict:
+    """Extract top-level string fields from a YAML frontmatter block.
+
+    Only handles the subset we need: `title:` and `description:`, single-line
+    or block-scalar (`|`, `>`). Avoids a PyYAML dependency.
+    """
+    if not text.startswith("---"):
+        return {}
+    end = text.find("\n---", 3)
+    if end == -1:
+        return {}
+    block = text[3:end].strip("\n")
+    result: dict = {}
+    key: str | None = None
+    folded_indent: int | None = None
+    folded_lines: list[str] = []
+
+    def flush_folded():
+        nonlocal key, folded_indent, folded_lines
+        if key is not None and folded_lines:
+            result[key] = " ".join(line.strip() for line in folded_lines).strip()
+        key = None
+        folded_indent = None
+        folded_lines = []
+
+    for raw in block.splitlines():
+        if folded_indent is not None:
+            stripped = raw.lstrip(" ")
+            indent = len(raw) - len(stripped)
+            if raw.strip() and indent >= folded_indent:
+                folded_lines.append(stripped)
+                continue
+            flush_folded()
+        m = re.match(r"^([A-Za-z_][\w-]*):\s*(.*)$", raw)
+        if not m:
+            continue
+        k, v = m.group(1), m.group(2).strip()
+        if v in ("|", ">"):
+            key = k
+            folded_indent = 2  # assume two-space indent for folded content
+            folded_lines = []
+            continue
+        if v.startswith(('"', "'")) and v.endswith(v[0]) and len(v) >= 2:
+            v = v[1:-1]
+        result[k] = v
+    flush_folded()
+    return result
+
+
+def extract(doc_path: Path, project_root: Path) -> tuple[str, str, str]:
+    """Return (title, description, repo-relative-path) for a doc file."""
+    try:
+        text = doc_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ("", "", str(doc_path.relative_to(project_root)))
+    fm = parse_frontmatter(text)
+    title = fm.get("title", "").strip() or doc_path.stem
+    desc = fm.get("description", "").strip()
+    return (title, desc, str(doc_path.relative_to(project_root)).replace("\\", "/"))
+
+
+def build_index(project_root: Path) -> str:
+    docs_root = project_root / DOCS_SUBPATH
+    if not docs_root.is_dir():
+        return ""
+
+    buckets: dict[str, list[tuple[str, str, str]]] = {name: [] for name in SECTION_ORDER}
+    root_entries: list[tuple[str, str, str]] = []
+
+    for path in sorted(docs_root.rglob("*")):
+        if not path.is_file() or path.suffix.lower() not in (".md", ".mdx"):
+            continue
+        rel_to_docs = path.relative_to(docs_root)
+        parts = rel_to_docs.parts
+        entry = extract(path, project_root)
+        if len(parts) == 1:
+            root_entries.append(entry)
+            continue
+        section = parts[0]
+        buckets.setdefault(section, []).append(entry)
+
+    lines: list[str] = []
+    lines.append("# Tesseron docs index")
+    lines.append("")
+    lines.append(
+        "Each row points at a published docs page. Treat these as the canonical "
+        "description of the protocol and SDK surface. Read the file itself - not "
+        "just this index - before answering questions about Tesseron behavior."
+    )
+    lines.append("")
+
+    if root_entries:
+        lines.append("## Landing")
+        lines.append("")
+        for title, desc, rel in root_entries:
+            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        lines.append("")
+
+    for section in SECTION_ORDER:
+        entries = buckets.get(section) or []
+        if not entries:
+            continue
+        lines.append(f"## {SECTION_LABELS.get(section, section.title())}")
+        lines.append("")
+        for title, desc, rel in entries:
+            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        lines.append("")
+
+    extras = {k: v for k, v in buckets.items() if k not in SECTION_ORDER and v}
+    for section, entries in sorted(extras.items()):
+        lines.append(f"## {section.title()}")
+        lines.append("")
+        for title, desc, rel in entries:
+            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main() -> None:
+    try:
+        input_data = json.load(sys.stdin)
+    except Exception:
+        sys.exit(0)
+
+    project_dir = os.environ.get("CLAUDE_PROJECT_DIR") or input_data.get("cwd") or ""
+    if not project_dir:
+        sys.exit(0)
+    project_root = Path(project_dir)
+
+    try:
+        index = build_index(project_root)
+    except Exception:
+        sys.exit(0)
+    if not index:
+        sys.exit(0)
+
+    additional = (
+        "<MANDATORY_INSTRUCTION>\n"
+        "BEFORE answering any question about Tesseron protocol behavior, SDK\n"
+        "surface, or package APIs, you MUST:\n"
+        "1. Acknowledge which docs page(s) cover the topic.\n"
+        "2. Read the relevant file(s) under docs/src/content/docs/ (paths\n"
+        "   listed in the index below) before exploring the source or\n"
+        "   answering from memory.\n"
+        "\n"
+        "AFTER completing any change to packages/ source that alters\n"
+        "protocol behavior, public types, exported functions, hook APIs,\n"
+        "or CLI flags, you MUST:\n"
+        "1. List the modified files.\n"
+        "2. Identify which docs page(s) describe the changed surface.\n"
+        "3. End with either:\n"
+        "   - 'Running update-docs skill to sync documentation.' then invoke it, OR\n"
+        "   - 'No docs updates needed because [reason].'\n"
+        "\n"
+        "If the change is test-only, tooling-only, or internal refactor with\n"
+        "no public surface shift, state that and skip the update.\n"
+        "</MANDATORY_INSTRUCTION>\n"
+        "\n"
+        "=== TESSERON DOCS INDEX ===\n"
+        "\n"
+        f"{index}"
+    )
+
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "UserPromptSubmit",
+            "additionalContext": additional,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,5 +16,18 @@
         "repo": "giuseppe-trisciuoglio/developer-kit"
       }
     }
+  },
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python \"${CLAUDE_PROJECT_DIR}/.claude/hooks/inject-docs-index.py\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: update-docs
+description: >-
+  Use this skill after any change to `packages/**` source that shifts
+  Tesseron's public surface - protocol messages, exported types, action/resource
+  builder APIs, ActionContext methods, transports, gateway CLI flags, or React
+  hooks - to sync `docs/src/content/docs/` so the Starlight site matches the
+  code. Triggers on "update the docs", "sync docs", "docs are stale after this
+  change", or when a session ends with public-surface edits unaccompanied by
+  doc edits. Do NOT trigger for test-only, tooling-only, or internal refactors
+  that leave the public surface identical.
+---
+
+# Update Tesseron docs
+
+Keep `docs/src/content/docs/` aligned with whatever just changed in `packages/**`. The docs are the published Starlight site and the contract Tesseron users read, so drift here is user-visible.
+
+## Prerequisites
+
+- A recent edit to `packages/**` (use `git diff` / `git diff --stat HEAD` to see the change set).
+- The docs tree at `docs/src/content/docs/`. If it's missing, stop and flag it.
+
+## Doc pages and what they own
+
+| Page | Owns |
+|------|------|
+| `overview/index.mdx` (the root `index.mdx`) | Elevator pitch, hero copy, top-level links. Rarely changes. |
+| `overview/architecture.mdx` | Three-process model diagram, protocol boundary descriptions. |
+| `overview/quickstart.mdx` | The 5-minute path: install, declare one action, run the gateway, see Claude call it. |
+| `overview/why.md` | Positioning vs browser automation / Playwright / chat widgets. |
+| `protocol/index.mdx` | One-page protocol overview. Update when a new top-level concept lands. |
+| `protocol/wire-format.mdx` | JSON-RPC envelope, method names, id rules. |
+| `protocol/transport.md` | WebSocket URL, framing, origin allowlist, reconnect behavior. |
+| `protocol/handshake.mdx` | `tesseron/hello`, `welcome`, claim code, `tools/list_changed`. |
+| `protocol/actions.mdx` | Action declaration, namespacing, invoke / validate / return. |
+| `protocol/progress-cancellation.mdx` | `actions/progress`, AbortSignal, `actions/cancel`. |
+| `protocol/sampling.mdx` | Handler re-entry into the agent's LLM. |
+| `protocol/elicitation.mdx` | `ctx.confirm` and `ctx.elicit`. |
+| `protocol/resources.mdx` | Readable / subscribable resource projection. |
+| `protocol/errors.mdx` | Every defined error code and what raises it. |
+| `protocol/lifecycle.mdx` | Session state machine, what happens to pending work. |
+| `protocol/security.mdx` | Origin enforcement, claim flow, trust boundaries. |
+| `sdk/typescript/index.mdx` | Install, `packages/` landscape, first action snippet. |
+| `sdk/typescript/action-builder.md` | `tesseron.action(...)` fluent API. |
+| `sdk/typescript/standard-schema.md` | Zod / Valibot / etc. adapter plumbing. |
+| `sdk/typescript/context.md` | `ActionContext` methods: progress, sample, confirm, elicit, signal. |
+| `sdk/typescript/resources.md` | `tesseron.resource(...)` builder, subscribe contract. |
+| `sdk/typescript/core.md` | `@tesseron/core` exports, custom transport extension points. |
+| `sdk/typescript/web.md` | `@tesseron/web` browser adapter. |
+| `sdk/typescript/server.md` | `@tesseron/server` Node adapter. |
+| `sdk/typescript/react.md` | `useTesseronAction`, `useTesseronResource`, `useTesseronConnection`. |
+| `sdk/typescript/mcp.md` | `@tesseron/mcp` gateway CLI, config, origin allowlist. |
+| `sdk/python/index.md` | Planned Python SDK - only update when roadmap changes. |
+| `sdk/porting.md` | How to port Tesseron to another language. |
+| `examples/index.mdx` | Table of the example apps. |
+| `examples/<name>.md` | Individual example app walk-through. |
+
+## Process
+
+### Step 1 - Inspect the change set
+
+Run these in one go:
+
+```bash
+git status --short
+git diff --stat HEAD
+git diff HEAD -- packages/
+```
+
+Focus on exported symbols, public types, protocol method names, CLI flags, and `.md`/`.mdx` snippets inside packages. Ignore changes under `**/*.test.ts`, `**/*.spec.ts`, `**/__tests__/**`, `tsconfig*.json`, `biome*.json`, `.changeset/`, and CI config - those don't require doc updates.
+
+### Step 2 - Map changes to doc pages
+
+For each modified public surface, find the doc pages that own it via the table above. Also `rg` across `docs/src/content/docs/` for the renamed / changed symbol to catch incidental mentions the owner table misses:
+
+```bash
+rg --fixed-strings "oldSymbolName" docs/src/content/docs/
+```
+
+### Step 3 - Edit the affected pages only
+
+- Prefer `Edit` over `Write`. Targeted edits keep diffs reviewable.
+- Preserve frontmatter (`title`, `description`). They feed both the sidebar and the injected docs index.
+- Keep Starlight components intact: `Diagram`, `Card`, `CardGrid`, `LinkCard`, `Code`, `Tabs`, etc.
+- Don't introduce em-dashes (`-`) in user-facing prose - use `-` or periods. Matches project voice.
+- Update version numbers / package exports only when the actual package boundary shifted.
+
+### Step 4 - Update frontmatter `description` if the page focus shifted
+
+The hook at `.claude/hooks/inject-docs-index.py` derives the injected index from `description` fields. If a page's scope changed materially (e.g., a method was promoted or removed), rewrite the `description` so it stays a one-line summary of what the page now covers.
+
+### Step 5 - Verify
+
+```bash
+cd docs && npx astro check
+```
+
+`astro check` catches broken frontmatter, bad component usage, and broken relative links. If the build is already wired into CI, rely on that instead; otherwise run it locally.
+
+### Step 6 - Report back
+
+End your turn with a bullet list:
+
+- Modified packages: `packages/...`
+- Docs updated: `docs/src/content/docs/...`
+- Docs reviewed but unchanged (and why)
+
+## What NOT to update
+
+- `.changeset/` files - maintained by the release workflow, not by this skill.
+- `README.md` at repo root - stays in sync by hand; mention in your report if it looks stale so the user decides.
+- The Starlight `sidebar` in `docs/astro.config.mjs` - only touch when a new page is added or a page is deleted, and even then prefer a note in the report so the user confirms ordering.
+- Auto-generated TypeDoc / API reference output (if any).
+
+## Success criteria
+
+- [ ] Every public-surface change is reflected in at least one doc page.
+- [ ] No orphaned references to removed / renamed symbols remain in `docs/`.
+- [ ] Frontmatter `title` / `description` accurate on every touched page.
+- [ ] `astro check` passes (or CI equivalent).
+- [ ] Report lists modified packages, updated docs, and reviewed-but-unchanged docs.


### PR DESCRIPTION
## Summary

Adds a Claude-Code project-level mechanism that grounds every session in the published Tesseron docs, so the model reads the right Starlight page before answering questions about protocol behavior or SDK surface.

- **`.claude/hooks/inject-docs-index.py`** - `UserPromptSubmit` hook. Walks `docs/src/content/docs/**/*.{md,mdx}`, pulls `title` / `description` from frontmatter, and emits a grouped index (Overview / Protocol / SDK / Examples) as `additionalContext`. No static index file - it is re-derived from the docs on every prompt, so it can't drift.
- **`.claude/skills/update-docs/SKILL.md`** - Skill that triggers after public-surface changes to `packages/**` (protocol messages, exported types, builder APIs, `ActionContext`, transports, gateway CLI flags, React hooks). Includes a page-ownership table mapping each package area to the doc pages that describe it, and `astro check` as the validation gate.
- **`.claude/settings.json`** - Registers the hook at the project level.

## Why

The repo already has comprehensive Starlight docs. Claude Code had no signal to prefer the docs over source when answering questions about protocol behavior, and no gate to catch docs drift after public-surface changes. This closes both gaps without introducing a separate doc-map-to-maintain: the docs themselves are the source of truth, and the hook indexes their frontmatter directly.

Parallel in spirit to `codebase-mapper`, but:
- no bootstrap / mapping step (docs already exist)
- no static `INDEX.md` to maintain (generated from frontmatter each prompt)
- Starlight-aware (respects `title` / `description`, MDX components, sidebar sections)

## Requirements

- Python 3.x on PATH. The same requirement the developer-kit plugin hooks rely on, per `.claude/CLAUDE.md`.

## Test plan

- [ ] Open a Claude Code session in this repo and submit a prompt; verify the injected docs index appears in the `additionalContext`.
- [ ] Verify frontmatter for each page still produces a sensible one-line summary under each section.
- [ ] Make a dummy change to a `packages/**` public export and confirm the `update-docs` skill triggers.
- [ ] Run `cd docs && npx astro check` after any doc edit the skill drives to confirm it stays green.

Generated with [Claude Code](https://claude.com/claude-code)
