### PR TITLE
fix(core): auto-derive JSON Schema from validators that ship a converter

### DIFF
--- a/.changeset/auto-derive-json-schema.md
+++ b/.changeset/auto-derive-json-schema.md
@@ -1,0 +1,32 @@
+---
+'@tesseron/core': patch
+'@tesseron/mcp': patch
+'@tesseron/server': patch
+'@tesseron/web': patch
+'@tesseron/react': patch
+'@tesseron/svelte': patch
+'@tesseron/vue': patch
+---
+
+Auto-derive JSON Schema from Standard Schema validators that ship a converter.
+
+The documented `.input(z.object({...}))` idiom previously shipped every action
+with a permissive `{type: 'object', additionalProperties: true}` because no
+auto-derivation existed in `@tesseron/core` — only the explicit-second-arg
+path was wired up. Agents got no field-type signal, which meant Claude
+sometimes JSON-encoded numeric arguments as strings; Zod's runtime then
+correctly rejected the call with `-32004 InputValidation`.
+
+`ActionBuilder.input` / `.output` and `ResourceBuilder.output` now look for a
+JSON Schema exporter on the validator and use it when the caller didn't pass
+one explicitly. Detection is duck-typed and never throws — failures fall
+through to the existing permissive default:
+
+- **Zod 4+** — `schema.toJSONSchema()` instance method.
+- **TypeBox** — schema object IS the JSON Schema; `~standard` is stripped.
+- **ArkType** — `schema.toJsonSchema()` instance method.
+- **Valibot / Effect Schema / Zod 3** — no native instance exporter; pass
+  JSON Schema as the second argument (use `@valibot/to-json-schema`,
+  `@effect/schema/JSONSchema`, or `zod-to-json-schema` respectively).
+
+Closes #43.

--- a/docs/src/content/docs/sdk/typescript/standard-schema.md
+++ b/docs/src/content/docs/sdk/typescript/standard-schema.md
@@ -65,15 +65,28 @@ The SDK validates the handler's return value the same way it validates input. Fa
 
 ## JSON Schema export
 
-The wire protocol transports each action's input and output as JSON Schema (for the MCP tool descriptor). There are two paths:
+The wire protocol transports each action's input and output as JSON Schema (for the MCP tool descriptor). The agent reads it to know which fields exist, what types they expect, and how to format invocations. A typeless permissive schema means the LLM has to guess - including, sometimes, JSON-encoding numbers as strings.
 
-### 1. Your validator provides it
+There are three paths the SDK checks, in order:
 
-Modern Zod, TypeBox, and Effect Schema can produce JSON Schema natively. The SDK picks it up automatically. No extra work.
+### 1. Auto-derive from the validator
+
+If your schema's vendor exposes a JSON Schema converter on the schema object, the SDK calls it automatically. No extra work in your action code.
+
+| Validator | Auto-derive | How |
+|---|---|---|
+| **Zod 4+** | ✅ | calls `schema.toJSONSchema()` (instance method) |
+| **TypeBox** | ✅ | the schema object IS the JSON Schema; the SDK strips the Standard Schema metadata and passes it through |
+| **ArkType** | ✅ | calls `schema.toJsonSchema()` (instance method) |
+| Zod 3 | ❌ | no native exporter; pass JSON Schema explicitly (see below), or use `zod-to-json-schema` |
+| Valibot | ❌ | install `@valibot/to-json-schema` and pass the result explicitly |
+| Effect Schema | ❌ | call `JSONSchema.make(schema)` from `@effect/schema/JSONSchema` and pass the result explicitly |
+
+If auto-derivation throws (e.g. the validator hits an unsupported feature), the SDK silently falls back - no exception escapes into your action wiring.
 
 ### 2. Pass it manually
 
-Some validators don't emit JSON Schema, or the export isn't great for a given shape. Pass the JSON Schema as the second argument:
+Always wins over auto-derivation. Pass the JSON Schema as the second argument:
 
 ```ts
 .input(
@@ -86,9 +99,11 @@ Some validators don't emit JSON Schema, or the export isn't great for a given sh
 )
 ```
 
+For Valibot, Effect Schema, or Zod 3, this is the path you'll typically take. Run your validator's converter once and pass the result.
+
 ### 3. Fallback
 
