### PR TITLE
fix(vite): forward text frames as text, not binary

### DIFF
--- a/.changeset/fix-vite-text-frame-forwarding.md
+++ b/.changeset/fix-vite-text-frame-forwarding.md
@@ -1,0 +1,20 @@
+---
+'@tesseron/vite': patch
+---
+
+Fix `@tesseron/vite` forwarding text frames as binary frames so the browser
+SDK silently dropped every gateway message and the connection hung at
+`status: 'connecting'`.
+
+The `ws` library hands handlers a `Buffer` for both text and binary frames
+and `Buffer` arguments to `send()` are forwarded as binary, which the
+browser receives as a `Blob`. `BrowserWebSocketTransport` in `@tesseron/web`
+only handles `string` frames, so the `tesseron/welcome`, action results,
+progress, and every other gateway message were discarded.
+
+The bridge now reads the `isBinary` flag both directions, decodes text
+frames back to UTF-8 strings before re-emitting them, and queues frames in
+their original form so re-`send()` after the gateway connects produces the
+correct frame type.
+
+Fixes #27.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -12,6 +12,12 @@ export interface TesseronViteOptions {
   appName?: string;
 }
 
+/** A frame buffered or forwarded across the bridge. Text frames are kept as
+ * `string` so that re-`send()` produces a text frame; binary frames stay as
+ * the original `RawData` (Buffer/ArrayBuffer/Buffer[]) and re-`send()` produces
+ * a binary frame. */
+type BridgePayload = string | RawData;
+
 interface PendingTab {
   tabId: string;
   appName?: string;
@@ -19,12 +25,21 @@ interface PendingTab {
   browserWs: WebSocket;
   gatewayWs?: WebSocket;
   /** Messages from browser buffered while the gateway connection is being established. */
-  queue: RawData[];
+  queue: BridgePayload[];
 }
 
 const WS_PATH_PREFIX = '/@tesseron/ws';
 const TABS_DIR = join(homedir(), '.tesseron', 'tabs');
 const GATEWAY_SUBPROTOCOL = 'tesseron-gateway';
+
+/** Decode a `ws` text-frame payload back to a string. `ws` always emits a
+ * Buffer (or Buffer fragments) for text frames; we just need UTF-8 it. */
+function rawDataToString(data: RawData): string {
+  if (typeof data === 'string') return data;
+  if (Buffer.isBuffer(data)) return data.toString('utf8');
+  if (Array.isArray(data)) return Buffer.concat(data).toString('utf8');
+  return Buffer.from(data as ArrayBuffer).toString('utf8');
+}
 
 async function ensureTabsDir(): Promise<void> {
   await mkdir(TABS_DIR, { recursive: true });
@@ -105,11 +120,17 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
               process.stderr.write(`[tesseron] failed to write tab file: ${err.message}\n`),
             );
 
-            ws.on('message', (data: RawData) => {
+            ws.on('message', (data: RawData, isBinary: boolean) => {
+              // `ws` hands us a Buffer for both text and binary frames. Calling
+              // send(Buffer) without options forwards as a binary frame, which
+              // the browser receives as a Blob and the @tesseron/web transport
+              // drops (it only handles string frames). Decode text frames back
+              // to a string so the frame type round-trips correctly.
+              const payload: RawData | string = isBinary ? data : rawDataToString(data);
               if (entry.gatewayWs?.readyState === 1 /* OPEN */) {
-                entry.gatewayWs.send(data as Buffer);
+                entry.gatewayWs.send(payload);
               } else {
-                entry.queue.push(data);
+                entry.queue.push(payload);
               }
             });
 
@@ -140,15 +161,18 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
           wss.handleUpgrade(req, socket, head, (ws) => {
             entry.gatewayWs = ws;
 
-            // Drain messages buffered while waiting for the gateway
+            // Drain messages buffered while waiting for the gateway. Each
+            // entry preserves its original frame type (string for text,
+            // Buffer/etc. for binary) so re-`send` re-emits the correct frame.
             for (const msg of entry.queue) {
-              ws.send(msg as Buffer);
+              ws.send(msg);
             }
             entry.queue = [];
 
-            ws.on('message', (data: RawData) => {
+            ws.on('message', (data: RawData, isBinary: boolean) => {
+              const payload: RawData | string = isBinary ? data : rawDataToString(data);
               if (entry.browserWs.readyState === 1 /* OPEN */) {
-                entry.browserWs.send(data as Buffer);
+                entry.browserWs.send(payload);
               }
             });
 


### PR DESCRIPTION
## Summary

`@tesseron/vite` v2.0.0 forwarded every text frame as a binary frame, so the browser SDK silently dropped every `tesseron/welcome`, action result, and progress update. The connection hung at `status: 'connecting'` and the claim code never showed up.

The `ws` library hands handlers a `Buffer` for both text and binary frames, and `ws.send(buffer)` without options sends a binary frame. The browser receives those as `Blob` and `BrowserWebSocketTransport` only handles `string` frames.

This PR reads the `isBinary` flag on both bridge directions, decodes text frames back to UTF-8 strings before re-`send`, and keeps queued-while-pending frames in their original form so the drain re-emits the correct frame type.

Fixes #27.

## Test plan

- [x] `pnpm typecheck` and `pnpm build` pass for `@tesseron/vite`.
- [ ] Manual: Svelte/Vite example app receives the welcome and renders the claim code within ~1s.

## Notes

The side observation in the issue (gateway socket overwrite if a second gateway dials the same tab path) is not addressed here. Tracking it as a separate concern; the title of this issue is scoped to the binary-frame bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
