### PR TITLE
fix(core,mcp): route reads to newest claimed session, close stale transport on reconnect

### DIFF
--- a/.changeset/fix-stale-session-on-hmr.md
+++ b/.changeset/fix-stale-session-on-hmr.md
@@ -1,0 +1,27 @@
+---
+'@tesseron/core': patch
+'@tesseron/mcp': patch
+'@tesseron/server': patch
+'@tesseron/web': patch
+'@tesseron/react': patch
+'@tesseron/svelte': patch
+'@tesseron/vue': patch
+---
+
+Fix `tesseron__read_resource` (and `__invoke_action`) hanging indefinitely
+after an HMR-driven reconnect.
+
+Two interlocking bugs:
+
+1. `TesseronClient.connect()` swapped in a new transport without closing the
+   previous one, so the old `WebSocket` lingered as a phantom claimed
+   session on the gateway side. `connect()` now closes any previously-
+   attached transport before swapping, and the per-transport `onClose`
+   handler guards against a late close from the prior transport trampling
+   the new dispatcher / welcome.
+2. `McpAgentBridge` resolved sessions by `Map`-iteration order, so when the
+   user reclaimed via a fresh socket the bridge still routed reads and
+   action invocations to the older — and now dead — session. The lookup
+   now picks the most-recently-claimed session matching the `app.id`.
+
+Closes #40.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -225,6 +225,14 @@ export class TesseronClient implements BuilderRegistry {
     if (!this.appConfig) {
       throw new Error('Tesseron: call app({ id, name }) before connect().');
     }
+    // If a previous transport is still attached (e.g. HMR re-ran the module
+    // and re-invoked `connect()` on the same singleton), close it now. The
+    // alternative — silently orphaning the old socket — leaves a phantom
+    // "claimed" session on the gateway side, and the bridge's by-app-id
+    // lookup picks that dead session before the freshly-claimed one.
+    if (this.transport && this.transport !== transport) {
+      this.transport.close();
+    }
     this.transport = transport;
     const dispatcher = new JsonRpcDispatcher((message) => transport.send(message));
     this.dispatcher = dispatcher;