-If neither path produces a schema, the SDK sends `{ type: 'object', additionalProperties: true }` - permissive, unhelpful to the agent, but the call still works.
+If both paths above produce nothing, the SDK sends `{ type: 'object', additionalProperties: true }` - permissive, unhelpful to the agent, but the call still works. Avoid this where you can: agents on a permissive schema sometimes JSON-encode numbers as strings (because they have no type signal), and the call then fails Zod runtime validation.
 
 ## Zod idioms that help the agent
 

--- a/examples/express-prompts/package.json
+++ b/examples/express-prompts/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tesseron/server": "workspace:*",
     "express": "^4.21.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@types/express": "^4.17.0",

--- a/examples/node-prompts/package.json
+++ b/examples/node-prompts/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tesseron/server": "workspace:*",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",

--- a/examples/react-todo/package.json
+++ b/examples/react-todo/package.json
@@ -14,7 +14,7 @@
     "@tesseron/react": "workspace:*",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@tesseron/vite": "workspace:*",

--- a/examples/svelte-todo/package.json
+++ b/examples/svelte-todo/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tesseron/svelte": "workspace:*",
     "svelte": "^5.0.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^4.0.0",

--- a/examples/vanilla-todo/package.json
+++ b/examples/vanilla-todo/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@tesseron/web": "workspace:*",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@tesseron/vite": "workspace:*",

--- a/examples/vue-todo/package.json
+++ b/examples/vue-todo/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@tesseron/vue": "workspace:*",
     "vue": "^3.5.0",
