### PR TITLE
feat(docs-mcp): initial @tesseron/docs-mcp package

### DIFF
--- a/.changeset/docs-mcp-initial.md
+++ b/.changeset/docs-mcp-initial.md
@@ -1,0 +1,5 @@
+---
+'@tesseron/docs-mcp': minor
+---
+
+Initial release of `@tesseron/docs-mcp`: a stdio MCP server that exposes the Tesseron documentation as three tools (`list_docs`, `search_docs`, `read_doc`) and `tesseron-docs://<slug>` resources. The docs snapshot (37 pages) is bundled in the package at publish time; search runs locally via minisearch BM25. Distribute via `npx @tesseron/docs-mcp`.

--- a/packages/docs-mcp/LICENSE
+++ b/packages/docs-mcp/LICENSE
@@ -1,0 +1,114 @@
+Business Source License 1.1
+
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Kenny Vaneetvelde
+
+Licensed Work:        Tesseron
+                      The Licensed Work is (c) 2026 Kenny Vaneetvelde.
+
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided your use does not include offering the
+                      Licensed Work, or a substantial portion of its
+                      functionality, to third parties as a hosted or
+                      managed service.
+
+                      For clarity, permitted uses include (but are not
+                      limited to): embedding the Licensed Work in your
+                      own applications (commercial or otherwise),
+                      internal use within your organization, consulting
+                      engagements that integrate the Licensed Work into
+                      client applications, redistributing modified or
+                      unmodified copies of the Licensed Work, and running
+                      the gateway locally on end-user machines as part
+                      of the user's own tooling.
+
+Change Date:          Four years from the date the Licensed Work is
+                      published. For each release of the Licensed Work,
+                      the Change Date is four years from the publication
+                      date of that release.
+
+Change License:       Apache License, Version 2.0
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed Work
+under this License, whichever comes first, the Licensor hereby grants you
+rights under the terms of the Change License, and the rights granted in the
+paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in
+this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, NON-INFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to
+all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License
+   can be included in a program with software provided under GPL Version 2.0
+   or a later version. Licensor may specify additional Change Licenses
+   without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License,
+   as the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an
+Open Source license. However, the Licensed Work will eventually be made
+available under an Open Source License, as stated in this License.

--- a/packages/docs-mcp/README.md
+++ b/packages/docs-mcp/README.md
@@ -1,0 +1,95 @@
+# @tesseron/docs-mcp
+
+[Tesseron](https://brainblend-ai.github.io/tesseron) documentation as an MCP server. Search and read the full protocol + SDK docs from any MCP-compatible AI client: Claude Code, Claude Desktop, Cursor, Windsurf, Zed, and anything else that speaks the [Model Context Protocol](https://modelcontextprotocol.io).
+
+No network, no vector store, no API keys. The docs snapshot is bundled in the npm package at publish time. Search runs locally with BM25 over in-memory text.
+
+## Why
+
+If you are writing a Tesseron app, your AI assistant should know Tesseron. This server exposes the canonical Tesseron docs as three MCP tools (`list_docs`, `search_docs`, `read_doc`) plus `tesseron-docs://<slug>` resources so the agent can retrieve exact spec text before answering instead of guessing from training data.
+
+## Install
+
+Nothing to install. Use `npx`.
+
+## Configure your AI client
+
+### Claude Code / Claude Desktop
+
+Add to `~/.claude.json` or `~/.config/Claude/claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "tesseron-docs": {
+      "command": "npx",
+      "args": ["-y", "@tesseron/docs-mcp"]
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to `~/.cursor/mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "tesseron-docs": {
+      "command": "npx",
+      "args": ["-y", "@tesseron/docs-mcp"]
+    }
+  }
+}
+```
+
+### Windsurf / Zed / any other MCP client
+
+Point the client at `npx -y @tesseron/docs-mcp`. stdio transport, Node ≥ 20.
+
+## Tools
+
+| Tool | Input | Returns |
+|---|---|---|
+| `list_docs` | `{}` | `{ count, docs: Array<{ slug, title, section, description, related }> }` |
+| `search_docs` | `{ query: string, limit?: number (1-20, default 8) }` | `{ query, count, hits: Array<{ slug, title, description, section, score, snippet }> }` |
+| `read_doc` | `{ slug: string }` | `{ slug, title, description, section, related, body }` (body is full markdown) |
+
+Slug format: `<section>/<basename>` without extension. Examples: `protocol/handshake`, `sdk/typescript/action-builder`, `examples/react-todo`.
+
+## Resources
+
+Each docs page is also exposed as an MCP resource at `tesseron-docs://<slug>`. Clients that prefer the resource surface over tools (Claude Desktop is one) get full listing via `list_resources` and full markdown bodies via `read_resource`.
+
+## Search behaviour
+
+- BM25 index via [minisearch](https://www.npmjs.com/package/minisearch).
+- Fields: `title` (weight 3), `description` (weight 2), `bodyText` (weight 1).
+- Fuzzy matching (`0.15`) and prefix matching are both on.
+- Snippets are ~240 chars centred on the best match, with ellipses added when truncated.
+
+## Dev / local use
+
+Point the server at a local snapshot or set the env var:
+
+```bash
+# Build fresh snapshot from the monorepo docs tree.
+pnpm --filter @tesseron/docs-mcp build:snapshot
+
+# Run from source with a custom snapshot file.
+pnpm --filter @tesseron/docs-mcp start -- --snapshot ./dist/docs-index.json
+
+# Or via env var.
+TESSERON_DOCS_SNAPSHOT=/abs/path/to/docs-index.json npx @tesseron/docs-mcp
+```
+
+The snapshot is rebuilt on every `pnpm build` (via `pnpm build:snapshot && tsup`) and on `prepublishOnly`.
+
+## Versioning
+
+`@tesseron/docs-mcp` versions track the docs snapshot, not the SDK. A new publish means the bundled docs were updated. It is unscoped from the `@tesseron/{core,web,server,react,mcp}` fixed-version bundle so SDK releases do not churn the docs package.
+
+## License
+
+BUSL-1.1. See [LICENSE](./LICENSE).

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@tesseron/docs-mcp",
+  "version": "0.1.0",
+  "description": "Tesseron documentation as an MCP server. Search and read the Tesseron protocol + SDK docs from any MCP-compatible AI client.",
+  "license": "BUSL-1.1",
+  "author": {
+    "name": "Kenny Vaneetvelde",
+    "email": "kenny.vaneetvelde@gmail.com",
+    "url": "https://brainblendai.com/"
+  },
+  "homepage": "https://github.com/BrainBlend-AI/tesseron#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrainBlend-AI/tesseron.git",
+    "directory": "packages/docs-mcp"
+  },
+  "bugs": {
+    "url": "https://github.com/BrainBlend-AI/tesseron/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "documentation",
+    "docs",
+    "search",
+    "claude",
+    "cursor",
+    "tesseron"
+  ],
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "bin": {
+    "tesseron-docs-mcp": "./src/cli.ts"
+  },
+  "files": ["dist", "README.md", "LICENSE"],
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "start": "tsx src/cli.ts",
+    "build:snapshot": "tsx scripts/build-snapshot.ts",
+    "build": "pnpm build:snapshot && tsup",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "gray-matter": "^4.0.3",
+    "minisearch": "^7.1.0",
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsup": "^8.3.0",
+    "tsx": "^4.19.0",
+    "vitest": "^2.1.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js",
+        "require": "./dist/index.cjs"
+      }
+    },
+    "bin": {
+      "tesseron-docs-mcp": "./dist/tesseron-docs-mcp.cjs"
+    }
+  }
+}

