### PR TITLE
chore(marketplace): sync marketplace.json to plugin 1.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,15 +7,15 @@
     "url": "https://github.com/BrainBlend-AI"
   },
   "metadata": {
-    "description": "Tesseron marketplace — ships the Tesseron Claude Code plugin: MCP gateway plus the framework skill, `tesseron-dev` wiring skill, and explorer/reviewer subagents for building and auditing web apps that speak the Tesseron protocol.",
-    "version": "1.0.2"
+    "description": "Tesseron marketplace — ships the Tesseron Claude Code plugin: MCP gateway plus the `framework` mental-model skill, the `tesseron-docs` authoritative-lookup skill (backed by the bundled `@tesseron/docs-mcp` server), the `tesseron-dev` wiring skill, and explorer/reviewer subagents for building and auditing web apps that speak the Tesseron protocol.",
+    "version": "1.1.0"
   },
   "plugins": [
     {
       "name": "tesseron",
       "source": "./plugin",
-      "version": "1.0.2",
-      "description": "Tesseron for Claude Code: MCP gateway for typed web-app actions over WebSocket, plus a framework skill (progressive-disclosure references for actions, resources, context, transports, react, protocol, schemas, errors, gateway, testing, project-structure), an `tesseron-dev` skill that integrates Tesseron into any JS/TS project by picking the right consumer package (`@tesseron/react`, `/server`, or `/web`) and inserting the canonical API, and isolated-context explorer/reviewer subagents.",
+      "version": "1.1.0",
+      "description": "Tesseron for Claude Code: MCP gateway for typed web-app actions over WebSocket, plus a `framework` skill for the Tesseron mental model, a `tesseron-docs` skill that calls the bundled `@tesseron/docs-mcp` server for authoritative chapter-and-verse spec lookups (`search_docs`, `read_doc`, `list_docs`), a `tesseron-dev` skill that integrates Tesseron into any JS/TS project by picking the right consumer package (`@tesseron/react`, `/server`, or `/web`) and inserting the canonical API, and isolated-context explorer/reviewer subagents.",
       "category": "integration",
       "tags": [
         "mcp",
@@ -28,7 +28,8 @@
         "typescript",
         "zod",
         "skill",
-        "subagent"
+        "subagent",
+        "documentation"
       ],
       "homepage": "https://github.com/BrainBlend-AI/tesseron"
     }


### PR DESCRIPTION
## Summary

PR #18 bumped `plugin/.claude-plugin/plugin.json` to 1.1.0 but left the outer `.claude-plugin/marketplace.json` at 1.0.2 with the old description. That is the file Claude Code's `/plugin` Discover tab reads, so users running `/plugin update` stayed on 1.0.2 and never saw the new `tesseron-docs` skill advertised.

## Changes

- `metadata.version` and `plugins[0].version` bumped to `1.1.0`.
- Both descriptions updated to mention the `tesseron-docs` skill and the `@tesseron/docs-mcp` server it wraps.
- Added `documentation` to `plugins[0].tags` so the plugin surfaces for users searching the marketplace for docs integrations.

## Why this is a separate PR

Marketplace manifest and plugin manifest are two different files at two different paths; I missed the outer one on #18. Keeping this fix narrow rather than folding into something else so it is easy to revert if the marketplace schema has a convention I am missing.

## Test plan

- [ ] After merge: `/plugin update tesseron` pulls version 1.1.0
- [ ] `/plugin` Discover tab shows the updated description mentioning `tesseron-docs`
- [ ] Installing fresh surfaces `tesseron-docs` alongside `framework` / `tesseron-dev`