-    "zod": "^3.24.0"
+    "zod": "^4.3.0"
   },
   "devDependencies": {
     "@tesseron/vite": "workspace:*",

--- a/packages/core/src/builder-impl.ts
+++ b/packages/core/src/builder-impl.ts
@@ -10,6 +10,7 @@ import type {
   TimeoutOptions,
 } from './builder.js';
 import type { ActionAnnotations } from './protocol.js';
+import { deriveJsonSchema } from './schema-helpers.js';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 
@@ -45,13 +46,17 @@ export class ActionBuilderImpl<I, O> implements ActionBuilder<I, O> {
 
   input<NewI>(schema: StandardSchemaV1<NewI>, jsonSchema?: unknown): ActionBuilder<NewI, O> {
     this.inputSchema = schema as unknown as StandardSchemaV1<I>;
-    if (jsonSchema !== undefined) this.inputJsonSchema = jsonSchema;
+    // Caller-provided JSON Schema always wins; otherwise opportunistically
+    // derive from the validator. Fixes the documented Zod path where
+    // `.input(z.object({...}))` shipped permissive `additionalProperties:true`
+    // because no auto-derivation existed.
+    this.inputJsonSchema = jsonSchema ?? deriveJsonSchema(schema);
     return this as unknown as ActionBuilder<NewI, O>;
   }
 
   output<NewO>(schema: StandardSchemaV1<NewO>, jsonSchema?: unknown): ActionBuilder<I, NewO> {
     this.outputSchema = schema as unknown as StandardSchemaV1<O>;
-    if (jsonSchema !== undefined) this.outputJsonSchema = jsonSchema;
+    this.outputJsonSchema = jsonSchema ?? deriveJsonSchema(schema);
     return this as unknown as ActionBuilder<I, NewO>;
   }
 
@@ -109,7 +114,7 @@ export class ResourceBuilderImpl<T> implements ResourceBuilder<T> {
 
   output<NewT>(schema: StandardSchemaV1<NewT>, jsonSchema?: unknown): ResourceBuilder<NewT> {
     this.outputSchema = schema as unknown as StandardSchemaV1<T>;
-    if (jsonSchema !== undefined) this.outputJsonSchema = jsonSchema;
+    this.outputJsonSchema = jsonSchema ?? deriveJsonSchema(schema);
     return this as unknown as ResourceBuilder<NewT>;
   }
 

--- a/packages/core/src/schema-helpers.ts
+++ b/packages/core/src/schema-helpers.ts
@@ -35,6 +35,69 @@ export function permissiveJsonSchema(): unknown {
 }
 
 /**
+ * Try to extract a JSON Schema from a Standard Schema validator without
+ * dragging the validator package in as a dependency. Auto-derivation is the
+ * documented happy path — the agent sees real property types instead of the
+ * `{type: 'object', additionalProperties: true}` fallback, which makes Claude
+ * dramatically more likely to JSON-encode field values correctly.
+ *
+ * Detection is duck-typed and conservative — we never throw, and any failure
+ * (vendor we can't introspect, a validator that throws inside its converter)
+ * silently returns `undefined` so the caller falls back to the permissive
+ * default. Callers that want a guaranteed schema should pass one explicitly
+ * as the second argument to `.input()` / `.output()`.
+ *
+ * Supported today:
+ *   - **Zod 4+**         – `schema.toJSONSchema()` (instance method).
+ *   - **ArkType**        – `schema.toJsonSchema()` (instance method, lowerCamelCase).
+ *   - **TypeBox**        – the schema object IS a JSON Schema; we strip the
+ *                          Standard Schema metadata field and return the rest.
+ *
+ * Not auto-derived (caller must pass JSON Schema explicitly):
+ *   - **Zod ≤ 3**        – no native export; pair `.input(schema, zodToJsonSchema(schema))`.
+ *   - **Valibot**        – needs `@valibot/to-json-schema` separately.
+ *   - **Effect Schema**  – needs `JSONSchema.make` from `@effect/schema` separately.
+ */
+export function deriveJsonSchema(schema: unknown): unknown | undefined {
+  if (!schema || typeof schema !== 'object') return undefined;
+  const s = schema as Record<string, unknown>;
+
+  // Zod 4 (and any other validator that ships an instance-method exporter
+  // following Zod's casing): `schema.toJSONSchema()`.
+  const toJSONSchema = s['toJSONSchema'];
+  if (typeof toJSONSchema === 'function') {
+    try {
+      const result = (toJSONSchema as () => unknown).call(schema);
+      if (result && typeof result === 'object') return result;
+    } catch {
+      // fall through to other strategies
+    }
+  }
+
+  // ArkType: lowerCamelCase variant.
+  const toJsonSchema = s['toJsonSchema'];
+  if (typeof toJsonSchema === 'function') {
+    try {
+      const result = (toJsonSchema as () => unknown).call(schema);
+      if (result && typeof result === 'object') return result;
+    } catch {
+      // fall through
+    }
+  }
+
+  // TypeBox: the schema object already conforms to JSON Schema; strip the
+  // Standard Schema metadata key so we don't leak `~standard` (which carries
+  // a `validate` function) into the wire manifest.
+  const standard = s['~standard'] as { vendor?: unknown } | undefined;
+  if (standard && standard.vendor === 'typebox' && typeof s['type'] === 'string') {
+    const { '~standard': _ignored, ...rest } = s;
+    return rest;
+  }
+
+  return undefined;
+}
+
+/**
  * Schema used by `ctx.confirm` — an object with zero properties, so MCP
  * clients render pure Accept/Decline without any input field. Verified
  * against the MCP SDK's `ElicitRequestFormParamsSchema` (ZodRecord with no

--- a/packages/core/test/schema-helpers.test.ts
+++ b/packages/core/test/schema-helpers.test.ts
@@ -1,3 +1,4 @@
+import type { StandardSchemaV1 } from '@standard-schema/spec';
 import { describe, expect, it } from 'vitest';
 import { TesseronError } from '../src/errors.js';
 import { TesseronErrorCode } from '../src/protocol.js';
@@ -5,6 +6,7 @@ import {
   CONFIRM_REQUESTED_SCHEMA,
   PERMISSIVE_ELICIT_SCHEMA,
   assertValidElicitSchema,
+  deriveJsonSchema,
 } from '../src/schema-helpers.js';
 
 describe('assertValidElicitSchema', () => {
@@ -87,5 +89,109 @@ describe('assertValidElicitSchema', () => {
       expect(e).toBeInstanceOf(TesseronError);
       expect((e as TesseronError).code).toBe(TesseronErrorCode.InvalidParams);
     }
+  });
+});
+
+/**
+ * Mock-driven tests for the validator-agnostic JSON Schema derivation. We
+ * don't pull in real Zod / TypeBox / ArkType here — the contract is duck-
+ * typed, so a mock that exposes the right method or `~standard.vendor` is
+ * a faithful substitute.
+ */
+describe('deriveJsonSchema', () => {
+  function withZodLike(): StandardSchemaV1<unknown> {
+    return {
+      '~standard': {
+        version: 1,
+        vendor: 'zod',
+        validate: () => ({ value: undefined }),
+      },
+      toJSONSchema: () => ({
+        type: 'object',
+        properties: {
+          name: { type: 'string' },
+          age: { type: 'integer' },
+        },
+        required: ['name'],
+      }),
+    } as never;
+  }
+
+  function withArkTypeLike(): StandardSchemaV1<unknown> {
+    return {
+      '~standard': {
+        version: 1,
+        vendor: 'arktype',
+        validate: () => ({ value: undefined }),
+      },
+      toJsonSchema: () => ({
+        type: 'object',
+        properties: { count: { type: 'integer' } },
+      }),
+    } as never;
+  }
+
+  function withTypeBoxLike(): StandardSchemaV1<unknown> {
+    return {
+      '~standard': {
+        version: 1,
+        vendor: 'typebox',
+        validate: () => ({ value: undefined }),
+      },
+      type: 'object',
+      properties: { value: { type: 'number' } },
+      required: ['value'],
+    } as never;
+  }
+
+  it('extracts JSON Schema from Zod-4-style instance method', () => {
+    const result = deriveJsonSchema(withZodLike()) as Record<string, unknown>;
+    expect(result?.['type']).toBe('object');
+    expect((result?.['properties'] as Record<string, unknown>)?.['age']).toEqual({
+      type: 'integer',
+    });
+  });
+
+  it('extracts JSON Schema from ArkType-style toJsonSchema', () => {
+    const result = deriveJsonSchema(withArkTypeLike()) as Record<string, unknown>;
+    expect((result?.['properties'] as Record<string, unknown>)?.['count']).toEqual({
+      type: 'integer',
+    });
+  });
+
+  it('returns the TypeBox schema as-is, with `~standard` stripped', () => {
+    const result = deriveJsonSchema(withTypeBoxLike()) as Record<string, unknown>;
+    expect(result).toBeTruthy();
+    expect(result['type']).toBe('object');
+    expect(result['~standard']).toBeUndefined();
+    expect(result['properties']).toEqual({ value: { type: 'number' } });
+  });
+
+  it('returns undefined for a validator with no exporter', () => {
+    const valibotLike: StandardSchemaV1<unknown> = {
+      '~standard': {
+        version: 1,
+        vendor: 'valibot',
+        validate: () => ({ value: undefined }),
+      },
+    };
+    expect(deriveJsonSchema(valibotLike)).toBeUndefined();
+  });
+
+  it('falls back to undefined when the exporter throws', () => {
+    const broken = {
+      '~standard': { version: 1, vendor: 'zod', validate: () => ({ value: undefined }) },
+      toJSONSchema: () => {
+        throw new Error('unsupported feature');
+      },
+    } as unknown as StandardSchemaV1<unknown>;
+    expect(deriveJsonSchema(broken)).toBeUndefined();
+  });
+
+  it('returns undefined for non-objects', () => {
+    expect(deriveJsonSchema(undefined)).toBeUndefined();
+    expect(deriveJsonSchema(null)).toBeUndefined();
+    expect(deriveJsonSchema('schema')).toBeUndefined();
+    expect(deriveJsonSchema(42)).toBeUndefined();
   });
 });

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -577,6 +577,47 @@ describe('Tesseron MCP integration', () => {
     });
   });
 
+  it('auto-derives JSON Schema from validators that expose toJSONSchema (Zod 4 path)', async () => {
+    // Mirrors the bug from issue #43: callers that follow the documented
+    // `.input(z.object(...))` idiom (without passing JSON Schema as the
+    // second argument) used to ship every action with a permissive
+    // `{type:'object', additionalProperties:true}` because no auto-derive
+    // existed in core. Here we verify the typed schema reaches the agent.
+    const zodLikeSchema = {
+      '~standard': {
+        version: 1,
+        vendor: 'zod',
+        validate: (value: unknown) => ({ value }),
+      },
+      toJSONSchema: () => ({
+        type: 'object',
+        properties: {
+          clipId: { type: 'string' },
+          volume: { type: 'number', minimum: 0, maximum: 1 },
+        },
+        required: ['clipId', 'volume'],
+      }),
+    } as never;
+    await setupAndClaim('schema_autoderive', (s) => {
+      s.action('set_audio_volume')
+        .input(zodLikeSchema)
+        .handler(() => ({ ok: true }));
+    });
+    const tools = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+    const tool = tools.tools.find((t) => t.name === 'schema_autoderive__set_audio_volume');
+    expect(tool).toBeTruthy();
+    expect(tool?.inputSchema).toMatchObject({
+      type: 'object',
+      properties: {
+        clipId: { type: 'string' },
+        volume: { type: 'number', minimum: 0, maximum: 1 },
+      },
+      required: ['clipId', 'volume'],
+    });
+    // The bug symptom — what the agent saw before the fix:
+    expect(tool?.inputSchema).not.toEqual({ type: 'object', additionalProperties: true });
+  });
+
   it('tesseron__invoke_action dispatches to the handler of a claimed session', async () => {
     await setupAndClaim('dispatch1', (s) => {
       s.action('echo')

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -18914,6 +18914,46 @@ var TransportClosedError = class extends TesseronError {
   }
 };
 
+// ../core/src/schema-helpers.ts
+function assertValidElicitSchema(schema) {
+  if (!schema || typeof schema !== "object") {
+    throw new TesseronError(
+      TesseronErrorCode.InvalidParams,
+      "elicit jsonSchema must be a JSON Schema object."
+    );
+  }
+  const s = schema;
+  if (s["type"] !== "object") {
+    throw new TesseronError(
+      TesseronErrorCode.InvalidParams,
+      `elicit jsonSchema must be { type: "object" } at the top level; got type="${String(
+        s["type"]
+      )}". Compose a flat object of primitives.`
+    );
+  }
+  if (s["oneOf"] || s["anyOf"] || s["allOf"] || s["not"]) {
+    throw new TesseronError(
+      TesseronErrorCode.InvalidParams,
+      "elicit jsonSchema must not use top-level oneOf/anyOf/allOf/not \u2014 MCP elicit clients require a single flat object shape."
+    );
+  }
+  const props = s["properties"] ?? {};
+  for (const [name, prop] of Object.entries(props)) {
+    if (!prop || typeof prop !== "object") continue;
+    const p = prop;
+    const type = Array.isArray(p["type"]) ? p["type"][0] : p["type"];
+    if (!type) continue;
+    const t = String(type);
+    if (!["string", "number", "integer", "boolean"].includes(t)) {
+      throw new TesseronError(
+        TesseronErrorCode.InvalidParams,
+        `elicit jsonSchema property "${name}" has unsupported type "${t}". MCP elicitation requires primitive-typed leaves (string, number, integer, boolean).`
+      );
+    }
+  }
+  return schema;
+}
+
 // ../core/src/dispatcher.ts
 var JsonRpcDispatcher = class {
   constructor(send) {
@@ -19046,46 +19086,6 @@ function toErrorPayload(error2) {
     return { code: TesseronErrorCode.InternalError, message: error2.message };
   }
   return { code: TesseronErrorCode.InternalError, message: String(error2) };
-}
-
-// ../core/src/schema-helpers.ts
-function assertValidElicitSchema(schema) {
-  if (!schema || typeof schema !== "object") {
-    throw new TesseronError(
-      TesseronErrorCode.InvalidParams,
-      "elicit jsonSchema must be a JSON Schema object."
-    );
-  }
-  const s = schema;
-  if (s["type"] !== "object") {
-    throw new TesseronError(
-      TesseronErrorCode.InvalidParams,
-      `elicit jsonSchema must be { type: "object" } at the top level; got type="${String(
-        s["type"]
-      )}". Compose a flat object of primitives.`
-    );
-  }
-  if (s["oneOf"] || s["anyOf"] || s["allOf"] || s["not"]) {
-    throw new TesseronError(
-      TesseronErrorCode.InvalidParams,
-      "elicit jsonSchema must not use top-level oneOf/anyOf/allOf/not \u2014 MCP elicit clients require a single flat object shape."
-    );
-  }
-  const props = s["properties"] ?? {};
-  for (const [name, prop] of Object.entries(props)) {
-    if (!prop || typeof prop !== "object") continue;
-    const p = prop;
-    const type = Array.isArray(p["type"]) ? p["type"][0] : p["type"];
-    if (!type) continue;
-    const t = String(type);
-    if (!["string", "number", "integer", "boolean"].includes(t)) {
-      throw new TesseronError(
-        TesseronErrorCode.InvalidParams,
-        `elicit jsonSchema property "${name}" has unsupported type "${t}". MCP elicitation requires primitive-typed leaves (string, number, integer, boolean).`
-      );
-    }
-  }
-  return schema;
 }
 
 // src/dialer.ts

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: ^4.21.0
         version: 4.22.1
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@types/express':
         specifier: ^4.17.0
@@ -95,12 +95,12 @@ importers:
         specifier: workspace:*
         version: link:../../packages/server
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.0.0
-        version: 1.29.0(zod@3.25.76)
+        version: 1.29.0(zod@4.3.6)
       '@tesseron/mcp':
         specifier: workspace:*
         version: link:../../packages/mcp
@@ -126,8 +126,8 @@ importers:
         specifier: ^18.3.0
         version: 18.3.1(react@18.3.1)
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@tesseron/vite':
         specifier: workspace:*
@@ -160,8 +160,8 @@ importers:
         specifier: ^5.0.0
         version: 5.55.4
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^4.0.0
@@ -188,8 +188,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/web
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@tesseron/vite':
         specifier: workspace:*
@@ -213,8 +213,8 @@ importers:
         specifier: ^3.5.0
         version: 3.5.32(typescript@5.9.3)
       zod:
-        specifier: ^3.24.0
-        version: 3.25.76
+        specifier: ^4.3.0
+        version: 4.3.6
     devDependencies:
       '@tesseron/vite':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

The documented `.input(z.object({...}))` idiom shipped every action with `{type: 'object', additionalProperties: true}` because `ActionBuilderImpl` only stored a JSON Schema when the caller passed one as the second argument — no auto-derivation existed in `@tesseron/core`. Agents got no field-type signal, which meant Claude sometimes JSON-encoded numeric arguments as strings; Zod's runtime then correctly rejected the call with `-32004 InputValidation`. The non-determinism (depends on whether the LLM happened to stringify a number) made it read as flaky agent behaviour instead of a manifest gap.

Closes #43.

## Fix

`ActionBuilder.input` / `.output` and `ResourceBuilder.output` now duck-type a JSON Schema exporter off the Standard Schema validator and use it when the caller didn't pass one. Detection silently falls through on failure, so the existing permissive default still applies for validators we can't introspect.

| Validator | Auto-derive | How |
|---|---|---|
| Zod 4+ | ✅ | `schema.toJSONSchema()` instance method |
| TypeBox | ✅ | schema object IS JSON Schema; `~standard` stripped |
| ArkType | ✅ | `schema.toJsonSchema()` instance method |
| Zod 3 | ❌ | use `zod-to-json-schema`, pass explicitly |
| Valibot | ❌ | use `@valibot/to-json-schema`, pass explicitly |
| Effect Schema | ❌ | use `@effect/schema/JSONSchema`, pass explicitly |

The new helper `deriveJsonSchema(schema)` lives in `packages/core/src/schema-helpers.ts`.

## Test plan

- [x] 7 mock-driven cases in `packages/core/test/schema-helpers.test.ts` covering Zod-4 path, ArkType path, TypeBox passthrough, Valibot fallback, exporter-throws fallback, non-object inputs.
- [x] End-to-end integration test in `packages/mcp/test/integration.test.ts` asserting that a Zod-shaped action's typed schema reaches the agent through `tools/list` (not the permissive fallback).
- [x] Full suite green: 28 core + 21 docs-mcp + 67 mcp (1 skipped UDS-on-Windows).
- [x] `pnpm lint` clean.
- [x] Plugin bundle rebuilt; CI's bundle-staleness guard verifies parity.

## Adjacent fixes

- `docs/src/content/docs/sdk/typescript/standard-schema.md` updated to be accurate about which validators auto-derive vs which need explicit JSON Schema.
- `examples/*/package.json` bumped from `zod@^3.24.0` to `zod@^4.3.0` so the example apps actually benefit from auto-derive (Zod 3 has no native exporter, so the examples themselves were silently shipping permissive schemas before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
