### PR TITLE
docs: shrink user→app edge while keeping pill-bearing edges roomy

### DIFF
--- a/docs/src/components/Diagram.astro
+++ b/docs/src/components/Diagram.astro
@@ -50,6 +50,13 @@ interface NodeSpec {
   variant?: Variant;
   width?: number;
   height?: number;
+  /**
+   * ELK-level per-node options. Used for per-edge spacing overrides —
+   * `{ 'elk.margins': '[left=70,...]' }` effectively lengthens the gap
+   * on this node's incoming edge, so the gap on preceding edges can be
+   * kept short globally while other edges stay comfortable.
+   */
+  layoutOptions?: Record<string, string>;
 }
 
 interface EdgeSpec {
@@ -155,6 +162,7 @@ const layout = (await elk.layout({
     id: n.id,
     width: n.width ?? nodeWidth,
     height: n.height ?? nodeHeight,
+    ...(n.layoutOptions ? { layoutOptions: n.layoutOptions } : {}),
   })),
   edges: edges.map((e, i) => ({
     id: `e-${i}`,

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,13 +33,18 @@ import Diagram from '../../components/Diagram.astro';
 <Diagram
   caption="Your web app declares actions. The MCP gateway bridges them to any MCP-capable agent (Claude Code, Cursor, Claude Desktop)."
   nodeWidth={130}
-  spacing={140}
+  spacing={70}
   pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
     { id: 'app',   label: 'YOUR APP', sub: 'browser or Node', icon: 'window' },
-    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', icon: 'bridge', variant: 'accent' },
-    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
+    // `gw` and `agent` carry 70px extra left margin so the 70px global gap
+    // is only applied between user and app; the pill-bearing edges get the
+    // full 140px (70 spacing + 70 margin) they need for visible line + pill.
+    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', icon: 'bridge', variant: 'accent',
+      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
+    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent',
+      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
   ]}
   edges={[
     { from: 'user', to: 'app' },

--- a/docs/src/content/docs/overview/architecture.mdx
+++ b/docs/src/content/docs/overview/architecture.mdx
@@ -13,13 +13,18 @@ import Diagram from '../../../components/Diagram.astro';
 <Diagram
   caption="Three processes, two protocols. Your app hosts a WebSocket endpoint and announces itself; the gateway dials in and speaks MCP stdio to the agent."
   nodeWidth={130}
-  spacing={140}
+  spacing={70}
   pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
     { id: 'app',   label: 'YOUR APP', sub: ['WS server +', 'tab file'], icon: 'window' },
-    { id: 'gw',    label: 'MCP GATEWAY', sub: ['WS client', '+ MCP'], icon: 'bridge', variant: 'accent' },
-    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
+    // `gw` and `agent` carry 70px extra left margin so the 70px global gap
+    // is only applied between user and app; the pill-bearing edges get the
+    // full 140px (70 spacing + 70 margin) they need for visible line + pill.
+    { id: 'gw',    label: 'MCP GATEWAY', sub: ['WS client', '+ MCP'], icon: 'bridge', variant: 'accent',
+      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
+    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent',
+      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
   ]}
   edges={[
     { from: 'user', to: 'app' },


### PR DESCRIPTION
Follow-up to #23. ELK layered applies one spacing to every layer gap, so spacing=140 made the empty USER→YOUR APP arrow look visually too long next to the pill-bearing edges.

Added per-node `layoutOptions` forwarding in `Diagram.astro`. Both diagrams now use global `spacing=70` with `elk.margins: [left=70,...]` on `gw` and `agent`:

- USER → YOUR APP: 70 px (pill-less, now balanced)
- YOUR APP ↔ MCP GATEWAY: 70 + 70 = 140 px (pill + line unchanged)
- MCP GATEWAY ↔ AGENT: 70 + 70 = 140 px (pill + line unchanged)

Verified live at `http://localhost:4321/` and `http://localhost:4321/overview/architecture/`.