### PR TITLE
chore(plugin): bump to v2.0.0 + sync docs to reverse-connection architecture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,15 +7,15 @@
     "url": "https://github.com/BrainBlend-AI"
   },
   "metadata": {
-    "description": "Tesseron marketplace — ships the Tesseron Claude Code plugin: MCP gateway plus the `framework` mental-model skill, the `tesseron-docs` authoritative-lookup skill (backed by the bundled `@tesseron/docs-mcp` server), the `tesseron-dev` wiring skill, and explorer/reviewer subagents for building and auditing web apps that speak the Tesseron protocol.",
-    "version": "1.1.0"
+    "description": "Tesseron marketplace — ships the Tesseron Claude Code plugin: MCP gateway (reverse-connection architecture, no fixed ports) plus the `framework` mental-model skill, the `tesseron-docs` authoritative-lookup skill (backed by the bundled `@tesseron/docs-mcp` server), the `tesseron-dev` wiring skill, and explorer/reviewer subagents for building and auditing web apps that speak the Tesseron protocol.",
+    "version": "2.0.0"
   },
   "plugins": [
     {
       "name": "tesseron",
       "source": "./plugin",
-      "version": "1.1.0",
-      "description": "Tesseron for Claude Code: MCP gateway for typed web-app actions over WebSocket, plus a `framework` skill for the Tesseron mental model, a `tesseron-docs` skill that calls the bundled `@tesseron/docs-mcp` server for authoritative chapter-and-verse spec lookups (`search_docs`, `read_doc`, `list_docs`), a `tesseron-dev` skill that integrates Tesseron into any JS/TS project by picking the right consumer package (`@tesseron/react`, `/server`, or `/web`) and inserting the canonical API, and isolated-context explorer/reviewer subagents.",
+      "version": "2.0.0",
+      "description": "Tesseron for Claude Code: MCP gateway for typed web-app actions over WebSocket. v2.0 reverse-connection architecture — the gateway is a pure WebSocket client that discovers apps via `~/.tesseron/tabs/`; no fixed ports, no env vars. Includes a `framework` skill for the Tesseron mental model, a `tesseron-docs` skill that calls the bundled `@tesseron/docs-mcp` server for authoritative chapter-and-verse spec lookups (`search_docs`, `read_doc`, `list_docs`), a `tesseron-dev` skill that integrates Tesseron into any JS/TS project by picking the right consumer package (`@tesseron/react`, `/svelte`, `/vue`, `/server`, or `/web`) and inserting the canonical API, and isolated-context explorer/reviewer subagents.",
       "category": "integration",
       "tags": [
         "mcp",

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tesseron",
-  "version": "1.1.0",
-  "description": "MCP gateway that lets any web app expose typed actions to Claude over WebSocket — no browser automation — plus a `framework` skill for the Tesseron mental model, a `tesseron-docs` skill that calls the bundled `@tesseron/docs-mcp` server for authoritative chapter-and-verse spec lookups, a `tesseron-dev` skill that picks the right consumer package (`@tesseron/react` for React, `/server` for Node, `/web` for any other browser context) and inserts the canonical API at the project's entry point, and isolated-context explorer/reviewer subagents for building and auditing Tesseron codebases.",
+  "version": "2.0.0",
+  "description": "MCP gateway that lets any web app expose typed actions to Claude over WebSocket — no browser automation. Reverse-connection architecture: the gateway is a pure WebSocket client that discovers apps via `~/.tesseron/tabs/` — no fixed ports, no env vars. Plus a `framework` skill for the Tesseron mental model, a `tesseron-docs` skill that calls the bundled `@tesseron/docs-mcp` server for authoritative chapter-and-verse spec lookups, a `tesseron-dev` skill that picks the right consumer package (`@tesseron/react` for React, `@tesseron/svelte` for Svelte 5, `@tesseron/vue` for Vue 3, `/server` for Node, `/web` for any other browser context) and inserts the canonical API at the project's entry point, and isolated-context explorer/reviewer subagents for building and auditing Tesseron codebases.",
   "author": {
     "name": "Kenny Vaneetvelde",
     "email": "kenny.vaneetvelde@gmail.com"

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -3,11 +3,7 @@
     "tesseron": {
       "type": "stdio",
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.cjs"],
-      "env": {
-        "TESSERON_PORT": "${TESSERON_PORT:-7475}",
-        "TESSERON_HOST": "${TESSERON_HOST:-127.0.0.1}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.cjs"]
     },
     "tesseron-docs": {
       "type": "stdio",

--- a/plugin/CHANGELOG.md
+++ b/plugin/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the Tesseron Claude Code plugin will be documented in thi
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-04-24
+
+Bumps the bundled gateway (`server/index.cjs`) to `@tesseron/mcp@2.0.0` — the reverse-connection architecture. The gateway is now a pure WebSocket client; apps host their own loopback endpoints and announce themselves via `~/.tesseron/tabs/<tabId>.json`. One discovery mechanism for every runtime, no fixed ports.
+
+### Breaking
+
+- **Gateway no longer binds a port.** `TESSERON_PORT`, `TESSERON_HOST`, and `TESSERON_ORIGIN_ALLOWLIST` env vars are removed (silently ignored if set). The `.mcp.json` that ships with the plugin no longer declares them.
+- **`NodeWebSocketTransport` replaced with `NodeWebSocketServerTransport`** on the Node SDK side. `tesseron.connect()` no longer accepts a gateway URL string.
+- **Browser apps require `@tesseron/vite`** (new package) to expose `/@tesseron/ws` on the dev server. Without it, `tesseron.connect()` has nothing to dial.
+
+### Added
+
+- **New adapter packages**: `@tesseron/svelte` (Svelte 5 runes), `@tesseron/vue` (Composition API), `@tesseron/vite` (dev-server bridge). The `tesseron-dev` skill now routes to them when appropriate.
+
+### Changed
+
+- `plugin/skills/framework/references/gateway.md` rewritten for the reverse-connection model: describes tab-file discovery, drops the env-vars section down to just `TESSERON_TOOL_SURFACE`, removes the `0.0.0.0` / origin-allowlist guidance that no longer applies.
+- `plugin/README.md` updated: gateway is now "dials apps via `~/.tesseron/tabs/`", compatibility section notes `/svelte`, `/vue`, `/vite` as part of the lockstep release.
+- `plugin/agents/tesseron-explorer.md` and `plugin/agents/tesseron-reviewer.md` updated to look for `NodeWebSocketServerTransport` + `@tesseron/vite` wiring and to flag stale `TESSERON_PORT` / `ws://localhost:7475` references as v2 regressions.
+
 ## [1.0.2] - 2026-04-23
 
 This release brings the plugin into version lockstep with the Tesseron SDK packages (`@tesseron/core`, `@tesseron/web`, `@tesseron/server`, `@tesseron/react`, `@tesseron/mcp`). Going forward, the plugin version matches the SDK version so users have one number to remember across all Tesseron surfaces. This is honest about what ships inside: the bundled gateway (`plugin/server/index.cjs`) is built from `@tesseron/mcp`, so sharing the version number reflects what users actually run.

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -28,7 +28,7 @@ Restart Claude Code. The plugin's MCP server (`tesseron`) starts automatically. 
 
 ## How to use the gateway
 
-1. **In your web app**, import `@tesseron/web` (or `/server`, `/react`), declare actions with the Zod-style builder, and call `tesseron.connect()`. The SDK opens a WebSocket to `ws://127.0.0.1:7475` (the gateway this plugin spawned).
+1. **In your web app**, import `@tesseron/web` (or `/server`, `/svelte`, `/vue`, `/react`), declare actions with the Zod-style builder, and call `tesseron.connect()`. The SDK binds a loopback WebSocket endpoint and writes a tab file to `~/.tesseron/tabs/<tabId>.json`. The plugin's gateway is watching that directory and dials in — no port to configure, no env vars to set.
 
 2. **The web app displays a 6-character claim code** (returned in the welcome handshake).
 
@@ -52,8 +52,7 @@ For complete runnable walkthroughs, see the repo's [examples/](https://github.co
 
 ## What the MCP gateway does
 
-- Listens on `ws://127.0.0.1:7475` (override with `TESSERON_PORT` env var).
-- Origin allowlist: localhost / 127.0.0.1 by default. Override with `TESSERON_ORIGIN_ALLOWLIST=https://your-app.example,https://staging.example`.
+- **No fixed port.** The gateway is a WebSocket *client*: it watches `~/.tesseron/tabs/` and dials each app it finds. Apps bind their own loopback endpoint and announce themselves by writing `<tabId>.json`.
 - Exposes a meta-tool `tesseron__claim_session({code})` for the click-to-connect handshake.
 - Forwards SDK→agent: action invocations, streaming progress, structured logs, sampling, elicitation, resource read/subscribe.
 - Forwards agent→SDK: tool calls, cancellations, MCP-side `notifications/progress`.
@@ -63,12 +62,9 @@ For complete runnable walkthroughs, see the repo's [examples/](https://github.co
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `TESSERON_PORT` | `7475` | WebSocket server port |
-| `TESSERON_HOST` | `127.0.0.1` | Bind address (use `0.0.0.0` only with an explicit allowlist) |
-| `TESSERON_ORIGIN_ALLOWLIST` | (none) | Comma-separated additional origins beyond localhost |
 | `TESSERON_TOOL_SURFACE` | `both` | `dynamic` \| `meta` \| `both` — see `skills/framework/references/gateway.md` |
 
-Set these in your Claude Code env, your shell, or override per-launch.
+v2.0 removed `TESSERON_PORT`, `TESSERON_HOST`, and `TESSERON_ORIGIN_ALLOWLIST`: the gateway no longer binds a port or accepts inbound connections.
 
 ## How the skills work
 
@@ -85,7 +81,7 @@ Read the `framework` skill's `SKILL.md` if you want to see the routing table and
 - TypeScript 5.7+ (strict mode, `noUncheckedIndexedAccess` recommended).
 - Node 20+ for server / gateway processes.
 - Protocol version `1.0.0`. Session resume added in SDK v1.1.
-- `@tesseron/core`, `/web`, `/server`, `/react`, `/mcp` released in lockstep — match them within a minor version.
+- `@tesseron/core`, `/web`, `/server`, `/react`, `/svelte`, `/vue`, `/vite`, `/mcp` released in lockstep — match them within a major version (currently `2.x`).
 
 ## Building the gateway from source
 

--- a/plugin/agents/tesseron-explorer.md
+++ b/plugin/agents/tesseron-explorer.md
@@ -31,7 +31,7 @@ If the caller does not specify, start from the directory the parent thread is op
    - `useTesseronAction(` / `useTesseronResource(` / `useTesseronConnection(` — React hook sites.
    - `ctx.sample(` / `ctx.confirm(` / `ctx.elicit(` / `ctx.progress(` / `ctx.log(` / `ctx.signal` — context method use.
    - `ResumeCredentials` / `resumeToken` / `sessionId` — resume-flow persistence.
-   - `BrowserWebSocketTransport` / `NodeWebSocketTransport` / `implements Transport` — transport wiring.
+   - `BrowserWebSocketTransport` / `NodeWebSocketServerTransport` / `@tesseron/vite` plugin / `implements Transport` — transport wiring.
    - `TesseronError` / `SamplingNotAvailableError` / `ElicitationNotAvailableError` / `TimeoutError` / `ResumeFailedError` — error handling.
 
 3. **Component mapping.** For each match, open just enough of the file to capture the component's shape. Do not read the whole file if a targeted span will do.
@@ -72,8 +72,8 @@ If the caller does not specify, start from the directory the parent thread is op
 
 **Transport**
 
-- Which transport implementation (built-in WebSocket, custom postMessage, in-memory for tests).
-- URL or pairing target (default `ws://localhost:7475` vs override).
+- Which transport implementation: `BrowserWebSocketTransport` (client, dials a `/@tesseron/ws` bridge), `NodeWebSocketServerTransport` (server, hosts a loopback endpoint and writes a tab file), custom postMessage, in-memory for tests.
+- For browser apps: whether `@tesseron/vite` is configured (required in v2.0 — it bridges browser tabs to the gateway via `/@tesseron/ws`).
 - Resume usage — whether `ConnectOptions.resume` is wired.
 
 **React hook site**

--- a/plugin/agents/tesseron-reviewer.md
+++ b/plugin/agents/tesseron-reviewer.md
@@ -82,15 +82,14 @@ Work through the categories below in order. Raise an issue only at ≥75% confid
 
 ### 7. Transports
 
-- `BrowserWebSocketTransport` used in browser code, `NodeWebSocketTransport` in Node. Mixing causes runtime errors (one expects `WebSocket` global, the other uses the `ws` package).
-- Gateway URL override done through a constant or env var, not hardcoded scattered throughout the codebase. `DEFAULT_GATEWAY_URL` is `ws://localhost:7475` for both SDKs.
+- `BrowserWebSocketTransport` used in browser code (dials `/@tesseron/ws`, provided by `@tesseron/vite`), `NodeWebSocketServerTransport` used in Node (hosts a loopback endpoint and writes a tab file). Mixing causes runtime errors (one expects `WebSocket` global, the other uses the `ws` package).
+- Browser apps register the `@tesseron/vite` plugin in `vite.config.ts`. Without it there's no `/@tesseron/ws` endpoint and `tesseron.connect()` fails with a connect error.
 - Custom transports implement the full `Transport` interface: `send`, `onMessage`, `onClose`, `close`. Missing `close` leaks resources.
 
 ### 8. Gateway (`@tesseron/mcp`) configuration
 
-- `TESSERON_ORIGIN_ALLOWLIST` set when the gateway is served to a non-localhost origin. Default allowlist is localhost/127.0.0.1 only; exposing to a LAN or public origin without an allowlist is a security bug.
-- `TESSERON_HOST=0.0.0.0` paired with an explicit allowlist. Binding to all interfaces without an allowlist exposes the gateway.
 - `TESSERON_TOOL_SURFACE` left as `both` (default) unless there is a concrete reason to restrict. `meta` drops per-app tools and breaks dynamic tool-list-changed updates for Claude.
+- No code should rely on `TESSERON_PORT` / `TESSERON_HOST` / `TESSERON_ORIGIN_ALLOWLIST` / `DEFAULT_GATEWAY_PORT` / `DEFAULT_GATEWAY_HOST`. Those were removed in v2.0 along with the inbound WebSocket server; the gateway now dials apps via `~/.tesseron/tabs/`.
 
 ### 9. Errors
 

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19223,6 +19223,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     if (this.connectedTabs.has(tabId)) return;
     const ws = new import_websocket.default(wsUrl, [GATEWAY_SUBPROTOCOL]);
     this.connectedTabs.set(tabId, ws);
+    this.handleConnection(ws, void 0);
+    ws.once("close", () => {
+      this.connectedTabs.delete(tabId);
+    });
     try {
       await new Promise((resolve, reject) => {
         ws.once("open", resolve);
@@ -19235,11 +19239,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       this.connectedTabs.delete(tabId);
       throw err;
     }
-    ws.once("close", () => {
-      this.connectedTabs.delete(tabId);
-    });
     logToStderr(`[tesseron] connected to app tab ${tabId} (${wsUrl})`);
-    this.handleConnection(ws, void 0);
   }
   /**
    * Watches `~/.tesseron/tabs/` for per-tab JSON files written by `@tesseron/vite`.

--- a/plugin/skills/framework/references/gateway.md
+++ b/plugin/skills/framework/references/gateway.md
@@ -2,12 +2,12 @@
 
 ## Contents
 - What the gateway does
+- Discovery via `~/.tesseron/tabs/`
 - Environment variables
 - Tool naming convention
 - Tool surface modes
 - Meta tools (dispatcher fallback)
 - Multi-app sessions
-- Origin allowlist and security
 - Running as a plugin (default) vs standalone
 - Common mistakes
 
@@ -15,11 +15,30 @@
 
 `@tesseron/mcp` is the bridge between Tesseron apps and MCP clients:
 
-- **SDK side**: listens on `ws://host:port` for app connections speaking the `tesseron/*` JSON-RPC protocol.
+- **SDK side**: the gateway is a WebSocket *client*. It watches `~/.tesseron/tabs/` for per-app discovery files and dials each app's loopback endpoint. Apps never need to know the gateway's address — the gateway finds them.
 - **MCP side**: exposes the joined app manifests as MCP tools and resources to a host (Claude Code, Claude Desktop, Cursor, etc.) over stdio.
 - **Routes both directions**: agent tool calls become `actions/invoke` on the SDK; SDK-side `ctx.sample` / `ctx.elicit` round-trip to the agent as MCP sampling / elicitation; `ctx.progress` and `ctx.log` become MCP notifications.
 
 When installed as a Claude Code plugin, the gateway is started automatically by the plugin's `.mcp.json` — users don't run it by hand. Running standalone is useful for development or for integrating with clients that are not auto-managed.
+
+## Discovery via `~/.tesseron/tabs/`
+
+Each app process writes a JSON file when it calls `tesseron.connect()`:
+
+```jsonc
+// ~/.tesseron/tabs/tab-mocythay-v0hh50.json
+{
+  "version": 1,
+  "tabId": "tab-mocythay-v0hh50",
+  "appName": "node-prompts",
+  "wsUrl": "ws://127.0.0.1:64872/",
+  "addedAt": 1777038462692
+}
+```
+
+The gateway polls + `fs.watch`es the directory and dials the `wsUrl` of each new tab. The app's WebSocket server only accepts upgrades on the `tesseron-gateway` subprotocol, so nothing else on loopback can impersonate a gateway.
+
+When an app disconnects (process exits, `sdk.disconnect()`), the tab file is deleted and the gateway's WebSocket client notices the socket close.
 
 ## Environment variables
 
@@ -27,18 +46,9 @@ Read at gateway startup:
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `TESSERON_PORT` | `7475` | WebSocket server port the SDK connects to |
-| `TESSERON_HOST` | `127.0.0.1` | Bind address. Use `0.0.0.0` only with an explicit allowlist |
-| `TESSERON_ORIGIN_ALLOWLIST` | *(none)* | Comma-separated origins beyond localhost (e.g. `https://app.example,https://staging.example`) |
 | `TESSERON_TOOL_SURFACE` | `both` | `dynamic` \| `meta` \| `both` (see below) |
 
-The companion constants are exported from `@tesseron/mcp`:
-
-```ts
-export const DEFAULT_GATEWAY_PORT = 7475;
-export const DEFAULT_GATEWAY_HOST = '127.0.0.1';
-export const DEFAULT_RESUME_TTL_MS = 90_000; // zombie-session retention for resume
-```
+v2.0 removed `TESSERON_PORT`, `TESSERON_HOST`, `TESSERON_ORIGIN_ALLOWLIST`, `DEFAULT_GATEWAY_PORT`, and `DEFAULT_GATEWAY_HOST`. The gateway no longer binds a port or accepts inbound connections, so none of those options apply.
 
 ## Tool naming convention
 
@@ -106,26 +116,9 @@ Multiple Tesseron apps can connect to the same gateway simultaneously. Each gets
 Use cases:
 - Developing a frontend + backend that both expose actions.
 - Claiming several sub-apps of a single product (shop + admin + CRM).
-- Running the showcase admin dashboard alongside the app it's inspecting.
+- Running an admin dashboard alongside the app it's inspecting.
 
 Apps disconnect independently; the gateway emits `actions/list_changed` / `resources/list_changed` on each event.
-
-## Origin allowlist and security
-
-The gateway is a local WebSocket server. Default bind is `127.0.0.1` — no LAN or external access. This is deliberately restrictive.
-
-**If you bind to a non-localhost interface (`TESSERON_HOST=0.0.0.0`)**, always pair with `TESSERON_ORIGIN_ALLOWLIST`:
-
-```
-TESSERON_HOST=0.0.0.0
-TESSERON_ORIGIN_ALLOWLIST=https://myapp.internal,https://staging.myapp.internal
-```
-
-Requests with an `Origin` header not in the allowlist are rejected with HTTP 403 before the WebSocket upgrades. `null` origins (file://, some embeds) are rejected unconditionally unless `null` is explicitly allowlisted.
-
-**Do not disable the allowlist "temporarily for testing".** A gateway bound to `0.0.0.0` with no allowlist lets any browser on the network invoke any handler.
-
-The allowlist is origin-prefix-matching — it compares the `Origin` header to each entry exactly; there's no wildcard support. For dynamic preview environments, configure the allowlist at gateway start (from config) rather than whitelisting `*`.
 
 ## Running as a plugin (default)
 
@@ -137,17 +130,13 @@ The default install path — the Tesseron Claude Code plugin — ships `server/i
     "tesseron": {
       "type": "stdio",
       "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.cjs"],
-      "env": {
-        "TESSERON_PORT": "${TESSERON_PORT:-7475}",
-        "TESSERON_HOST": "${TESSERON_HOST:-127.0.0.1}"
-      }
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.cjs"]
     }
   }
 }
 ```
 
-Claude Code starts the gateway automatically on session launch. The user's Claude Code `.env` / shell can override `TESSERON_PORT`, `TESSERON_HOST`, `TESSERON_ORIGIN_ALLOWLIST`, and `TESSERON_TOOL_SURFACE`.
+Claude Code starts the gateway automatically on session launch. Nothing to configure — the gateway picks up tab files as apps announce themselves.
 
 ## Running standalone
 
@@ -165,9 +154,10 @@ Combined with a custom MCP client, this lets you iterate on the SDK without runn
 
 ## Common mistakes
 
-- **`TESSERON_HOST=0.0.0.0` without `TESSERON_ORIGIN_ALLOWLIST`.** Exposes the gateway to anything on the network that can reach that interface. Always pair them.
+- **Expecting the gateway to accept an inbound WebSocket.** It doesn't — the architecture inverted in v2.0. Apps bind loopback WebSocket servers; the gateway dials them. Old code that connected an SDK to `ws://localhost:7475` will fail because no such server exists.
+- **Setting `TESSERON_PORT` / `TESSERON_HOST` / `TESSERON_ORIGIN_ALLOWLIST`.** These env vars no longer exist in v2.0. They're silently ignored.
 - **Changing the app `id` across releases.** Agents cache tool names `<app_id>__<action>`; renaming breaks their memory of which tool does what. Pick a stable `id` early.
 - **Relying on `TESSERON_TOOL_SURFACE=dynamic` alone with clients that don't honor list-changed.** If you know the target client freezes tools at startup, use `both` (default) or `meta`.
 - **Pasting the claim code into the terminal instead of the agent.** The claim code is consumed by the MCP client (Claude) calling `tesseron__claim_session`, not by the shell.
 - **Persisting the claim code.** It's one-shot; it expires quickly after the welcome handshake. Use the resume token for reconnection, not the claim code.
-- **Expecting a single gateway to route to SDKs on a different host.** The gateway is local-only by design. For remote apps, run a gateway on the remote host or tunnel the WebSocket (and still set an origin allowlist).
+- **Expecting a single gateway to route to SDKs on a different host.** The gateway only reads `~/.tesseron/tabs/` on the local filesystem and only dials loopback URLs. Remote apps need their own gateway or a WebSocket tunnel.

--- a/plugin/skills/tesseron-dev/SKILL.md
+++ b/plugin/skills/tesseron-dev/SKILL.md
@@ -11,13 +11,16 @@ This skill does not create projects, pick build tooling, or template framework-s
 
 ## What Tesseron officially supports
 
-Tesseron ships three consumer packages. Everything else — package managers, bundlers, TypeScript configs, framework-specific idioms — is outside Tesseron's responsibility.
+Tesseron ships five consumer packages plus one build-tool plugin. Everything else — package managers, TypeScript configs, framework-specific idioms — is outside Tesseron's responsibility.
 
 | Package | Scope |
 |---|---|
-| `@tesseron/react` | React projects — exports `useTesseronAction`, `useTesseronResource`, `useTesseronConnection`. Tesseron ships framework-specific ergonomics here because React's hook model warrants them. |
+| `@tesseron/react` | React projects — exports `useTesseronAction`, `useTesseronResource`, `useTesseronConnection`. |
+| `@tesseron/svelte` | Svelte 5 projects — exports `tesseronAction`, `tesseronResource`, `tesseronConnection` runes-style helpers with lifecycle-scoped registration. |
+| `@tesseron/vue` | Vue 3 projects — Composition API equivalents of the Svelte helpers with the same lifecycle-scoped semantics. |
 | `@tesseron/server` | Node processes — headless services, CLIs, backend adapters. |
-| `@tesseron/web` | **Any other browser context.** A framework-neutral singleton — the same singleton API serves vanilla JS and any browser framework Tesseron does not officially ship a dedicated adapter for. Tesseron has no framework-specific code for non-React browser contexts; the singleton is called from whatever module scope or startup hook the framework provides. |
+| `@tesseron/web` | **Any other browser context.** A framework-neutral singleton — the same singleton API serves vanilla JS and any browser framework Tesseron does not officially ship a dedicated adapter for. |
+| `@tesseron/vite` | Vite dev-server plugin. **Required for every browser app in v2** — exposes the `/@tesseron/ws` bridge the gateway dials into. Add it to `vite.config.ts` alongside the consumer package. |
 
 `@tesseron/core` (protocol types) and `@tesseron/mcp` (the gateway binary) are not consumer packages; ignore them here.
 
@@ -25,11 +28,15 @@ Tesseron ships three consumer packages. Everything else — package managers, bu
 
 Detect from the project's `package.json` + file layout:
 
+- `svelte` in dependencies → `@tesseron/svelte`.
+- `vue` in dependencies → `@tesseron/vue`.
 - `react` and `react-dom` in dependencies → `@tesseron/react`.
 - Node process without a browser bundle (no `index.html`, no Vite/webpack/etc., `@types/node` present) → `@tesseron/server`.
 - Anything else that runs in a browser → `@tesseron/web`.
 
-If the signals conflict (e.g. a React app embedded in a Node workspace — which package applies is usually about where the `tesseron.connect()` will run), ask the user which process needs the agent surface. Only one `@tesseron/*` package per process.
+For browser apps, ALSO install `@tesseron/vite` as a dev dependency and register it in `vite.config.ts` — v2 relies on the plugin to bridge the browser WebSocket to the gateway.
+
+If the signals conflict (e.g. a React app embedded in a Node workspace — which package applies is usually about where the `tesseron.connect()` will run), ask the user which process needs the agent surface. Only one consumer `@tesseron/*` package per process.
 
 If the project is on a non-JS/TS stack (Rails, Django, Go, raw PHP, etc.), stop. Tesseron consumes the SDK from JS/TS only.
 
@@ -41,7 +48,7 @@ Every action needs a Standard-Schema-compatible validator for its `.input(...)`.
 
 Detect the package manager from the lockfile (`pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, `package-lock.json` or none → npm) and use it. Never swap managers.
 
-Install the chosen `@tesseron/*` package (+ the validator if missing) pinned as `^1.0.0`. All `@tesseron/*` packages release in lockstep, so this range resolves them compatibly as new minors land.
+Install the chosen `@tesseron/*` package (+ the validator if missing, + `@tesseron/vite` as a devDependency for browser apps) pinned as `^2.0.0`. All `@tesseron/*` packages release in lockstep, so this range resolves them compatibly as new minors land. If an older project is still on `^1.0.0`, upgrade it to `^2.0.0` — v2 is a breaking reverse-connection migration and mixing majors will fail at connect time.
 
 ## Phase 4 — Insert the canonical Tesseron API
 


### PR DESCRIPTION
Bumps the Claude Code plugin to v2.0.0 now that the SDK/gateway landed in #21 → #22.

## What changed

**Version bump (both files, per the repo convention)**
- `plugin/.claude-plugin/plugin.json`: 1.1.0 → 2.0.0 + description refresh
- `.claude-plugin/marketplace.json`: 1.1.0 → 2.0.0 + description refresh

**Bundled gateway**
- `plugin/server/index.cjs` rebuilt from `@tesseron/mcp@2.0.0` via `pnpm --filter @tesseron/mcp build:plugin`. Confirmed the bundle has `connectToApp` + `watchAppsJson` and no `DEFAULT_GATEWAY_PORT`.

**Docs scrubbed for removed APIs** (v2 dropped `TESSERON_PORT`, `TESSERON_HOST`, `TESSERON_ORIGIN_ALLOWLIST`, `DEFAULT_GATEWAY_PORT`, `DEFAULT_GATEWAY_HOST`, and `NodeWebSocketTransport`)
- `plugin/.mcp.json` — removed `TESSERON_PORT`/`TESSERON_HOST` env block
- `plugin/README.md` — dropped port/host/origin-allowlist table, added "no env vars to configure" note, listed new adapters
- `plugin/skills/framework/references/gateway.md` — rewritten for the reverse-connection model (tab-file discovery, just `TESSERON_TOOL_SURFACE`)
- `plugin/agents/tesseron-explorer.md` and `tesseron-reviewer.md` — now look for `NodeWebSocketServerTransport` + `@tesseron/vite` and flag stale v1 refs as regressions
- `plugin/skills/tesseron-dev/SKILL.md` — adapter table now lists all five consumer packages + `@tesseron/vite`; install pin bumped `^1.0.0` → `^2.0.0`

**Changelog** — added `[2.0.0] - 2026-04-24` entry to `plugin/CHANGELOG.md`.

## Validation

- `pnpm -r typecheck` ✅ all 19 packages
- `pnpm -r test` ✅ 103 tests passing (core 22, docs-mcp 21, mcp 60)
- `pnpm lint` ✅ clean
- Plugin bundle freshness verified: `connectToApp` + `watchAppsJson` present, `DEFAULT_GATEWAY_PORT` absent