--- a/packages/docs-mcp/scripts/build-snapshot.ts
+++ b/packages/docs-mcp/scripts/build-snapshot.ts
@@ -1,0 +1,49 @@
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseDoc, walkDocs } from '../src/content/parse.js';
+import type { Snapshot } from '../src/content/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(here, '..');
+const repoRoot = resolve(packageRoot, '..', '..');
+const docsRoot = resolve(repoRoot, 'docs', 'src', 'content', 'docs');
+const outPath = resolve(packageRoot, 'dist', 'docs-index.json');
+
+function shortSha(): string {
+  try {
+    return execSync('git rev-parse --short HEAD', {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return 'dev';
+  }
+}
+
+function main(): void {
+  if (!existsSync(docsRoot)) {
+    throw new Error(`Docs root not found at ${docsRoot}. Snapshot build must run in the monorepo.`);
+  }
+
+  const files = walkDocs(docsRoot);
+  const docs = files.map((file) => parseDoc(file, docsRoot));
+  docs.sort((a, b) => a.slug.localeCompare(b.slug));
+
+  const snapshot: Snapshot = {
+    version: shortSha(),
+    generatedAt: new Date().toISOString(),
+    count: docs.length,
+    docs,
+  };
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(snapshot, null, 0), 'utf8');
+  process.stdout.write(
+    `[build-snapshot] wrote ${docs.length} docs (${(JSON.stringify(snapshot).length / 1024).toFixed(1)} KB) to ${outPath}\n`,
+  );
+}
+
+main();

--- a/packages/docs-mcp/src/cli.ts
+++ b/packages/docs-mcp/src/cli.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { createDocsMcpServer } from './server.js';
+import { loadSnapshot } from './snapshot.js';
+
+function parseSnapshotArg(argv: string[]): string | undefined {
+  const idx = argv.indexOf('--snapshot');
+  if (idx !== -1 && idx + 1 < argv.length) return argv[idx + 1];
+  const eqArg = argv.find((a) => a.startsWith('--snapshot='));
+  if (eqArg) return eqArg.slice('--snapshot='.length);
+  return undefined;
+}
+
+async function main(): Promise<void> {
+  const override = parseSnapshotArg(process.argv.slice(2));
+  const snapshot = loadSnapshot(override);
+  const server = createDocsMcpServer({ snapshot });
+  await server.connect(new StdioServerTransport());
+  process.stderr.write(
+    `[tesseron-docs] serving ${snapshot.count} pages (snapshot ${snapshot.version})\n`,
+  );
+}
+
+main().catch((err: unknown) => {
+  process.stderr.write(`[tesseron-docs] fatal: ${err instanceof Error ? err.stack : String(err)}\n`);
+  process.exit(1);
+});

--- a/packages/docs-mcp/src/content/parse.ts
+++ b/packages/docs-mcp/src/content/parse.ts
@@ -1,0 +1,98 @@
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import matter from 'gray-matter';
+import type { DocEntry } from './types.js';
+
+const DOC_EXTENSIONS = new Set(['.md', '.mdx']);
+
+/**
+ * Recursively collect absolute paths of every Markdown/MDX file under `root`.
+ * Order is stable (sorted at each directory level) so snapshots are deterministic.
+ */
+export function walkDocs(root: string): string[] {
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    const entries = readdirSync(dir).sort();
+    for (const name of entries) {
+      const full = join(dir, name);
+      const stat = statSync(full);
+      if (stat.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      const ext = name.slice(name.lastIndexOf('.'));
+      if (DOC_EXTENSIONS.has(ext)) out.push(full);
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/** Derive a stable slug from a doc file path relative to the docs root. */
+export function slugFromPath(absPath: string, docsRoot: string): string {
+  const rel = relative(docsRoot, absPath).split(sep).join('/');
+  const dot = rel.lastIndexOf('.');
+  return dot === -1 ? rel : rel.slice(0, dot);
+}
+
+/** Return the top-level folder of a slug, or `''` for root pages. */
+export function sectionFromSlug(slug: string): string {
+  const first = slug.indexOf('/');
+  return first === -1 ? '' : slug.slice(0, first);
+}
+
+/** Derive a human-friendly fallback title when frontmatter lacks one. */
+export function titleFromSlug(slug: string): string {
+  const last = slug.slice(slug.lastIndexOf('/') + 1);
+  return last.replace(/[-_]/g, ' ');
+}
+
+/**
+ * Strip MDX imports and JSX-style component blocks from a raw body so the
+ * remainder is suitable for text search. Regular Markdown (code fences, tables,
+ * headings, lists) is preserved verbatim.
+ */
+export function toSearchText(raw: string): string {
+  let out = raw;
+  out = out.replace(/^import\s+[\s\S]*?;?\s*$/gm, '');
+  out = out.replace(/<([A-Z][\w.]*)([^>]*)\/>/g, '');
+  out = out.replace(/<([A-Z][\w.]*)([^>]*?)>[\s\S]*?<\/\1>/g, '');
+  out = out.replace(/\n{3,}/g, '\n\n').trim();
+  return out;
+}
+
+type Frontmatter = {
+  title?: unknown;
+  description?: unknown;
+  related?: unknown;
+};
+
+function asString(v: unknown): string {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+function asStringList(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === 'string' && item.trim()) out.push(item.trim());
+  }
+  return out;
+}
+
+/** Parse a single doc file into a `DocEntry`. */
+export function parseDoc(absPath: string, docsRoot: string): DocEntry {
+  const raw = readFileSync(absPath, 'utf8');
+  const parsed = matter(raw);
+  const fm = parsed.data as Frontmatter;
+
+  const slug = slugFromPath(absPath, docsRoot);
+  const title = asString(fm.title) || titleFromSlug(slug);
+  const description = asString(fm.description);
+  const related = asStringList(fm.related);
+  const section = sectionFromSlug(slug);
+  const bodyRaw = parsed.content;
+  const bodyText = toSearchText(bodyRaw);
+
+  return { slug, title, description, section, related, bodyRaw, bodyText };
+}

--- a/packages/docs-mcp/src/content/types.ts
+++ b/packages/docs-mcp/src/content/types.ts
@@ -1,0 +1,26 @@
+export type DocEntry = {
+  /** Slug relative to `docs/src/content/docs/`, no extension. E.g. `protocol/handshake`. */
+  slug: string;
+  /** `title` field from frontmatter, or the filename stem as fallback. */
+  title: string;
+  /** `description` field from frontmatter; empty string if absent. */
+  description: string;
+  /** Top-level folder segment of the slug (`protocol`, `sdk`, `examples`, etc.). */
+  section: string;
+  /** Sibling-page slugs from the `related:` frontmatter list. */
+  related: string[];
+  /** Raw markdown/MDX body, exactly as authored. Returned by `read_doc`. */
+  bodyRaw: string;
+  /** Cleaned plain-text body used for full-text indexing. MDX imports and JSX removed. */
+  bodyText: string;
+};
+
+export type Snapshot = {
+  /** Short git SHA of the docs tree at build time, or `dev` when built locally. */
+  version: string;
+  /** ISO timestamp when the snapshot was generated. */
+  generatedAt: string;
+  /** Total number of docs pages in the snapshot. */
+  count: number;
+  docs: DocEntry[];
+};

--- a/packages/docs-mcp/src/index.ts
+++ b/packages/docs-mcp/src/index.ts
@@ -1,0 +1,5 @@
+export type { DocEntry, Snapshot } from './content/types.js';
+export type { SearchHit } from './search.js';
+export { DocsIndex } from './search.js';
+export { createDocsMcpServer } from './server.js';
+export { loadSnapshot, resolveSnapshotPath } from './snapshot.js';

--- a/packages/docs-mcp/src/search.ts
+++ b/packages/docs-mcp/src/search.ts
@@ -1,0 +1,88 @@
+import MiniSearch from 'minisearch';
+import type { DocEntry } from './content/types.js';
+
+export type SearchHit = {
+  slug: string;
+  title: string;
+  description: string;
+  section: string;
+  score: number;
+  snippet: string;
+};
+
+const SNIPPET_RADIUS = 120;
+const SNIPPET_MAX = SNIPPET_RADIUS * 2;
+
+export class DocsIndex {
+  private readonly mini: MiniSearch<DocEntry>;
+  private readonly bySlug: Map<string, DocEntry>;
+
+  constructor(docs: DocEntry[]) {
+    this.bySlug = new Map(docs.map((d) => [d.slug, d]));
+    this.mini = new MiniSearch<DocEntry>({
+      idField: 'slug',
+      fields: ['title', 'description', 'bodyText'],
+      storeFields: ['slug', 'title', 'description', 'section'],
+      searchOptions: {
+        boost: { title: 3, description: 2 },
+        fuzzy: 0.15,
+        prefix: true,
+      },
+    });
+    this.mini.addAll(docs);
+  }
+
+  search(query: string, limit = 8): SearchHit[] {
+    const raw = this.mini.search(query);
+    const out: SearchHit[] = [];
+    for (const r of raw.slice(0, Math.max(1, Math.min(limit, 20)))) {
+      const slug = String(r['slug']);
+      const entry = this.bySlug.get(slug);
+      if (!entry) continue;
+      out.push({
+        slug,
+        title: String(r['title']),
+        description: String(r['description'] ?? ''),
+        section: String(r['section'] ?? ''),
+        score: typeof r['score'] === 'number' ? r['score'] : 0,
+        snippet: makeSnippet(entry, query),
+      });
+    }
+    return out;
+  }
+}
+
+/**
+ * Extract a ~240-char snippet centred on the best match for `query` within
+ * `entry.bodyText`. Falls back to `description` when no body match is found.
+ */
+export function makeSnippet(entry: DocEntry, query: string): string {
+  const text = entry.bodyText;
+  if (!text) return entry.description;
+
+  const terms = query
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 1);
+  if (terms.length === 0) return truncate(text, SNIPPET_MAX);
+
+  const lower = text.toLowerCase();
+  let bestIdx = -1;
+  for (const t of terms) {
+    const idx = lower.indexOf(t);
+    if (idx !== -1 && (bestIdx === -1 || idx < bestIdx)) bestIdx = idx;
+  }
+  if (bestIdx === -1) return entry.description || truncate(text, SNIPPET_MAX);
+
+  const start = Math.max(0, bestIdx - SNIPPET_RADIUS);
+  const end = Math.min(text.length, bestIdx + SNIPPET_RADIUS);
+  let slice = text.slice(start, end).replace(/\s+/g, ' ').trim();
+  if (start > 0) slice = `…${slice}`;
+  if (end < text.length) slice = `${slice}…`;
+  return slice;
+}
+
+function truncate(s: string, n: number): string {
+  const single = s.replace(/\s+/g, ' ').trim();
+  return single.length <= n ? single : `${single.slice(0, n - 1)}…`;
+}

--- a/packages/docs-mcp/src/server.ts
+++ b/packages/docs-mcp/src/server.ts
@@ -1,0 +1,161 @@
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { DocEntry, Snapshot } from './content/types.js';
+import { DocsIndex } from './search.js';
+
+const RESOURCE_SCHEME = 'tesseron-docs';
+
+export type ServerOptions = {
+  /** Snapshot produced by `scripts/build-snapshot.ts`. */
+  snapshot: Snapshot;
+  /** Optional override of the reported server name (for test isolation). */
+  name?: string;
+  /** Optional override of the reported server version. */
+  version?: string;
+};
+
+/**
+ * Build an `McpServer` wired up with `list_docs`, `search_docs`, `read_doc`
+ * tools and `tesseron-docs://<slug>` resources.
+ */
+export function createDocsMcpServer(options: ServerOptions): McpServer {
+  const { snapshot } = options;
+  const bySlug = new Map<string, DocEntry>(snapshot.docs.map((d) => [d.slug, d]));
+  const index = new DocsIndex(snapshot.docs);
+
+  const server = new McpServer({
+    name: options.name ?? 'tesseron-docs',
+    version: options.version ?? snapshot.version,
+  });
+
+  server.registerTool(
+    'list_docs',
+    {
+      description:
+        'List every Tesseron documentation page with title, slug, section, short description, and related slugs. Cheap, call before searching when you want the full catalogue.',
+      inputSchema: {},
+    },
+    () => {
+      const docs = snapshot.docs.map((d) => ({
+        slug: d.slug,
+        title: d.title,
+        section: d.section,
+        description: d.description,
+        related: d.related,
+      }));
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ count: docs.length, docs }, null, 2) }],
+      };
+    },
+  );
+
+  server.registerTool(
+    'search_docs',
+    {
+      description:
+        'Full-text search across Tesseron docs (BM25, title- and description-weighted). Returns ranked hits with short snippets. Call `read_doc(slug)` on promising hits for full content.',
+      inputSchema: {
+        query: z
+          .string()
+          .min(1)
+          .describe('Free-form query. Supports multiple terms; fuzzy + prefix matching are on.'),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(20)
+          .optional()
+          .describe('Maximum hits to return. Default 8, hard cap 20.'),
+      },
+    },
+    ({ query, limit }) => {
+      const hits = index.search(query, limit ?? 8);
+      return {
+        content: [
+          {
+            type: 'text',
+            text: JSON.stringify({ query, count: hits.length, hits }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
+    'read_doc',
+    {
+      description:
+        'Return the full markdown body of a Tesseron docs page plus its structured frontmatter (title, description, section, related). Slug format: `<section>/<basename>` without extension (e.g. `protocol/handshake`).',
+      inputSchema: {
+        slug: z
+          .string()
+          .min(1)
+          .describe('Page slug. Use `list_docs` or `search_docs` to discover valid slugs.'),
+      },
+    },
+    ({ slug }) => {
+      const entry = bySlug.get(slug);
+      if (!entry) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: `No doc found for slug "${slug}". Call list_docs to see valid slugs.`,
+            },
+          ],
+        };
+      }
+      const payload = {
+        slug: entry.slug,
+        title: entry.title,
+        description: entry.description,
+        section: entry.section,
+        related: entry.related,
+        body: entry.bodyRaw,
+      };
+      return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+    },
+  );
+
+  server.registerResource(
+    'tesseron-doc',
+    new ResourceTemplate(`${RESOURCE_SCHEME}://{+slug}`, {
+      list: () => ({
+        resources: snapshot.docs.map((d) => ({
+          uri: `${RESOURCE_SCHEME}://${d.slug}`,
+          name: d.title,
+          description: d.description,
+          mimeType: 'text/markdown',
+        })),
+      }),
+    }),
+    {
+      title: 'Tesseron documentation page',
+      description: 'Full markdown body of a single Tesseron docs page, keyed by slug.',
+    },
+    (uri, variables) => {
+      const slug = Array.isArray(variables['slug'])
+        ? variables['slug'][0]
+        : (variables['slug'] as string | undefined);
+      if (!slug) {
+        throw new Error(`Missing slug in resource URI ${uri.href}`);
+      }
+      const entry = bySlug.get(slug);
+      if (!entry) {
+        throw new Error(`No doc found for slug "${slug}".`);
+      }
+      return {
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'text/markdown',
+            text: entry.bodyRaw,
+          },
+        ],
+      };
+    },
+  );
+
+  return server;
+}

