### PR TITLE
docs: fix light-mode color bleed + revert user→app spacing shrink

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -33,18 +33,13 @@ import Diagram from '../../components/Diagram.astro';
 <Diagram
   caption="Your web app declares actions. The MCP gateway bridges them to any MCP-capable agent (Claude Code, Cursor, Claude Desktop)."
   nodeWidth={130}
-  spacing={70}
+  spacing={140}
   pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
     { id: 'app',   label: 'YOUR APP', sub: 'browser or Node', icon: 'window' },
-    // `gw` and `agent` carry 70px extra left margin so the 70px global gap
-    // is only applied between user and app; the pill-bearing edges get the
-    // full 140px (70 spacing + 70 margin) they need for visible line + pill.
-    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', icon: 'bridge', variant: 'accent',
-      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
-    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent',
-      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
+    { id: 'gw',    label: 'MCP GATEWAY', sub: 'WS client + MCP', icon: 'bridge', variant: 'accent' },
+    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
   ]}
   edges={[
     { from: 'user', to: 'app' },

--- a/docs/src/content/docs/overview/architecture.mdx
+++ b/docs/src/content/docs/overview/architecture.mdx
@@ -13,18 +13,13 @@ import Diagram from '../../../components/Diagram.astro';
 <Diagram
   caption="Three processes, two protocols. Your app hosts a WebSocket endpoint and announces itself; the gateway dials in and speaks MCP stdio to the agent."
   nodeWidth={130}
-  spacing={70}
+  spacing={140}
   pad={42}
   nodes={[
     { id: 'user',  label: 'USER',    sub: ['human at', 'the keyboard'],     icon: 'user' },
     { id: 'app',   label: 'YOUR APP', sub: ['WS server +', 'tab file'], icon: 'window' },
-    // `gw` and `agent` carry 70px extra left margin so the 70px global gap
-    // is only applied between user and app; the pill-bearing edges get the
-    // full 140px (70 spacing + 70 margin) they need for visible line + pill.
-    { id: 'gw',    label: 'MCP GATEWAY', sub: ['WS client', '+ MCP'], icon: 'bridge', variant: 'accent',
-      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
-    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent',
-      layoutOptions: { 'elk.margins': '[top=0,left=70,bottom=0,right=0]' } },
+    { id: 'gw',    label: 'MCP GATEWAY', sub: ['WS client', '+ MCP'], icon: 'bridge', variant: 'accent' },
+    { id: 'agent', label: 'AGENT',   sub: ['Claude Code,', 'Cursor, Desktop'], icon: 'agent' },
   ]}
   edges={[
     { from: 'user', to: 'app' },

--- a/docs/src/styles/theme.css
+++ b/docs/src/styles/theme.css
@@ -1,7 +1,14 @@
 /* Tesseron Starlight theme overrides. Anchored on warm, high-contrast neutrals
-   that match the amber gateway color used in the D2 diagrams. */
+   that match the amber gateway color used in the diagrams.
+ *
+ * Note on Starlight's palette convention: Starlight treats `:root` as the
+ * DARK palette and `:root[data-theme="light"]` as the LIGHT one (the theme
+ * loader always sets `data-theme` explicitly). Override grays inside the
+ * appropriate scope — putting dark values at bare `:root` bleeds into light
+ * mode because `data-theme="light"` alone doesn't re-set every variable. */
 
 :root {
+  /* Accent + theme-agnostic tokens */
   --sl-color-accent-low: #3a1f00;
   --sl-color-accent: #f59e0b;
   --sl-color-accent-high: #fed7aa;
@@ -10,6 +17,16 @@
      render at their full intrinsic size without scaling down. */
   --sl-content-width: 64rem;
 
+  --tesseron-sdk: #3b6bb3;
+  --tesseron-gateway: #c97a00;
+  --tesseron-agent: #6b46c1;
+  --tesseron-user: #2e7d32;
+  --tesseron-error: #c62828;
+}
+
+/* Dark-mode gray scale — slightly cooler / denser than Starlight's default
+   so the amber accent stays legible against the page chrome. */
+:root[data-theme="dark"] {
   --sl-color-white: #ffffff;
   --sl-color-gray-1: #eef1f6;
   --sl-color-gray-2: #c2c8d1;
@@ -18,12 +35,6 @@
   --sl-color-gray-5: #2a303a;
   --sl-color-gray-6: #1b1f27;
   --sl-color-black: #0d1017;
-
-  --tesseron-sdk: #3b6bb3;
-  --tesseron-gateway: #c97a00;
-  --tesseron-agent: #6b46c1;
-  --tesseron-user: #2e7d32;
-  --tesseron-error: #c62828;
 }
 
 :root[data-theme="light"] {


### PR DESCRIPTION
Two unrelated-but-session-batched docs fixes.

## 1. Light-mode gray palette was escaping dark mode

`theme.css` overrode `--sl-color-white`, `--sl-color-gray-1..6`, and `--sl-color-black` at bare `:root`. Starlight's convention: bare `:root` IS the dark palette; `:root[data-theme="light"]` inverts it. Overriding at `:root` without matching light-mode values meant `--sl-color-white: #fff` (white text!) and `--sl-color-gray-6: #1b1f27` (near-black background) stuck around in light mode — hence the persistent dark styling flagged by the user.

Scoped the gray overrides to `:root[data-theme="dark"]`. Light mode now falls through to Starlight's default light palette. Accent and theme-agnostic tokens stay at bare `:root`.

## 2. Revert user→app spacing shrink from #24

The `elk.margins` trick was supposed to keep the pill-bearing edges at 140px while shrinking the USER→YOUR APP gap to 70px. ELK honored the margin for node placement but drew edges between visible card edges, so the pill-bearing edges collapsed to ~70px visible length — arrowheads but no line.

Going back to global `spacing=140`. The `layoutOptions` pass-through in `Diagram.astro` stays (it's a harmless generic feature); no node uses it. USER→YOUR APP arrow is the same length as the pill-bearing edges again.

Verified locally at `http://localhost:4321/` and `http://localhost:4321/overview/architecture/` in both light and dark themes.