### PR TITLE
feat(claude): related-pages graph in docs injection hook

### DIFF
--- a/.claude/hooks/inject-docs-index.py
+++ b/.claude/hooks/inject-docs-index.py
@@ -27,65 +27,115 @@ SECTION_LABELS = {
 }
 
 
-def parse_frontmatter(text: str) -> dict:
-    """Extract top-level string fields from a YAML frontmatter block.
+def _strip_quotes(v: str) -> str:
+    if v.startswith(('"', "'")) and v.endswith(v[0]) and len(v) >= 2:
+        return v[1:-1]
+    return v
 
-    Only handles the subset we need: `title:` and `description:`, single-line
-    or block-scalar (`|`, `>`). Avoids a PyYAML dependency.
+
+def parse_frontmatter(text: str) -> dict:
+    """Extract top-level fields from a YAML frontmatter block.
+
+    Supported shapes:
+      - `key: value` scalars (with optional single/double quotes)
+      - `key: |` / `key: >` folded/literal scalars
+      - `key:` followed by `  - item` block lists
+    Avoids a PyYAML dependency.
     """
     if not text.startswith("---"):
         return {}
     end = text.find("\n---", 3)
     if end == -1:
         return {}
-    block = text[3:end].strip("\n")
+    lines = text[3:end].strip("\n").splitlines()
     result: dict = {}
-    key: str | None = None
-    folded_indent: int | None = None
-    folded_lines: list[str] = []
+    i = 0
+    key_re = re.compile(r"^([A-Za-z_][\w-]*):\s*(.*)$")
+    list_re = re.compile(r"^(\s+)-\s+(.*)$")
 
-    def flush_folded():
-        nonlocal key, folded_indent, folded_lines
-        if key is not None and folded_lines:
-            result[key] = " ".join(line.strip() for line in folded_lines).strip()
-        key = None
-        folded_indent = None
-        folded_lines = []
-
-    for raw in block.splitlines():
-        if folded_indent is not None:
-            stripped = raw.lstrip(" ")
-            indent = len(raw) - len(stripped)
-            if raw.strip() and indent >= folded_indent:
-                folded_lines.append(stripped)
-                continue
-            flush_folded()
-        m = re.match(r"^([A-Za-z_][\w-]*):\s*(.*)$", raw)
+    while i < len(lines):
+        raw = lines[i]
+        m = key_re.match(raw)
         if not m:
+            i += 1
             continue
         k, v = m.group(1), m.group(2).strip()
+
         if v in ("|", ">"):
-            key = k
-            folded_indent = 2  # assume two-space indent for folded content
-            folded_lines = []
+            j = i + 1
+            folded: list[str] = []
+            indent: int | None = None
+            while j < len(lines):
+                nl = lines[j]
+                if not nl.strip():
+                    j += 1
+                    continue
+                stripped = nl.lstrip(" ")
+                ind = len(nl) - len(stripped)
+                if indent is None:
+                    indent = ind
+                if ind < indent:
+                    break
+                folded.append(stripped)
+                j += 1
+            if folded:
+                result[k] = " ".join(line.strip() for line in folded).strip()
+            i = j
             continue
-        if v.startswith(('"', "'")) and v.endswith(v[0]) and len(v) >= 2:
-            v = v[1:-1]
-        result[k] = v
-    flush_folded()
+
+        if v == "":
+            j = i + 1
+            items: list[str] = []
+            while j < len(lines):
+                nl = lines[j]
+                if not nl.strip():
+                    j += 1
+                    continue
+                lm = list_re.match(nl)
+                if not lm:
+                    break
+                items.append(_strip_quotes(lm.group(2).strip()))
+                j += 1
+            if items:
+                result[k] = items
+                i = j
+                continue
+            i += 1
+            continue
+
+        result[k] = _strip_quotes(v)
+        i += 1
+
     return result
 
 
-def extract(doc_path: Path, project_root: Path) -> tuple[str, str, str]:
-    """Return (title, description, repo-relative-path) for a doc file."""
+def extract(doc_path: Path, project_root: Path) -> tuple[str, str, str, list[str]]:
+    """Return (title, description, repo-relative-path, related-slugs)."""
     try:
         text = doc_path.read_text(encoding="utf-8", errors="replace")
     except OSError:
-        return ("", "", str(doc_path.relative_to(project_root)))
+        return ("", "", str(doc_path.relative_to(project_root)), [])
     fm = parse_frontmatter(text)
-    title = fm.get("title", "").strip() or doc_path.stem
-    desc = fm.get("description", "").strip()
-    return (title, desc, str(doc_path.relative_to(project_root)).replace("\\", "/"))
+    title = (fm.get("title") or "").strip() if isinstance(fm.get("title"), str) else ""
+    if not title:
+        title = doc_path.stem
+    desc_raw = fm.get("description") or ""
+    desc = desc_raw.strip() if isinstance(desc_raw, str) else ""
+    related_raw = fm.get("related") or []
+    related = [s.strip() for s in related_raw if isinstance(s, str) and s.strip()] \
+        if isinstance(related_raw, list) else []
+    rel = str(doc_path.relative_to(project_root)).replace("\\", "/")
+    return (title, desc, rel, related)
+
+
+Entry = tuple[str, str, str, list[str]]
+
+
+def _render_entry(lines: list[str], entry: Entry) -> None:
+    title, desc, rel, related = entry
+    lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+    if related:
+        lines.append(f"  Related: {', '.join(related)}")
 
 
 def build_index(project_root: Path) -> str:
@@ -93,8 +143,8 @@ def build_index(project_root: Path) -> str:
     if not docs_root.is_dir():
         return ""
 
-    buckets: dict[str, list[tuple[str, str, str]]] = {name: [] for name in SECTION_ORDER}
-    root_entries: list[tuple[str, str, str]] = []
+    buckets: dict[str, list[Entry]] = {name: [] for name in SECTION_ORDER}
+    root_entries: list[Entry] = []
 
     for path in sorted(docs_root.rglob("*")):
         if not path.is_file() or path.suffix.lower() not in (".md", ".mdx"):
@@ -117,12 +167,18 @@ def build_index(project_root: Path) -> str:
         "just this index - before answering questions about Tesseron behavior."
     )
     lines.append("")
+    lines.append(
+        "Entries with a `Related:` line name adjacent pages by slug "
+        "(`<section>/<basename>` without extension). Follow those edges "
+        "when a question spans topics."
+    )
+    lines.append("")
 
     if root_entries:
         lines.append("## Landing")
         lines.append("")
-        for title, desc, rel in root_entries:
-            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        for entry in root_entries:
+            _render_entry(lines, entry)
         lines.append("")
 
     for section in SECTION_ORDER:
@@ -131,16 +187,16 @@ def build_index(project_root: Path) -> str:
             continue
         lines.append(f"## {SECTION_LABELS.get(section, section.title())}")
         lines.append("")
-        for title, desc, rel in entries:
-            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        for entry in entries:
+            _render_entry(lines, entry)
         lines.append("")
 
     extras = {k: v for k, v in buckets.items() if k not in SECTION_ORDER and v}
     for section, entries in sorted(extras.items()):
         lines.append(f"## {section.title()}")
         lines.append("")
-        for title, desc, rel in entries:
-            lines.append(f"- **{title}** ({rel}) - {desc}" if desc else f"- **{title}** ({rel})")
+        for entry in entries:
+            _render_entry(lines, entry)
         lines.append("")
 
     return "\n".join(lines).rstrip() + "\n"

--- a/docs/src/content/docs/examples/express-todo.md
+++ b/docs/src/content/docs/examples/express-todo.md
@@ -1,6 +1,9 @@
 ---
 title: express-todo
 description: REST API + Tesseron on the same Node process, backed by the same state.
+related:
+  - sdk/typescript/server
+  - examples/node-todo
 ---
 
 **What it teaches:** how to expose the same backend operations via two channels at once - HTTP for human / programmatic clients, Tesseron for the agent. Neither knows the other exists.

--- a/docs/src/content/docs/examples/index.mdx
+++ b/docs/src/content/docs/examples/index.mdx
@@ -1,6 +1,9 @@
 ---
 title: All examples
 description: Six runnable Todo apps that together cover every framework adapter and every major feature of the SDK.
+related:
+  - overview/quickstart
+  - sdk/typescript/index
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/examples/node-todo.md
+++ b/docs/src/content/docs/examples/node-todo.md
@@ -1,6 +1,8 @@
 ---
 title: node-todo
 description: Headless Node service - no HTTP, no browser. Proves the SDK isn't tied to DOM.
+related:
+  - sdk/typescript/server
 ---
 
 **What it teaches:** a pure-Node Tesseron integration. No Express, no web server - just a Node script that registers actions and connects. Good when you're building a CLI, a daemon, or a worker that Claude should drive.

--- a/docs/src/content/docs/examples/react-todo.md
+++ b/docs/src/content/docs/examples/react-todo.md
@@ -1,6 +1,9 @@
 ---
 title: react-todo
 description: React 18 + `@tesseron/react` hooks. Idiomatic integration with component lifecycle.
+related:
+  - sdk/typescript/react
+  - sdk/typescript/web
 ---
 
 **What it teaches:** declarative action registration in React. Mount = register; unmount = unregister. State is mutated through `setTodos` exactly like in a normal React app.

--- a/docs/src/content/docs/examples/svelte-todo.md
+++ b/docs/src/content/docs/examples/svelte-todo.md
@@ -1,6 +1,8 @@
 ---
 title: svelte-todo
 description: Svelte 5 runes (`$state`, `$derived`). Mutation via direct reassignment.
+related:
+  - sdk/typescript/web
 ---
 
 **What it teaches:** integrating Tesseron with Svelte 5's rune-based reactivity. Handlers reassign `let todos = $state(...)` and Svelte re-renders.

--- a/docs/src/content/docs/examples/vanilla-todo.md
+++ b/docs/src/content/docs/examples/vanilla-todo.md
@@ -1,6 +1,9 @@
 ---
 title: vanilla-todo
 description: Plain Vite + TypeScript. The minimum environment for exercising the SDK.
+related:
+  - sdk/typescript/web
+  - sdk/typescript/index
 ---
 
 **What it teaches:** the raw action / resource builder API with no framework in the way. Read this before any of the framework-specific examples.

--- a/docs/src/content/docs/examples/vue-todo.md
+++ b/docs/src/content/docs/examples/vue-todo.md
@@ -1,6 +1,8 @@
 ---
 title: vue-todo
 description: Vue 3 composition API with `ref()` and `computed()`.
+related:
+  - sdk/typescript/web
 ---
 
 **What it teaches:** integrating Tesseron with Vue 3's reactivity. Handlers mutate `todos.value` and `computed()` recomputes downstream derived state.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -1,6 +1,10 @@
 ---
 title: Tesseron
 description: Expose typed web-app actions to MCP-compatible AI agents over WebSocket. No browser automation, no scraping.
+related:
+  - overview/quickstart
+  - overview/why
+  - overview/architecture
 template: splash
 hero:
   tagline: |

--- a/docs/src/content/docs/overview/architecture.mdx
+++ b/docs/src/content/docs/overview/architecture.mdx
@@ -1,6 +1,11 @@
 ---
 title: Architecture at a glance
 description: The three moving parts - your app, the MCP gateway, the agent - and how a single action flows between them.
+related:
+  - overview/quickstart
+  - protocol/handshake
+  - protocol/actions
+  - sdk/typescript/mcp
 ---
 
 import Diagram from '../../../components/Diagram.astro';

--- a/docs/src/content/docs/overview/quickstart.mdx
+++ b/docs/src/content/docs/overview/quickstart.mdx
@@ -1,6 +1,11 @@
 ---
 title: Quickstart (5 minutes)
 description: Install the plugin, drop the SDK into an app, declare one action, watch Claude call it.
+related:
+  - sdk/typescript/index
+  - sdk/typescript/action-builder
+  - overview/architecture
+  - examples/index
 ---
 
 import { Steps, Tabs, TabItem } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/overview/why.md
+++ b/docs/src/content/docs/overview/why.md
@@ -1,6 +1,9 @@
 ---
 title: Why Tesseron?
 description: The problem Tesseron solves, and where it fits relative to browser automation, chat widgets, and custom APIs.
+related:
+  - overview/architecture
+  - protocol/index
 ---
 
 Agents are great at reasoning about what to do. They're bad at reaching into your app to do it.

--- a/docs/src/content/docs/protocol/actions.mdx
+++ b/docs/src/content/docs/protocol/actions.mdx
@@ -1,6 +1,12 @@
 ---
 title: Action model
 description: How actions are declared, namespaced, invoked, validated, and returned.
+related:
+  - sdk/typescript/action-builder
+  - protocol/wire-format
+  - protocol/elicitation
+  - protocol/sampling
+  - protocol/progress-cancellation
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/elicitation.mdx
+++ b/docs/src/content/docs/protocol/elicitation.mdx
@@ -1,6 +1,10 @@
 ---
 title: Elicitation
 description: Handlers pause to ask the user a question. Two verbs - ctx.confirm for yes/no, ctx.elicit for structured content.
+related:
+  - protocol/actions
+  - protocol/wire-format
+  - sdk/typescript/context
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/errors.mdx
+++ b/docs/src/content/docs/protocol/errors.mdx
@@ -1,6 +1,9 @@
 ---
 title: Errors & capabilities
 description: Every error code Tesseron defines, what raises each one, and how capability negotiation shapes handler behaviour.
+related:
+  - protocol/wire-format
+  - protocol/handshake
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/handshake.mdx
+++ b/docs/src/content/docs/protocol/handshake.mdx
@@ -1,6 +1,11 @@
 ---
 title: Handshake & claiming
 description: How a WebSocket becomes a bound session - tesseron/hello, welcome, claim code, and tools/list_changed.
+related:
+  - protocol/wire-format
+  - protocol/transport
+  - protocol/security
+  - protocol/lifecycle
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/index.mdx
+++ b/docs/src/content/docs/protocol/index.mdx
@@ -1,6 +1,13 @@
 ---
 title: Protocol overview
 description: The Tesseron protocol in one page - wire format, transport, handshake, action model, MCP capabilities, errors, lifecycle.
+related:
+  - protocol/wire-format
+  - protocol/transport
+  - protocol/handshake
+  - protocol/actions
+  - protocol/errors
+  - protocol/lifecycle
 ---
 
 import { Aside, Card, CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/protocol/lifecycle.mdx
+++ b/docs/src/content/docs/protocol/lifecycle.mdx
@@ -1,6 +1,10 @@
 ---
 title: Lifecycle & failure modes
 description: The session state machine, and what happens to pending work at every transition.
+related:
+  - protocol/handshake
+  - protocol/resume
+  - protocol/transport
 ---
 
 import Diagram from '../../../components/Diagram.astro';

--- a/docs/src/content/docs/protocol/progress-cancellation.mdx
+++ b/docs/src/content/docs/protocol/progress-cancellation.mdx
@@ -1,6 +1,10 @@
 ---
 title: Progress & cancellation
 description: Streaming updates via `actions/progress` and AbortSignal-based cancellation via `actions/cancel`.
+related:
+  - protocol/actions
+  - protocol/wire-format
+  - sdk/typescript/context
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/resources.mdx
+++ b/docs/src/content/docs/protocol/resources.mdx
@@ -1,6 +1,9 @@
 ---
 title: Resources
 description: Typed, readable, optionally subscribable state your app projects to the agent.
+related:
+  - sdk/typescript/resources
+  - protocol/wire-format
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/resume.mdx
+++ b/docs/src/content/docs/protocol/resume.mdx
@@ -1,6 +1,11 @@
 ---
 title: Session resume
 description: How a Tesseron app rejoins a previously-claimed session after a transport drop via tesseron/resume - protocol shape, gateway behaviour, and the 4-line localStorage recipe.
+related:
+  - protocol/handshake
+  - protocol/transport
+  - protocol/wire-format
+  - protocol/lifecycle
 ---
 
 A Tesseron session lives in the gateway's memory. When the underlying WebSocket drops (tab refresh, window close, network blip, HMR reload), the session normally goes away and a reconnecting app would have to go through the full `tesseron/hello` + claim-code dance again - even if the user had already paired it.

--- a/docs/src/content/docs/protocol/sampling.mdx
+++ b/docs/src/content/docs/protocol/sampling.mdx
@@ -1,6 +1,10 @@
 ---
 title: Sampling
 description: How a handler re-enters the agent's LLM for a reasoning step, and what the schema contract looks like.
+related:
+  - protocol/actions
+  - protocol/wire-format
+  - sdk/typescript/context
 ---
 
 import Sequence from '../../../components/Sequence.astro';

--- a/docs/src/content/docs/protocol/security.mdx
+++ b/docs/src/content/docs/protocol/security.mdx
@@ -1,6 +1,9 @@
 ---
 title: Security model
 description: Origin allowlist, claim codes, multi-app namespacing, and the threats Tesseron does and does not defend against.
+related:
+  - protocol/handshake
+  - protocol/transport
 ---
 
 import Diagram from '../../../components/Diagram.astro';

--- a/docs/src/content/docs/protocol/transport.md
+++ b/docs/src/content/docs/protocol/transport.md
@@ -1,6 +1,9 @@
 ---
 title: Transport (WebSocket)
 description: URL, framing, origin enforcement, reconnection, and what happens to pending work on disconnect.
+related:
+  - protocol/handshake
+  - protocol/wire-format
 ---
 
 ## Endpoint

--- a/docs/src/content/docs/protocol/wire-format.mdx
+++ b/docs/src/content/docs/protocol/wire-format.mdx
@@ -1,6 +1,11 @@
 ---
 title: Wire format (JSON-RPC)
 description: The envelope shapes Tesseron uses, the full method surface in both directions, and the ID-correlation rules.
+related:
+  - protocol/transport
+  - protocol/handshake
+  - protocol/errors
+  - protocol/actions
 ---
 
 import Diagram from '../../../components/Diagram.astro';

--- a/docs/src/content/docs/sdk/index.mdx
+++ b/docs/src/content/docs/sdk/index.mdx
@@ -1,6 +1,10 @@
 ---
 title: SDK overview
 description: What a Tesseron SDK has to expose - in TypeScript today, in any other language tomorrow.
+related:
+  - sdk/porting
+  - sdk/typescript/index
+  - protocol/index
 ---
 
 import { Card, CardGrid, LinkCard } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/sdk/porting.md
+++ b/docs/src/content/docs/sdk/porting.md
@@ -1,6 +1,11 @@
 ---
 title: Port Tesseron to your language
 description: Step-by-step guide to writing a new Tesseron SDK and a conformance checklist for testing it.
+related:
+  - sdk/index
+  - protocol/index
+  - protocol/wire-format
+  - sdk/typescript/core
 ---
 
 Tesseron's wire protocol is small enough that a competent engineer can implement an SDK for a new language in a couple of days. This page is your map.

--- a/docs/src/content/docs/sdk/python/index.md
+++ b/docs/src/content/docs/sdk/python/index.md
@@ -1,6 +1,9 @@
 ---
 title: Python SDK (planned)
 description: Status and intended shape of a Python implementation of the Tesseron SDK.
+related:
+  - sdk/index
+  - sdk/porting
 ---
 
 A Python SDK is on the roadmap but **not yet shipped**.

--- a/docs/src/content/docs/sdk/typescript/action-builder.md
+++ b/docs/src/content/docs/sdk/typescript/action-builder.md
@@ -1,6 +1,10 @@
 ---
 title: Action builder
 description: Every step of the fluent builder, what it does, and when to use it.
+related:
+  - protocol/actions
+  - sdk/typescript/standard-schema
+  - sdk/typescript/context
 ---
 
 The action builder is the fluent API on `tesseron.action(name)`. It chains until `.handler(fn)` terminates it with an `ActionDefinition<I, O>`.

--- a/docs/src/content/docs/sdk/typescript/context.md
+++ b/docs/src/content/docs/sdk/typescript/context.md
@@ -1,6 +1,10 @@
 ---
 title: Context API (progress, sampling, elicit)
 description: Everything available on the `ctx` argument of an action handler.
+related:
+  - protocol/elicitation
+  - protocol/sampling
+  - protocol/progress-cancellation
 ---
 
 Every action handler receives `(input, ctx)`. `ctx: ActionContext` is where the protocol-level capabilities are exposed as methods.

--- a/docs/src/content/docs/sdk/typescript/core.md
+++ b/docs/src/content/docs/sdk/typescript/core.md
@@ -1,6 +1,9 @@
 ---
 title: "@tesseron/core"
 description: The protocol types, builder, JSON-RPC dispatcher, and abstract client that every runtime adapter extends.
+related:
+  - protocol/wire-format
+  - sdk/typescript/action-builder
 ---
 
 `@tesseron/core` is the runtime-independent layer. It has **zero runtime dependencies beyond Standard Schema spec types**. If you're writing a custom transport - Bun, Deno, a browser extension background worker, a native WebSocket implementation - you extend `core` directly.

--- a/docs/src/content/docs/sdk/typescript/index.mdx
+++ b/docs/src/content/docs/sdk/typescript/index.mdx
@@ -1,6 +1,11 @@
 ---
 title: Install & first action
 description: The minimum code to go from zero to a working Tesseron integration in TypeScript.
+related:
+  - sdk/typescript/action-builder
+  - sdk/typescript/web
+  - sdk/typescript/standard-schema
+  - overview/quickstart
 ---
 
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';

--- a/docs/src/content/docs/sdk/typescript/mcp.md
+++ b/docs/src/content/docs/sdk/typescript/mcp.md
@@ -1,6 +1,10 @@
 ---
 title: "@tesseron/mcp (MCP gateway)"
 description: The MCP gateway process - WebSocket server + MCP stdio bridge. Bundled into the Claude Code plugin; you rarely run it by hand.
+related:
+  - protocol/handshake
+  - protocol/security
+  - protocol/transport
 ---
 
 `@tesseron/mcp` is the MCP gateway. It:

--- a/docs/src/content/docs/sdk/typescript/react.md
+++ b/docs/src/content/docs/sdk/typescript/react.md
@@ -1,6 +1,9 @@
 ---
 title: "@tesseron/react"
 description: Hooks for declarative action and resource registration inside React components.
+related:
+  - sdk/typescript/web
+  - sdk/typescript/action-builder
 ---
 
 `@tesseron/react` wraps `@tesseron/web` in three hooks. Registration becomes a declarative part of your component tree; unmount tears down cleanly.

--- a/docs/src/content/docs/sdk/typescript/resources.md
+++ b/docs/src/content/docs/sdk/typescript/resources.md
@@ -1,6 +1,9 @@
 ---
 title: Resources
 description: Declaring readable and subscribable state for the agent to observe.
+related:
+  - protocol/resources
+  - sdk/typescript/core
 ---
 
 A resource is a named piece of app state. The agent can read it on demand and, if your resource supports it, subscribe for live updates.

--- a/docs/src/content/docs/sdk/typescript/server.md
+++ b/docs/src/content/docs/sdk/typescript/server.md
@@ -1,6 +1,10 @@
 ---
 title: "@tesseron/server"
 description: The Node SDK. Same action surface as @tesseron/web, different transport.
+related:
+  - sdk/typescript/core
+  - protocol/transport
+  - sdk/typescript/action-builder
 ---
 
 `@tesseron/server` is what you use in a Node process - an Express server, a NestJS app, a CLI tool, a background worker. The builder API is identical to `@tesseron/web`; only the transport differs.

--- a/docs/src/content/docs/sdk/typescript/standard-schema.md
+++ b/docs/src/content/docs/sdk/typescript/standard-schema.md
@@ -1,6 +1,8 @@
 ---
 title: Standard Schema (Zod, Valibot, …)
 description: Any Standard Schema v1 validator works. What that means, which libraries are supported, and how to handle JSON Schema export.
+related:
+  - sdk/typescript/action-builder
 ---
 
 Tesseron's action builder accepts any validator that implements [Standard Schema v1](https://standardschema.dev). That's a small contract that most modern TypeScript validation libraries already expose:

--- a/docs/src/content/docs/sdk/typescript/web.md
+++ b/docs/src/content/docs/sdk/typescript/web.md
@@ -1,6 +1,10 @@
 ---
 title: "@tesseron/web"
 description: The browser SDK. Singleton client, WebSocket transport, framework-agnostic.
+related:
+  - sdk/typescript/core
+  - protocol/transport
+  - sdk/typescript/action-builder
 ---
 
 The package for anything running in a browser tab - vanilla TS, Vite, Next, Svelte, Vue. If you use React, the [@tesseron/react](/sdk/typescript/react/) adapter is the ergonomic wrapper on top of this.


### PR DESCRIPTION
## Summary

- Adds `related:` block-list support to the UserPromptSubmit docs-injection hook.
- Seeds `related:` frontmatter on every docs page that has cross-cutting edges.
- Renders each edge set as a `Related:` sub-line under its TOC entry in the injected context.

## Why

The flat index told Claude *what* pages exist but gave no hint about *which adjacent pages to consult together* for cross-cutting questions (e.g. "resume" pulls in handshake + transport + wire-format). Edges in frontmatter give a lightweight graph without shipping an embedding pipeline, touching the build, or introducing staleness. Every regeneration of the index walks the filesystem, so edges can never drift from the filesystem that carries them.

This was considered against a full vector-DB / semantic-search layer. Declined because:

- Docs are 37 curated files (~264 KB). Not the "giant proprietary codebase" case RAG is built for.
- Anthropic itself removed RAG from Claude Code in favour of agentic search. Same reasons apply here.
- The hook already runs on every prompt and regenerates from frontmatter, so there is no staleness problem to solve.

## What changed

- `.claude/hooks/inject-docs-index.py`:
  - Parser now handles block-style YAML lists (`key:` + `  - item` lines) alongside scalars and folded scalars. Rewritten with explicit lookahead instead of the previous state-flag loop.
  - `extract()` returns a `related` slug list; `build_index()` renders it as `Related: a, b, c` indented under the entry.
  - Preamble gains one line explaining the slug convention.
- Every page under `docs/src/content/docs/` got a `related:` field where meaningful edges exist (37 pages, 0 skipped). Slug format: `<section>/<basename>` without extension, so edges survive `.md` <-> `.mdx` renames.

## Verification

- `astro check` under `docs/`: 0 errors, 0 warnings, 0 hints. Starlight's default schema passes unknown frontmatter through, so no schema change was needed.
- Parser smoke tests: plain scalars, folded scalars (regression), and new block lists all parse correctly.
- Hook end-to-end: 37 `Related:` lines render, injected context grows from ~6.8 KB to ~9.3 KB.
- No `packages/**` source changed. Public SDK surface unaffected.

## Test plan

- [x] `cd docs && npx astro check`
- [x] Simulate hook invocation end-to-end and confirm 37 `Related:` lines render
- [x] Confirm all seeded slugs point at real pages