--- a/packages/docs-mcp/src/snapshot.ts
+++ b/packages/docs-mcp/src/snapshot.ts
@@ -1,0 +1,56 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { DocEntry, Snapshot } from './content/types.js';
+
+const SNAPSHOT_FILENAME = 'docs-index.json';
+const ENV_SNAPSHOT_PATH = 'TESSERON_DOCS_SNAPSHOT';
+
+function thisModuleDir(): string {
+  if (typeof __dirname !== 'undefined') return __dirname;
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+/**
+ * Locate the bundled snapshot JSON. Lookup order:
+ *   1. `TESSERON_DOCS_SNAPSHOT` environment variable, if set.
+ *   2. Explicit `override` argument.
+ *   3. Alongside the compiled bin (production / `npx` use).
+ *   4. `../dist/docs-index.json` (when running via `tsx src/cli.ts` in dev).
+ */
+export function resolveSnapshotPath(override?: string): string {
+  const envPath = process.env[ENV_SNAPSHOT_PATH];
+  if (envPath) return envPath;
+  if (override) return override;
+
+  const here = thisModuleDir();
+  const bundled = resolve(here, SNAPSHOT_FILENAME);
+  if (existsSync(bundled)) return bundled;
+
+  const devFallback = resolve(here, '..', 'dist', SNAPSHOT_FILENAME);
+  return devFallback;
+}
+
+export function loadSnapshot(override?: string): Snapshot {
+  const path = resolveSnapshotPath(override);
+  if (!existsSync(path)) {
+    throw new Error(
+      `[tesseron-docs-mcp] snapshot not found at ${path}. ` +
+        'Run "pnpm --filter @tesseron/docs-mcp build" to generate it, ' +
+        `or set ${ENV_SNAPSHOT_PATH}=/abs/path/to/docs-index.json.`,
+    );
+  }
+  const raw = readFileSync(path, 'utf8');
+  const parsed = JSON.parse(raw) as Snapshot;
+  if (!Array.isArray(parsed.docs)) {
+    throw new Error(`[tesseron-docs-mcp] invalid snapshot at ${path}: missing "docs" array.`);
+  }
+  return parsed;
+}
+
+/** Index docs by slug for O(1) lookup in `read_doc`. */
+export function indexBySlug(docs: DocEntry[]): Map<string, DocEntry> {
+  const map = new Map<string, DocEntry>();
+  for (const d of docs) map.set(d.slug, d);
+  return map;
+}

--- a/packages/docs-mcp/test/parse.test.ts
+++ b/packages/docs-mcp/test/parse.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  parseDoc,
+  sectionFromSlug,
+  slugFromPath,
+  titleFromSlug,
+  toSearchText,
+  walkDocs,
+} from '../src/content/parse';
+
+function makeTmpDoc(body: string, name = 'page.mdx'): { root: string; file: string } {
+  const root = mkdtempSync(join(tmpdir(), 'docs-mcp-'));
+  const file = join(root, name);
+  writeFileSync(file, body, 'utf8');
+  return { root, file };
+}
+
+describe('slugFromPath', () => {
+  it('strips extension and normalizes separators', () => {
+    const root = '/docs';
+    expect(slugFromPath('/docs/protocol/handshake.mdx', root)).toBe('protocol/handshake');
+    expect(slugFromPath('/docs/index.mdx', root)).toBe('index');
+  });
+});
+
+describe('sectionFromSlug', () => {
+  it('returns the first path segment or empty for root', () => {
+    expect(sectionFromSlug('protocol/handshake')).toBe('protocol');
+    expect(sectionFromSlug('sdk/typescript/core')).toBe('sdk');
+    expect(sectionFromSlug('index')).toBe('');
+  });
+});
+
+describe('titleFromSlug', () => {
+  it('humanises the last segment', () => {
+    expect(titleFromSlug('protocol/handshake-and-claiming')).toBe('handshake and claiming');
+    expect(titleFromSlug('index')).toBe('index');
+  });
+});
+
+describe('toSearchText', () => {
+  it('strips MDX imports', () => {
+    const out = toSearchText(
+      `import Foo from './Foo.astro';\nimport { Bar } from './Bar';\n\nReal content here.`,
+    );
+    expect(out).toBe('Real content here.');
+  });
+
+  it('strips self-closing and paired JSX components', () => {
+    const out = toSearchText(
+      `<Diagram foo="bar" />\n\nParagraph.\n\n<Card>\ninner\n</Card>\n\nTrailing.`,
+    );
+    expect(out).toContain('Paragraph.');
+    expect(out).toContain('Trailing.');
+    expect(out).not.toContain('Diagram');
+    expect(out).not.toContain('inner');
+  });
+
+  it('keeps code fences and markdown', () => {
+    const out = toSearchText('```ts\nconst x = 1;\n```\n\nProse.');
+    expect(out).toContain('const x = 1');
+    expect(out).toContain('Prose.');
+  });
+});
+
+describe('parseDoc', () => {
+  it('parses title, description, related list, and strips frontmatter from body', () => {
+    const { root, file } = makeTmpDoc(
+      `---\ntitle: Session resume\ndescription: Short description.\nrelated:\n  - protocol/handshake\n  - protocol/transport\n---\n\nBody text.`,
+      'resume.mdx',
+    );
+    const entry = parseDoc(file, root);
+    expect(entry.slug).toBe('resume');
+    expect(entry.title).toBe('Session resume');
+    expect(entry.description).toBe('Short description.');
+    expect(entry.related).toEqual(['protocol/handshake', 'protocol/transport']);
+    expect(entry.bodyRaw).toContain('Body text.');
+    expect(entry.bodyText).toBe('Body text.');
+  });
+
+  it('falls back to the filename stem when title is missing', () => {
+    const { root, file } = makeTmpDoc(
+      `---\ndescription: Only description.\n---\n\nBody.`,
+      'plain.md',
+    );
+    const entry = parseDoc(file, root);
+    expect(entry.title).toBe('plain');
+  });
+
+  it('returns an empty related array when the field is absent', () => {
+    const { root, file } = makeTmpDoc(`---\ntitle: T\n---\nBody.`, 'x.md');
+    expect(parseDoc(file, root).related).toEqual([]);
+  });
+});
+
+describe('walkDocs', () => {
+  it('finds only .md/.mdx files recursively, in sorted order', () => {
+    const root = mkdtempSync(join(tmpdir(), 'docs-mcp-walk-'));
+    writeFileSync(join(root, 'z.md'), '---\ntitle: z\n---\n');
+    writeFileSync(join(root, 'a.mdx'), '---\ntitle: a\n---\n');
+    writeFileSync(join(root, 'ignore.txt'), 'nope');
+    const files = walkDocs(root).map((f) => f.replace(root, ''));
+    expect(files).toHaveLength(2);
+    expect(files[0]).toMatch(/a\.mdx$/);
+    expect(files[1]).toMatch(/z\.md$/);
+  });
+});

