### PR TITLE
docs: restore horizontal layout on architecture + landing diagrams

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,17 +33,21 @@ import Diagram from '../../components/Diagram.astro';
 <Diagram
   caption="Your web app declares actions. The MCP gateway bridges them to any MCP-capable agent (Claude Code, Cursor, Claude Desktop)."
   nodeWidth={130}
-  spacing={115}
+  spacing={140}
   pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
-    { id: 'app',   label: 'YOUR APP', sub: '/@tesseron/ws', code: '@tesseron/web', icon: 'window' },
-    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', code: '@tesseron/mcp', icon: 'bridge', variant: 'accent' },
+    { id: 'app',   label: 'YOUR APP', sub: 'browser or Node', icon: 'window' },
+    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', icon: 'bridge', variant: 'accent' },
     { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
   ]}
   edges={[
     { from: 'user', to: 'app' },
-    { from: 'gw',   to: 'app',   label: 'WebSocket', bidirectional: true, accent: true },
+    // Arrow direction controls ELK's layer assignment — `app → gw → agent`
+    // forms a linear chain so the four cards sit in one horizontal row.
+    // The bidirectional flag keeps the visual meaning (both protocols flow
+    // both ways) regardless of source/target.
+    { from: 'app',  to: 'gw',    label: 'WebSocket', bidirectional: true, accent: true },
     { from: 'gw',   to: 'agent', label: 'MCP stdio', bidirectional: true, accent: true },
   ]}
 />

--- a/docs/src/content/docs/overview/architecture.mdx
+++ b/docs/src/content/docs/overview/architecture.mdx
@@ -12,15 +12,23 @@ import Diagram from '../../../components/Diagram.astro';
 
 <Diagram
   caption="Three processes, two protocols. Your app hosts a WebSocket endpoint and announces itself; the gateway dials in and speaks MCP stdio to the agent."
+  nodeWidth={130}
+  spacing={140}
+  pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
-    { id: 'app',   label: 'YOUR APP', sub: 'WS server + tab file', code: '@tesseron/vite | /server', icon: 'window' },
-    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', code: '@tesseron/mcp', icon: 'bridge', variant: 'accent' },
+    { id: 'app',   label: 'YOUR APP', sub: ['WS server +', 'tab file'], icon: 'window' },
+    { id: 'gw',    label: 'MCP GATEWAY', sub: ['WS client', '+ MCP'], icon: 'bridge', variant: 'accent' },
     { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
   ]}
   edges={[
     { from: 'user', to: 'app' },
-    { from: 'gw',   to: 'app',   label: 'WebSocket', bidirectional: true, accent: true },
+    // Arrow direction controls ELK's layer assignment — `app → gw → agent`
+    // forms a linear chain so the four cards sit in one horizontal row.
+    // The bidirectional flag keeps the visual meaning (both protocols flow
+    // both ways) regardless of source/target. In reality the gateway is
+    // the WS client dialling into the app; only the layout is reversed.
+    { from: 'app',  to: 'gw',    label: 'WebSocket', bidirectional: true, accent: true },
     { from: 'gw',   to: 'agent', label: 'MCP stdio', bidirectional: true, accent: true },
   ]}
 />


### PR DESCRIPTION
The reverse-connection migration in #21 flipped one edge direction and
accidentally made the architecture + landing diagrams render as a 2×2
grid instead of the intended horizontal flow.

## Root cause

Previous edges had `gw → app` (gateway points at the app). In ELK's
layered layout `gw` becomes a source of two edges, so it joined `user`
in layer 0. Result: `{user, gw}` on top, `{app, agent}` on bottom.

## Fix

Flip the WebSocket edge back to `app → gw`. Now the edges form a linear
chain (`user → app → gw → agent`) and ELK produces four layers in one
horizontal row. `bidirectional: true` keeps the arrow visually drawn
both ways — the source/target is purely a layout hint.

Also:

- **Spacing bumped to 140.** The previous value left no room between
  the "WebSocket" pill (~72px) and the bidirectional arrowheads
  (10px each side); only the arrow tips were visible with no
  connecting line.
- **Dropped `code:` labels** from the "YOUR APP" and "MCP GATEWAY"
  cards (`@tesseron/web`, `@tesseron/mcp`, `@tesseron/vite | /server`).
  Package names don't belong in an architecture diagram.

Previews:

- http://localhost:4321/
- http://localhost:4321/overview/architecture/

## Test plan

- [x] `pnpm docs:dev` — both diagrams render as a single horizontal row
      with visible lines + arrow tips + pills on every edge
- [x] `pnpm -r typecheck` still green
