### PR TITLE
chore: align @tesseron/docs-mcp with SDK version bundle

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,14 @@
   "changelog": ["@changesets/changelog-github", { "repo": "BrainBlend-AI/tesseron" }],
   "commit": false,
   "fixed": [
-    ["@tesseron/core", "@tesseron/web", "@tesseron/server", "@tesseron/react", "@tesseron/mcp"]
+    [
+      "@tesseron/core",
+      "@tesseron/web",
+      "@tesseron/server",
+      "@tesseron/react",
+      "@tesseron/mcp",
+      "@tesseron/docs-mcp"
+    ]
   ],
   "linked": [],
   "access": "public",

--- a/packages/docs-mcp/package.json
+++ b/packages/docs-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tesseron/docs-mcp",
-  "version": "0.2.0",
+  "version": "1.1.0",
   "description": "Tesseron documentation as an MCP server. Search and read the Tesseron protocol + SDK docs from any MCP-compatible AI client.",
   "license": "BUSL-1.1",
   "author": {


### PR DESCRIPTION
## Summary

Bring `@tesseron/docs-mcp` under the same version as the rest of the SDK packages so the `@tesseron/*` family moves together.

- Manually bumps `packages/docs-mcp/package.json` from `0.2.0` to `1.1.0` to match the current `@tesseron/{core, web, server, react, mcp}` baseline.
- Adds `@tesseron/docs-mcp` to the `fixed` bundle in `.changeset/config.json`.

No `.changeset/` file is added; this PR should not publish anything by itself. The alignment takes effect on the next real change to any fixed-bundle package, at which point all six versions bump together.

## Why

`@tesseron/docs-mcp@0.2.0` sitting next to `@tesseron/core@1.1.0` on npm looked inconsistent and made the docs-MCP package seem less mature than it is. Keeping the whole `@tesseron/*` family on one version number gives users a single Tesseron version to reason about (release notes, compatibility, pinning) and removes the "is this package on 0.x for a reason?" question.

## Tradeoff accepted

Docs-only changes (typo fix in a protocol page, new `related:` edge) will now force a synthetic version bump across all SDK packages, even when their behavior is identical. That is acceptable at this stage because:

- SDK and docs churn at roughly the same cadence early on; most docs changes ride along with real SDK changes anyway.
- End users install docs-mcp via `npx -y @tesseron/docs-mcp` which always resolves to `@latest`, so the version number is never observed in practice.
- Easy to split back to independent versioning later by dropping it from the `fixed` array.

## Verification

- `pnpm install` regenerates the lockfile cleanly.
- No `.changeset/` file added, so the next `pnpm version-packages` cycle does not see this as a pending release. Alignment is a working-tree change only.

## What this does NOT do

- Does not publish a new `@tesseron/docs-mcp@1.1.0` to npm on merge. Publishing still requires an accompanying changeset on a future PR.
- Does not touch `@tesseron/devtools`, `@tesseron/docs` (private), or `create-tesseron`. Those keep their independent lifecycles.

## Test plan

- [x] `pnpm install` succeeds
- [x] `fixed` array contains all six packages
- [x] `packages/docs-mcp/package.json` version matches the other SDK packages