--- a/packages/docs-mcp/test/search.test.ts
+++ b/packages/docs-mcp/test/search.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import type { DocEntry } from '../src/content/types';
+import { DocsIndex, makeSnippet } from '../src/search';
+
+function docEntry(partial: Partial<DocEntry> & { slug: string }): DocEntry {
+  return {
+    slug: partial.slug,
+    title: partial.title ?? partial.slug,
+    description: partial.description ?? '',
+    section: partial.section ?? partial.slug.split('/')[0] ?? '',
+    related: partial.related ?? [],
+    bodyRaw: partial.bodyRaw ?? '',
+    bodyText: partial.bodyText ?? '',
+  };
+}
+
+describe('DocsIndex', () => {
+  const docs: DocEntry[] = [
+    docEntry({
+      slug: 'protocol/handshake',
+      title: 'Handshake and claiming',
+      description: 'How a WebSocket becomes a bound session.',
+      bodyText: 'The handshake begins with tesseron/hello and ends with welcome.',
+    }),
+    docEntry({
+      slug: 'protocol/resume',
+      title: 'Session resume',
+      description: 'How a Tesseron app rejoins a previously-claimed session.',
+      bodyText: 'Resume requires a resumeToken issued during the original handshake.',
+    }),
+    docEntry({
+      slug: 'sdk/typescript/core',
+      title: '@tesseron/core',
+      description: 'The protocol types, builder, JSON-RPC dispatcher.',
+      bodyText: 'Exports ActionContext, Transport, and the JSON-RPC dispatcher.',
+    }),
+  ];
+
+  const index = new DocsIndex(docs);
+
+  it('ranks title matches highest', () => {
+    const hits = index.search('handshake');
+    expect(hits[0]?.slug).toBe('protocol/handshake');
+  });
+
+  it('finds body-only matches', () => {
+    const hits = index.search('resumeToken');
+    expect(hits.map((h) => h.slug)).toContain('protocol/resume');
+  });
+
+  it('returns snippets with ellipses when the body is longer than the window', () => {
+    const hits = index.search('tesseron/hello');
+    expect(hits[0]?.snippet).toContain('tesseron/hello');
+  });
+
+  it('respects the limit cap', () => {
+    const hits = index.search('the', 1);
+    expect(hits.length).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('makeSnippet', () => {
+  const entry = {
+    slug: 'x',
+    title: 't',
+    description: 'a fallback description',
+    section: '',
+    related: [],
+    bodyRaw: '',
+    bodyText:
+      'The quick brown fox jumps over the lazy dog. Then a handshake sequence occurs between the client and server, followed by a welcome frame and eventually a claim code.',
+  } satisfies DocEntry;
+
+  it('centres on the best match and truncates', () => {
+    const s = makeSnippet(entry, 'handshake');
+    expect(s).toContain('handshake');
+    expect(s.length).toBeLessThanOrEqual(260);
+  });
+
+  it('falls back to description when no body match exists', () => {
+    const s = makeSnippet(entry, 'nonexistentterm');
+    expect(s).toBe('a fallback description');
+  });
+});

--- a/packages/docs-mcp/test/server.test.ts
+++ b/packages/docs-mcp/test/server.test.ts
@@ -1,0 +1,102 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { beforeAll, describe, expect, it } from 'vitest';
+import type { DocEntry, Snapshot } from '../src/content/types';
+import { createDocsMcpServer } from '../src/server';
+
+const docs: DocEntry[] = [
+  {
+    slug: 'protocol/handshake',
+    title: 'Handshake and claiming',
+    description: 'How a WebSocket becomes a bound session.',
+    section: 'protocol',
+    related: ['protocol/wire-format', 'protocol/transport'],
+    bodyRaw: '# Handshake\n\nFull body of the handshake page.',
+    bodyText: 'Full body of the handshake page.',
+  },
+  {
+    slug: 'protocol/resume',
+    title: 'Session resume',
+    description: 'How a Tesseron app rejoins a previously-claimed session.',
+    section: 'protocol',
+    related: ['protocol/handshake'],
+    bodyRaw: '# Session resume\n\nResume uses a resumeToken.',
+    bodyText: 'Resume uses a resumeToken.',
+  },
+];
+
+const snapshot: Snapshot = {
+  version: 'test',
+  generatedAt: new Date().toISOString(),
+  count: docs.length,
+  docs,
+};
+
+describe('tesseron-docs MCP server (in-memory)', () => {
+  let client: Client;
+
+  beforeAll(async () => {
+    const server = createDocsMcpServer({ snapshot });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    client = new Client({ name: 'test', version: '0.0.0' });
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  });
+
+  it('list_docs returns every entry', async () => {
+    const res = await client.callTool({ name: 'list_docs', arguments: {} });
+    const text = (res.content as Array<{ type: string; text: string }>)[0]?.text ?? '';
+    const parsed = JSON.parse(text) as { count: number; docs: Array<{ slug: string }> };
+    expect(parsed.count).toBe(2);
+    expect(parsed.docs.map((d) => d.slug).sort()).toEqual([
+      'protocol/handshake',
+      'protocol/resume',
+    ]);
+  });
+
+  it('search_docs finds the right page for a title match', async () => {
+    const res = await client.callTool({
+      name: 'search_docs',
+      arguments: { query: 'session resume' },
+    });
+    const text = (res.content as Array<{ type: string; text: string }>)[0]?.text ?? '';
+    const parsed = JSON.parse(text) as { hits: Array<{ slug: string }> };
+    expect(parsed.hits[0]?.slug).toBe('protocol/resume');
+  });
+
+  it('read_doc returns the full body plus frontmatter fields', async () => {
+    const res = await client.callTool({
+      name: 'read_doc',
+      arguments: { slug: 'protocol/handshake' },
+    });
+    const text = (res.content as Array<{ type: string; text: string }>)[0]?.text ?? '';
+    const parsed = JSON.parse(text) as {
+      slug: string;
+      title: string;
+      related: string[];
+      body: string;
+    };
+    expect(parsed.slug).toBe('protocol/handshake');
+    expect(parsed.title).toBe('Handshake and claiming');
+    expect(parsed.related).toContain('protocol/wire-format');
+    expect(parsed.body).toContain('Full body of the handshake page.');
+  });
+
+  it('read_doc returns an isError result for unknown slugs', async () => {
+    const res = await client.callTool({
+      name: 'read_doc',
+      arguments: { slug: 'nope/missing' },
+    });
+    expect(res.isError).toBe(true);
+  });
+
+  it('lists resources and reads one by URI', async () => {
+    const list = await client.listResources();
+    const uris = list.resources.map((r) => r.uri);
+    expect(uris).toContain('tesseron-docs://protocol/handshake');
+
+    const read = await client.readResource({ uri: 'tesseron-docs://protocol/handshake' });
+    const first = read.contents[0];
+    expect(first).toBeDefined();
+    expect('text' in first! && first.text).toContain('Full body of the handshake page.');
+  });
+});

--- a/packages/docs-mcp/tsconfig.json
+++ b/packages/docs-mcp/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "include": ["src", "scripts", "test"]
+}

--- a/packages/docs-mcp/tsup.config.ts
+++ b/packages/docs-mcp/tsup.config.ts
@@ -1,0 +1,41 @@
+import { copyFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { defineConfig } from 'tsup';
+
+const SNAPSHOT_SRC = resolve(__dirname, 'dist/docs-index.json');
+
+export default defineConfig([
+  {
+    entry: { 'tesseron-docs-mcp': 'src/cli.ts' },
+    outDir: 'dist',
+    format: ['cjs'],
+    target: 'node20',
+    platform: 'node',
+    bundle: true,
+    noExternal: [/.*/],
+    clean: false,
+    splitting: false,
+    sourcemap: false,
+    minify: false,
+    async onSuccess() {
+      if (!existsSync(SNAPSHOT_SRC)) {
+        throw new Error(
+          `docs-index.json missing at ${SNAPSHOT_SRC}; run "pnpm build:snapshot" before tsup.`,
+        );
+      }
+      copyFileSync(SNAPSHOT_SRC, resolve(__dirname, 'dist/docs-index.json'));
+    },
+  },
+  {
+    entry: { index: 'src/index.ts' },
+    outDir: 'dist',
+    format: ['esm', 'cjs'],
+    target: 'node20',
+    platform: 'node',
+    dts: true,
+    sourcemap: true,
+    splitting: false,
+    treeshake: true,
+    clean: false,
+  },
+]);

--- a/packages/docs-mcp/vitest.config.ts
+++ b/packages/docs-mcp/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 15_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -224,6 +224,34 @@ importers:
         specifier: workspace:*
         version: link:../core
 
+  packages/docs-mcp:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.0.0
+        version: 1.29.0(zod@3.25.76)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      minisearch:
+        specifier: ^7.1.0
+        version: 7.2.0
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/mcp:
     dependencies:
       '@modelcontextprotocol/sdk':
@@ -2792,6 +2820,10 @@ packages:
   expressive-code@0.41.7:
     resolution: {integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==}
 
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
@@ -2918,6 +2950,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
 
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
@@ -3084,6 +3120,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -3182,6 +3222,10 @@ packages:
 
   khroma@2.1.0:
     resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -3490,6 +3534,9 @@ packages:
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -3969,6 +4016,10 @@ packages:
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -4106,6 +4157,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -5781,6 +5836,28 @@ snapshots:
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.2
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.14)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.7
+      express: 5.2.1
+      express-rate-limit: 8.3.2(express@5.2.1)
+      hono: 4.12.14
+      jose: 6.2.2
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
     dependencies:
@@ -7470,6 +7547,10 @@ snapshots:
       '@expressive-code/plugin-shiki': 0.41.7
       '@expressive-code/plugin-text-markers': 0.41.7
 
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
   extend@3.0.2: {}
 
   extendable-error@0.1.7: {}
@@ -7611,6 +7692,13 @@ snapshots:
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.14.2
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
   h3@1.15.11:
     dependencies:
@@ -7890,6 +7978,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-extendable@0.1.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -7962,6 +8052,8 @@ snapshots:
       commander: 8.3.0
 
   khroma@2.1.0: {}
+
+  kind-of@6.0.3: {}
 
   kleur@3.0.3: {}
 
@@ -8550,6 +8642,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.1.0
 
+  minisearch@7.2.0: {}
+
   mlly@1.8.2:
     dependencies:
       acorn: 8.16.0
@@ -9090,6 +9184,11 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
   semver@6.3.1: {}
 
   semver@7.7.4: {}
@@ -9317,6 +9416,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-bom-string@1.0.0: {}
 
   strip-bom@3.0.0: {}
 


### PR DESCRIPTION
## Summary

New workspace package `@tesseron/docs-mcp`: a stdio MCP server that exposes the Tesseron documentation so any MCP-compatible AI client (Claude Code, Claude Desktop, Cursor, Windsurf, Zed) can search and read the protocol + SDK docs without leaving the editor.

No network, no vector store, no embedding model, no API keys. Docs snapshot bundled in the npm package at publish time. Search runs locally via `minisearch` BM25.

## Tool surface

| Tool | Input | Returns |
|---|---|---|
| `list_docs` | `{}` | Full TOC: slugs, titles, sections, descriptions, related edges |
| `search_docs` | `{ query, limit? (1-20, default 8) }` | Ranked hits with `slug`, `title`, `description`, `section`, `score`, `snippet` (~240 chars centred on match) |
| `read_doc` | `{ slug }` | `slug`, `title`, `description`, `section`, `related`, full markdown `body` |

Plus MCP resources at `tesseron-docs://<slug>` for clients that prefer the resource surface.

## Build pipeline

- `scripts/build-snapshot.ts` walks `docs/src/content/docs/**` via `gray-matter`, strips MDX imports + JSX component blocks from the body for search, and writes `dist/docs-index.json`.
- `tsup` bundles `src/cli.ts` into a single CJS bin and `src/index.ts` as a dual ESM/CJS library with types.
- `prepublishOnly` rebuilds the snapshot so the published tarball always carries the current docs.

## Design choices

- **Three tools, not one**. Matches the idiomatic surface from AWS docs MCP and android-skills-mcp; `search` returns cheap snippets, `read` returns the full page.
- **No `recommend` tool**. The `related:` frontmatter added in #13 flows through `read_doc`, so clients get the edges without an extra round trip.
- **Bundled snapshot, not runtime fetch**. Matches android-skills-mcp's pattern (parsed snapshot in `dist/`). Offline, zero-network, fast startup.
- **BM25 only, no vectors**. Same reasoning the project landed on for the UserPromptSubmit hook: curated prose + exact-match retrieval beats semantic for this shape of corpus.
- **Unscoped from the SDK fixed-version bundle**. `@tesseron/docs-mcp` versions track the docs, not the SDK. SDK releases do not churn the docs package.

## Verification

- `pnpm --filter @tesseron/docs-mcp typecheck` -> clean.
- `pnpm --filter @tesseron/docs-mcp test` -> 21/21 passing (parser, search ranking + snippet extraction, in-memory MCP server round-trip).
- `pnpm --filter @tesseron/docs-mcp build` -> 290 KB snapshot with all 37 docs + 812 KB bundled CJS bin + dual-format library.
- End-to-end smoke test: spawned `dist/tesseron-docs-mcp.cjs`, ran `initialize`, `tools/list`, `tools/call` for `search_docs({query: 'session resume'})`. Returned `protocol/resume` as the top hit.

## Distribution

```json
{
  "mcpServers": {
    "tesseron-docs": {
      "command": "npx",
      "args": ["-y", "@tesseron/docs-mcp"]
    }
  }
}
```

## Test plan

- [x] Snapshot builds with 37 pages from the current docs tree
- [x] Unit tests for parser, search, snippet extraction
- [x] Integration test spawning server via `InMemoryTransport`
- [x] End-to-end smoke test via stdio with real bundled bin
- [x] Typecheck clean under strict + `noUncheckedIndexedAccess` + `verbatimModuleSyntax`

## What this unblocks

PR C can now add a `tesseron-docs` Claude Code skill that references these tools. PR B (llms.txt pipeline in the docs site) is independent and already in flight.