@@ -232,6 +240,10 @@ export class TesseronClient implements BuilderRegistry {
     transport.onMessage((message) => dispatcher.receive(message));
     transport.onClose((reason) => {
       dispatcher.rejectAllPending(new TransportClosedError(reason));
+      // Only clear instance state if it still belongs to *this* transport.
+      // A stale onClose from a previously-attached transport firing after
+      // a reconnect would otherwise trample the new dispatcher and welcome.
+      if (this.dispatcher !== dispatcher) return;
       this.dispatcher = undefined;
       this.welcome = undefined;
       for (const ctrl of this.invocations.values()) ctrl.abort();

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -344,7 +344,7 @@ export class McpAgentBridge {
         localName = name.slice(separatorIdx + PREFIX_SEPARATOR.length);
         invokeArgs = args;
       }
-      const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+      const session = this.latestClaimedByApp(appId);
       if (!session) {
         return errorResult(`No claimed session found for app "${appId}".`);
       }
@@ -465,6 +465,27 @@ export class McpAgentBridge {
     });
   }
 
+  /**
+   * Picks the most-recently-claimed session matching `appId`. The gateway can
+   * legitimately hold more than one claimed session per `app.id`: a second
+   * browser tab opening the app, an HMR-driven reconnect that briefly overlaps
+   * with the prior socket, or a long-tailed close event that hasn't fired yet.
+   * `Map` iteration order is insertion order, so a naive `find` returns the
+   * oldest match — which can be a phantom whose transport is dead, in which
+   * case the action invocation or resource read hangs indefinitely. Picking
+   * the latest `claimedAt` matches what the user actually intends to drive.
+   */
+  private latestClaimedByApp(appId: string): Session | undefined {
+    let latest: Session | undefined;
+    for (const session of this.gateway.getClaimedSessions()) {
+      if (session.app.id !== appId) continue;
+      if (!latest || (session.claimedAt ?? 0) > (latest.claimedAt ?? 0)) {
+        latest = session;
+      }
+    }
+    return latest;
+  }
+
   private locateResource(uri: string): { session: Session; resourceName: string } | null {
     let parsed: URL;
     try {
@@ -476,7 +497,7 @@ export class McpAgentBridge {
     const appId = parsed.hostname;
     const resourceName = parsed.pathname.replace(/^\//, '');
     if (!appId || !resourceName) return null;
-    const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+    const session = this.latestClaimedByApp(appId);
     if (!session) return null;
     return { session, resourceName };
   }
@@ -541,7 +562,7 @@ export class McpAgentBridge {
         'tesseron__read_resource requires string "app_id" and "name". Use tesseron__list_actions to enumerate available resources.',
       );
     }
-    const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+    const session = this.latestClaimedByApp(appId);
     if (!session) {
       return errorResult(`No claimed session found for app "${appId}".`);
     }

--- a/packages/mcp/test/reconnect.test.ts
+++ b/packages/mcp/test/reconnect.test.ts
@@ -1,0 +1,173 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import type { Transport } from '@tesseron/core';
+import { ServerTesseronClient } from '@tesseron/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { McpAgentBridge, TesseronGateway } from '../src/index.js';
+import { type Sandbox, dialSdk, prepareSandbox } from './setup.js';
+
+/**
+ * Two interlocking guarantees, both motivated by the HMR-driven hang in
+ * `tesseron__read_resource` from issue #40:
+ *
+ *  1. (Bridge defense in depth) When more than one claimed session shares an
+ *     `app.id`, the bridge picks the most-recently-claimed one. A naive
+ *     `Map`-iteration `find` returned the oldest, which after HMR was the
+ *     phantom session whose transport was already gone — so the read hung.
+ *
+ *  2. (Root cause) Calling `client.connect()` again on the same singleton
+ *     while a transport is still attached now closes the previous transport
+ *     instead of orphaning it. Without this, HMR-driven re-mounts left two
+ *     sockets alive on the gateway side simultaneously.
+ */
+
+let sandbox: Sandbox;
+let gateway: TesseronGateway;
+let bridge: McpAgentBridge;
+let client: Client;
+
+beforeAll(async () => {
+  sandbox = prepareSandbox();
+  gateway = new TesseronGateway();
+  bridge = new McpAgentBridge({ gateway });
+  const [agentSide, gatewaySide] = InMemoryTransport.createLinkedPair();
+  await bridge.connect(gatewaySide);
+  client = new Client({ name: 'reconnect-test', version: '0.0.0' }, { capabilities: {} });
+  await client.connect(agentSide);
+});
+
+afterAll(async () => {
+  await client.close().catch(() => {});
+  await gateway.stop().catch(() => {});
+  sandbox.cleanup();
+});
+
+async function callTool(name: string, args: unknown): Promise<{ text: string; isError: boolean }> {
+  const r = await client.request(
+    { method: 'tools/call', params: { name, arguments: args as Record<string, unknown> } },
+    CallToolResultSchema,
+  );
+  return {
+    text: r.content.map((c) => (c.type === 'text' ? c.text : '')).join(''),
+    isError: r.isError === true,
+  };
+}
+
+describe('reconnect / HMR resilience', () => {
+  it('routes resource reads to the most recently claimed session for an app.id', async () => {
+    // Two SDKs, both registering the same app.id. Mirrors the HMR scenario
+    // where the old socket lingers as a "claimed" session in the gateway map
+    // while the user has already reclaimed via the new socket.
+    const stateA = { items: [{ id: 'OLD' }] };
+    const sdkA = new ServerTesseronClient();
+    sdkA.app({ id: 'multi_repro', name: 'Multi Repro', origin: 'http://localhost' });
+    sdkA.resource('media_library').read(() => stateA.items);
+
+    const welcomeA = await dialSdk(gateway, sandbox, () => sdkA.connect());
+    expect((await callTool('tesseron__claim_session', { code: welcomeA.claimCode })).isError).toBe(
+      false,
+    );
+
+    const stateB = { items: [{ id: 'NEW' }] };
+    const sdkB = new ServerTesseronClient();
+    sdkB.app({ id: 'multi_repro', name: 'Multi Repro', origin: 'http://localhost' });
+    sdkB.resource('media_library').read(() => stateB.items);
+
+    const welcomeB = await dialSdk(gateway, sandbox, () => sdkB.connect());
+    expect((await callTool('tesseron__claim_session', { code: welcomeB.claimCode })).isError).toBe(
+      false,
+    );
+
+    const result = await Promise.race([
+      callTool('tesseron__read_resource', { app_id: 'multi_repro', name: 'media_library' }),
+      new Promise<{ text: string; isError: boolean }>((_, rej) =>
+        setTimeout(() => rej(new Error('TIMEOUT after 3s — read_resource hung')), 3000),
+      ),
+    ]);
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('NEW');
+    expect(result.text).not.toContain('OLD');
+
+    await sdkA.disconnect().catch(() => {});
+    await sdkB.disconnect().catch(() => {});
+  });
+
+  it('routes action invocations to the most recently claimed session for an app.id', async () => {
+    // Same fix; invokeAction goes through the same `find` codepath the read
+    // path does. Cover both so a future regression on either is caught.
+    const sdkA = new ServerTesseronClient();
+    sdkA.app({ id: 'invoke_repro', name: 'Invoke Repro', origin: 'http://localhost' });
+    sdkA.action('which').handler(() => ({ which: 'OLD' }));
+    const welcomeA = await dialSdk(gateway, sandbox, () => sdkA.connect());
+    expect((await callTool('tesseron__claim_session', { code: welcomeA.claimCode })).isError).toBe(
+      false,
+    );
+
+    const sdkB = new ServerTesseronClient();
+    sdkB.app({ id: 'invoke_repro', name: 'Invoke Repro', origin: 'http://localhost' });
+    sdkB.action('which').handler(() => ({ which: 'NEW' }));
+    const welcomeB = await dialSdk(gateway, sandbox, () => sdkB.connect());
+    expect((await callTool('tesseron__claim_session', { code: welcomeB.claimCode })).isError).toBe(
+      false,
+    );
+
+    const result = await Promise.race([
+      callTool('tesseron__invoke_action', {
+        app_id: 'invoke_repro',
+        action: 'which',
+        args: {},
+      }),
+      new Promise<{ text: string; isError: boolean }>((_, rej) =>
+        setTimeout(() => rej(new Error('TIMEOUT after 3s — invoke hung')), 3000),
+      ),
+    ]);
+    expect(result.isError).toBe(false);
+    expect(result.text).toContain('NEW');
+
+    await sdkA.disconnect().catch(() => {});
+    await sdkB.disconnect().catch(() => {});
+  });
+
+  it('closes the previous transport when connect() is called again on the same client', async () => {
+    // Prove the SDK-side root cause is fixed. The first transport's `close`
+    // method should be invoked when the second connect() runs.
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'reconnect_root', name: 'Reconnect Root', origin: 'http://localhost' });
+    sdk.action('ping').handler(() => ({ ok: true }));
+
+    let firstClosed = false;
+    const messageHandlers: Array<(m: unknown) => void> = [];
+    const closeHandlers: Array<(reason?: string) => void> = [];
+    const fakeTransport: Transport = {
+      send() {
+        // Pretend to talk to a peer; never respond, never error.
+      },
+      onMessage(h) {
+        messageHandlers.push(h);
+      },
+      onClose(h) {
+        closeHandlers.push(h);
+      },
+      close() {
+        firstClosed = true;
+        for (const h of closeHandlers) h('reconnected');
+      },
+    };
+
+    // Attach the fake transport directly to the underlying TesseronClient
+    // (skips the bind-and-announce wrapper). Don't await the welcome — the
+    // fake transport never responds; we only care about the close behavior.
+    const helloPromise = sdk.connect(fakeTransport).catch(() => {});
+
+    // Now call connect again with a real bind-and-announce transport. Should
+    // close the fake one.
+    expect(firstClosed).toBe(false);
+    const welcome = await dialSdk(gateway, sandbox, () => sdk.connect());
+    expect(firstClosed).toBe(true);
+    expect(welcome.sessionId).toBeTruthy();
+    await helloPromise;
+
+    await sdk.disconnect().catch(() => {});
+  });
+});

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -25774,7 +25774,7 @@ var McpAgentBridge = class {
         localName = name.slice(separatorIdx + PREFIX_SEPARATOR.length);
         invokeArgs = args;
       }
-      const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+      const session = this.latestClaimedByApp(appId);
       if (!session) {
         return errorResult(`No claimed session found for app "${appId}".`);
       }
@@ -25881,6 +25881,26 @@ var McpAgentBridge = class {
       return {};
     });
   }
+  /**
+   * Picks the most-recently-claimed session matching `appId`. The gateway can
+   * legitimately hold more than one claimed session per `app.id`: a second
+   * browser tab opening the app, an HMR-driven reconnect that briefly overlaps
+   * with the prior socket, or a long-tailed close event that hasn't fired yet.
+   * `Map` iteration order is insertion order, so a naive `find` returns the
+   * oldest match — which can be a phantom whose transport is dead, in which
+   * case the action invocation or resource read hangs indefinitely. Picking
+   * the latest `claimedAt` matches what the user actually intends to drive.
+   */
+  latestClaimedByApp(appId) {
+    let latest;
+    for (const session of this.gateway.getClaimedSessions()) {
+      if (session.app.id !== appId) continue;
+      if (!latest || (session.claimedAt ?? 0) > (latest.claimedAt ?? 0)) {
+        latest = session;
+      }
+    }
+    return latest;
+  }
   locateResource(uri) {
     let parsed;
     try {
@@ -25892,7 +25912,7 @@ var McpAgentBridge = class {
     const appId = parsed.hostname;
     const resourceName = parsed.pathname.replace(/^\//, "");
     if (!appId || !resourceName) return null;
-    const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+    const session = this.latestClaimedByApp(appId);
     if (!session) return null;
     return { session, resourceName };
   }
@@ -25947,7 +25967,7 @@ var McpAgentBridge = class {
         'tesseron__read_resource requires string "app_id" and "name". Use tesseron__list_actions to enumerate available resources.'
       );
     }
-    const session = this.gateway.getClaimedSessions().find((s) => s.app.id === appId);
+    const session = this.latestClaimedByApp(appId);
     if (!session) {
       return errorResult(`No claimed session found for app "${appId}".`);
     }


### PR DESCRIPTION
## Summary

`tesseron__read_resource` and `tesseron__invoke_action` hang indefinitely (the agent shows the tool as in-progress forever) after a Vite HMR cycle reconnects the browser tab. Reported via real-world use; reproduced in `packages/mcp/test/reconnect.test.ts`.

Closes #40.

## Root cause

Two bugs interlock:

**1. SDK orphans the previous transport on reconnect.** `TesseronClient.connect()` swapped in a new transport without closing the previous one. When HMR re-ran a module that called `connect()` again on the singleton (the typical `tesseronConnection()` Svelte / React adapter pattern), the old `WebSocket` was dropped from `this.transport` but never closed. Both sockets stayed alive — and the gateway saw both as live, claimed sessions for the same `app.id`.

**2. Bridge picks the OLDEST session by `app.id`.** `McpAgentBridge`'s three by-app-id lookups (`__invoke_action`, `__read_resource`, MCP `resources/read`) used `getClaimedSessions().find(s => s.app.id === appId)`. `Map` iteration is insertion order, so this returns the oldest entry. After HMR, that entry is the phantom session whose transport has gone dead. The bridge dispatches into it, the JSON-RPC request never settles, and the agent hangs (the dispatcher has no timeout).

## Fix

**`packages/core/src/client.ts`** — `connect()` closes any previously-attached transport before swapping. The per-transport `onClose` handler now guards `if (this.dispatcher !== dispatcher) return;` so a late close from the prior transport can't trample the new dispatcher and welcome.

**`packages/mcp/src/mcp-bridge.ts`** — Three by-app-id `find()` lookups replaced with a `latestClaimedByApp(appId)` helper that picks the session with the most recent `claimedAt`. Defense in depth — even when the SDK side hasn't yet closed the old socket, the bridge always routes to whatever the user claimed most recently.

## Test plan

- [x] `packages/mcp/test/reconnect.test.ts` (3 tests): resource read prefers newest session; action invoke prefers newest session; `connect()` closes prior transport on reconnect. All pass.
- [x] Full suite green: 22 core + 21 docs-mcp + 66 mcp (1 skipped UDS-on-Windows).
- [x] Plugin bundle rebuilt (`pnpm build:plugin`); CI's bundle-staleness guard from #39 verifies this.
- [x] Manifests synced (`pnpm sync-plugin-version --check`).

## Files

```
packages/core/src/client.ts            // close prev transport, guard late onClose
packages/mcp/src/mcp-bridge.ts         // latestClaimedByApp helper, 3 call sites
packages/mcp/test/reconnect.test.ts    // new: 3 tests covering both fixes
plugin/server/index.cjs                // rebuilt bundle
.changeset/fix-stale-session-on-hmr.md // patch bumps for affected packages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
