### PR TITLE
feat(react): surface tesseron/resume through useTesseronConnection

### DIFF
--- a/.changeset/react-resume-hook.md
+++ b/.changeset/react-resume-hook.md
@@ -1,0 +1,5 @@
+---
+'@tesseron/react': minor
+---
+
+`useTesseronConnection` now accepts a `resume` option that persists `sessionId` / `resumeToken` so the hook reattaches to the existing claimed session via `tesseron/resume` after a page refresh, HMR reload, or brief network drop instead of issuing a new claim code on every reconnect. Pass `resume: true` for the default `localStorage` backend, a `string` to override the storage key, or a `{ load, save, clear }` object for custom backends (Electron, OS keychain, iframe partition). Falls back to a fresh `tesseron/hello` automatically when the gateway rejects the resume with `ResumeFailed`.

--- a/docs/src/content/docs/protocol/resume.mdx
+++ b/docs/src/content/docs/protocol/resume.mdx
@@ -121,6 +121,8 @@ localStorage.setItem('tesseron:shop', JSON.stringify({
 
 Four lines. The SDK does not do this for you; `localStorage` is one answer among many. A desktop app might stash the pair in the OS keychain. A server process might put it in a file next to its config. An iframe-embedded app might have CSP reasons not to persist at all.
 
+If you're using [`@tesseron/react`](/sdk/typescript/react/), the `useTesseronConnection` hook bakes in this recipe behind a `resume` option - pass `resume: true` to persist via `localStorage` automatically, or hand it a `ResumeStorage` object for custom backends.
+
 ### Falling back when resume fails
 
 ```ts

--- a/docs/src/content/docs/sdk/typescript/react.md
+++ b/docs/src/content/docs/sdk/typescript/react.md
@@ -58,12 +58,41 @@ Options:
 
 ```ts
 interface UseTesseronConnectionOptions {
-  url?: string;     // defaults to `<location.origin>/@tesseron/ws` (served by @tesseron/vite)
+  url?: string;      // defaults to `<location.origin>/@tesseron/ws` (served by @tesseron/vite)
   enabled?: boolean; // gate the connect, e.g. only when logged in
+  resume?: boolean | string | ResumeStorage;
 }
 ```
 
 Only one component should call `useTesseronConnection` per client - it owns the WebSocket. Most apps put it at the root.
+
+### Surviving page refresh / HMR with `resume`
+
+By default, every mount of `useTesseronConnection` starts a brand-new session, which means a brand-new claim code on every page refresh. For most local-dev React apps that's exactly the wrong default - flip `resume: true` and the hook persists the `sessionId` / `resumeToken` from each handshake in `localStorage`, then sends `tesseron/resume` instead of `tesseron/hello` on the next mount. The agent stays paired across refreshes, HMR reloads, and brief network blips:
+
+```tsx
+const conn = useTesseronConnection({ resume: true });
+```
+
+The hook handles the backing protocol details for you - token rotation, the [`ResumeFailed`](/protocol/resume/) fallback to a fresh hello when the gateway zombie has expired, and clearing stale credentials. See [Session resume](/protocol/resume/) for the underlying primitives.
+
+The `resume` option accepts three forms:
+
+| Form | Behaviour |
+|---|---|
+| `true` | Persist in `localStorage` under `'tesseron:resume'`. |
+| `string` | Persist in `localStorage` under that exact key. Use a per-app value if you mount multiple `WebTesseronClient` instances on one page. |
+| `ResumeStorage` | Custom `{ load, save, clear }` callbacks (sync or async). Use this when `localStorage` is not available - Electron with strict CSP, an iframe partition, the OS keychain, etc. |
+
+```ts
+interface ResumeStorage {
+  load: () => ResumeCredentials | null | Promise<ResumeCredentials | null>;
+  save: (credentials: ResumeCredentials) => void | Promise<void>;
+  clear: () => void | Promise<void>;
+}
+```
+
+Resume tokens are one-shot - the gateway rotates the token on every successful resume, so the hook always overwrites the stored value with the freshest token from each handshake. After a successful resume `welcome.claimCode` is `undefined`, since the session is already claimed.
 
 ## `useTesseronAction`
 

--- a/docs/src/content/docs/sdk/typescript/react.md
+++ b/docs/src/content/docs/sdk/typescript/react.md
@@ -51,8 +51,15 @@ interface TesseronConnectionState {
   welcome?: WelcomeResult;
   claimCode?: string;
   error?: Error;
+  resumeStatus?: 'none' | 'resumed' | 'failed';
 }
 ```
+
+`resumeStatus` is set when `status === 'open'`:
+
+- `'none'` - no resume was attempted (no stored creds, or `resume` disabled).
+- `'resumed'` - `tesseron/resume` succeeded; the prior session was reattached.
+- `'failed'` - resume was attempted but the gateway rejected it; the hook fell back to a fresh `tesseron/hello` and persisted the new credentials. Useful for telemetry, and for UIs that want to show "your previous session expired" instead of silently switching to a new claim code.
 
 Options:
 
@@ -68,13 +75,13 @@ Only one component should call `useTesseronConnection` per client - it owns the 
 
 ### Surviving page refresh / HMR with `resume`
 
-By default, every mount of `useTesseronConnection` starts a brand-new session, which means a brand-new claim code on every page refresh. For most local-dev React apps that's exactly the wrong default - flip `resume: true` and the hook persists the `sessionId` / `resumeToken` from each handshake in `localStorage`, then sends `tesseron/resume` instead of `tesseron/hello` on the next mount. The agent stays paired across refreshes, HMR reloads, and brief network blips:
+By default, every page load of an app that uses `useTesseronConnection` starts a brand-new session, which means a brand-new claim code on every refresh. For most local-dev React apps that's exactly the wrong default - flip `resume: true` and the hook persists the `sessionId` / `resumeToken` from each handshake in `localStorage`, then sends `tesseron/resume` instead of `tesseron/hello` on the next page load. The agent stays paired across refreshes, HMR reloads, and brief network blips:
 
 ```tsx
 const conn = useTesseronConnection({ resume: true });
 ```
 
-The hook handles the backing protocol details for you - token rotation, the [`ResumeFailed`](/protocol/resume/) fallback to a fresh hello when the gateway zombie has expired, and clearing stale credentials. See [Session resume](/protocol/resume/) for the underlying primitives.
+The hook handles the backing protocol details for you - token rotation, the [`ResumeFailed`](/protocol/resume/) fallback to a fresh hello when the gateway zombie has expired, and clearing stale credentials. Inspect `conn.resumeStatus` to tell whether the current session was resumed (`'resumed'`), is a fallback after a rejected resume (`'failed'`), or was a plain hello (`'none'`). See [Session resume](/protocol/resume/) for the underlying primitives.
 
 The `resume` option accepts three forms:
 
@@ -86,13 +93,21 @@ The `resume` option accepts three forms:
 
 ```ts
 interface ResumeStorage {
-  load: () => ResumeCredentials | null | Promise<ResumeCredentials | null>;
+  load: () =>
+    | ResumeCredentials
+    | null
+    | undefined
+    | Promise<ResumeCredentials | null | undefined>;
   save: (credentials: ResumeCredentials) => void | Promise<void>;
   clear: () => void | Promise<void>;
 }
 ```
 
-Resume tokens are one-shot - the gateway rotates the token on every successful resume, so the hook always overwrites the stored value with the freshest token from each handshake. After a successful resume `welcome.claimCode` is `undefined`, since the session is already claimed.
+Resume tokens are one-shot - the gateway rotates the token on every successful handshake (hello or resume), so the hook always overwrites the stored value with the freshest token. After a successful resume `welcome.claimCode` is `undefined`, since the session is already claimed.
+
+Resume re-establishes the session, **not** its `resources/subscribe` bindings. `useTesseronResource` re-registers subscriptions naturally on remount, so apps using the provided hooks see no behavioural difference; if you wire subscriptions by hand against the lower-level client, re-subscribe after each connect.
+
+Storage failures (private mode, quota exceeded, a throwing custom backend) are non-fatal: the hook treats them as a no-op for save/clear, and as "no saved session" for load. The connection itself is never failed by storage problems.
 
 ## `useTesseronAction`
 

--- a/examples/react-todo/src/app.tsx
+++ b/examples/react-todo/src/app.tsx
@@ -25,7 +25,10 @@ export function App(): JSX.Element {
   const [input, setInput] = useState('');
   const [lastLog, setLastLog] = useState<string>('');
 
-  const connection = useTesseronConnection();
+  // `resume: true` persists `{ sessionId, resumeToken }` in localStorage so a
+  // page refresh / HMR reload reattaches to the same claimed session via
+  // `tesseron/resume` instead of issuing a fresh claim code each time.
+  const connection = useTesseronConnection({ resume: true });
 
   // Refs to read latest state from handlers that close over stale values.
   const todosRef = useRef(todos);

--- a/packages/core/src/builder-impl.ts
+++ b/packages/core/src/builder-impl.ts
@@ -19,7 +19,7 @@ export interface BuilderRegistry {
   registerResource(resource: ResourceDefinition): void;
 }
 
-export interface ActionBuilderInit<I, O> {
+export interface ActionBuilderInit {
   inputJsonSchema?: unknown;
   outputJsonSchema?: unknown;
 }

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -16,7 +16,6 @@ import {
   type ResourceManifestEntry,
   SamplingNotAvailableError,
   TesseronError,
-  TesseronErrorCode,
   type TesseronStructuredError,
 } from '@tesseron/core';
 import { assertValidElicitSchema } from '@tesseron/core/internal';

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -622,7 +622,7 @@ describe('Tesseron MCP integration', () => {
     await setupAndClaim('dispatch1', (s) => {
       s.action('echo')
         .describe('echo the text back')
-        .handler(({ text }: { text: string }) => ({ said: text }));
+        .handler((input) => ({ said: (input as { text: string }).text }));
     });
     const result = await callTool('tesseron__invoke_action', {
       app_id: 'dispatch1',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,7 @@
   "scripts": {
     "build": "tsup",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
@@ -43,7 +44,13 @@
     "@tesseron/web": "workspace:*"
   },
   "devDependencies": {
-    "@types/react": "^18.3.0"
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "^18.3.0",
+    "@types/react-dom": "^18.3.0",
+    "jsdom": "^25.0.1",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "vitest": "^2.1.0"
   },
   "peerDependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,9 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import {
   type ActionAnnotations,
   type ActionContext,
+  type ResumeCredentials,
+  TesseronError,
+  TesseronErrorCode,
   type WebTesseronClient,
   type WelcomeResult,
   tesseron,
@@ -110,21 +113,109 @@ export function useTesseronResource<T = unknown>(
   }, [name, client]);
 }
 
+/**
+ * Persistence backend for resume credentials. Implementations may be sync or
+ * async; the hook awaits each call. Returning `null` from `load` means "no
+ * stored session, do a fresh hello."
+ */
+export interface ResumeStorage {
+  load: () => ResumeCredentials | null | Promise<ResumeCredentials | null>;
+  save: (credentials: ResumeCredentials) => void | Promise<void>;
+  clear: () => void | Promise<void>;
+}
+
 /** Options for {@link useTesseronConnection}. */
 export interface UseTesseronConnectionOptions {
   /** Gateway URL; defaults to `DEFAULT_GATEWAY_URL` (the local bridge). */
   url?: string;
   /** Set to `false` to skip connecting (useful for gating behind auth). Defaults to `true`. */
   enabled?: boolean;
+  /**
+   * Persist `{ sessionId, resumeToken }` so the hook can rejoin an existing
+   * claimed session via `tesseron/resume` after the transport drops (page
+   * refresh, HMR reload, brief network blip) instead of issuing a new claim
+   * code. See [protocol/resume](https://tesseron.dev/protocol/resume/).
+   *
+   * - `false` / omitted (default): no persistence. Every connect is a fresh hello.
+   * - `true`: persist in `localStorage` under `'tesseron:resume'`.
+   * - `string`: persist in `localStorage` under that exact key. Use a per-app
+   *   value when you have multiple `WebTesseronClient` instances per page.
+   * - `ResumeStorage`: custom `{ load, save, clear }` callbacks. Useful when
+   *   `localStorage` is not available (Electron renderer with strict CSP, an
+   *   iframe partition, custom storage).
+   *
+   * On a `TesseronError(ResumeFailed)` (TTL expired, token rotated by another
+   * tab, gateway restarted), the hook clears the stored credentials and falls
+   * back to a fresh `tesseron/hello`. Resume tokens are one-shot - the hook
+   * always overwrites the stored value with the freshest token from each
+   * successful handshake.
+   */
+  resume?: boolean | string | ResumeStorage;
 }
 
 /** Reactive connection state returned from {@link useTesseronConnection}. */
 export interface TesseronConnectionState {
   status: 'idle' | 'connecting' | 'open' | 'error' | 'closed';
   welcome?: WelcomeResult;
-  /** Claim code to display in the UI so the user can paste it into their MCP client. */
+  /**
+   * Claim code to display in the UI. Present only on a fresh `tesseron/hello`;
+   * absent after a successful resume because the session was already claimed.
+   */
   claimCode?: string;
   error?: Error;
+}
+
+const DEFAULT_RESUME_STORAGE_KEY = 'tesseron:resume';
+
+function localStorageResumeBackend(key: string): ResumeStorage {
+  return {
+    load: () => {
+      // SSR: no window, nothing to load.
+      if (typeof window === 'undefined') return null;
+      try {
+        const raw = window.localStorage.getItem(key);
+        if (!raw) return null;
+        const parsed: unknown = JSON.parse(raw);
+        if (parsed && typeof parsed === 'object') {
+          const obj = parsed as Record<string, unknown>;
+          if (typeof obj['sessionId'] === 'string' && typeof obj['resumeToken'] === 'string') {
+            return { sessionId: obj['sessionId'], resumeToken: obj['resumeToken'] };
+          }
+        }
+        return null;
+      } catch {
+        // Corrupted entry or localStorage access denied (private mode, etc.)
+        // - treat as no saved session and let the hook do a fresh hello.
+        return null;
+      }
+    },
+    save: (creds) => {
+      if (typeof window === 'undefined') return;
+      try {
+        window.localStorage.setItem(key, JSON.stringify(creds));
+      } catch {
+        // Quota exceeded or storage disabled - non-fatal; the session still
+        // works for this page load, it just won't survive the next refresh.
+      }
+    },
+    clear: () => {
+      if (typeof window === 'undefined') return;
+      try {
+        window.localStorage.removeItem(key);
+      } catch {
+        // Same as save: best-effort cleanup.
+      }
+    },
+  };
+}
+
+function resolveResumeStorage(
+  option: UseTesseronConnectionOptions['resume'],
+): ResumeStorage | null {
+  if (!option) return null;
+  if (option === true) return localStorageResumeBackend(DEFAULT_RESUME_STORAGE_KEY);
+  if (typeof option === 'string') return localStorageResumeBackend(option);
+  return option;
 }
 
 /**
@@ -132,6 +223,9 @@ export interface TesseronConnectionState {
  * the connection status (and claim code) for rendering. Register your actions
  * and resources with {@link useTesseronAction} / {@link useTesseronResource}
  * before this hook runs so they appear in the initial `tesseron/hello` manifest.
+ *
+ * Pass `options.resume` to survive page refresh / HMR reloads without losing
+ * the claimed session - see {@link UseTesseronConnectionOptions.resume}.
  */
 export function useTesseronConnection(
   options: UseTesseronConnectionOptions = {},
@@ -140,21 +234,63 @@ export function useTesseronConnection(
   const [state, setState] = useState<TesseronConnectionState>({ status: 'idle' });
   const enabled = options.enabled ?? true;
   const url = options.url;
+  const resumeRef = useRef(options.resume);
+  resumeRef.current = options.resume;
 
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
     setState({ status: 'connecting' });
-    client
-      .connect(url)
-      .then((welcome) => {
+
+    const storage = resolveResumeStorage(resumeRef.current);
+
+    void (async () => {
+      try {
+        let saved: ResumeCredentials | null = null;
+        if (storage) {
+          try {
+            saved = await storage.load();
+          } catch {
+            // A throwing custom backend shouldn't break the connection; fall
+            // through to a fresh hello.
+            saved = null;
+          }
+        }
+
+        let welcome: WelcomeResult;
+        try {
+          welcome = await client.connect(url, saved ? { resume: saved } : undefined);
+        } catch (err) {
+          if (
+            saved &&
+            err instanceof TesseronError &&
+            err.code === TesseronErrorCode.ResumeFailed
+          ) {
+            // Stored creds are stale (TTL elapsed, gateway restarted, token
+            // already rotated by another tab). Clear and start fresh.
+            await storage?.clear();
+            if (cancelled) return;
+            welcome = await client.connect(url);
+          } else {
+            throw err;
+          }
+        }
+
+        if (cancelled) return;
+        if (storage && welcome.resumeToken) {
+          await storage.save({
+            sessionId: welcome.sessionId,
+            resumeToken: welcome.resumeToken,
+          });
+        }
         if (cancelled) return;
         setState({ status: 'open', welcome, claimCode: welcome.claimCode });
-      })
-      .catch((error: Error) => {
+      } catch (error) {
         if (cancelled) return;
-        setState({ status: 'error', error });
-      });
+        setState({ status: 'error', error: error as Error });
+      }
+    })();
+
     return () => {
       cancelled = true;
     };

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -115,11 +115,14 @@ export function useTesseronResource<T = unknown>(
 
 /**
  * Persistence backend for resume credentials. Implementations may be sync or
- * async; the hook awaits each call. Returning `null` from `load` means "no
- * stored session, do a fresh hello."
+ * async; the hook awaits each call. Returning `null` or `undefined` from
+ * `load` means "no stored session, do a fresh hello." Throws from any method
+ * are non-fatal: the hook treats them like an empty backend (load) or a
+ * silent no-op (save/clear) so storage problems can't fail-close the
+ * connection.
  */
 export interface ResumeStorage {
-  load: () => ResumeCredentials | null | Promise<ResumeCredentials | null>;
+  load: () => ResumeCredentials | null | undefined | Promise<ResumeCredentials | null | undefined>;
   save: (credentials: ResumeCredentials) => void | Promise<void>;
   clear: () => void | Promise<void>;
 }
@@ -145,13 +148,33 @@ export interface UseTesseronConnectionOptions {
    *   iframe partition, custom storage).
    *
    * On a `TesseronError(ResumeFailed)` (TTL expired, token rotated by another
-   * tab, gateway restarted), the hook clears the stored credentials and falls
-   * back to a fresh `tesseron/hello`. Resume tokens are one-shot - the hook
-   * always overwrites the stored value with the freshest token from each
-   * successful handshake.
+   * tab, gateway restarted, session was never claimed), the hook clears the
+   * stored credentials, falls back to a fresh `tesseron/hello`, and surfaces
+   * `resumeStatus: 'failed'` in {@link TesseronConnectionState} so the UI can
+   * react. Resume tokens rotate on every successful handshake (hello or
+   * resume), and the hook always overwrites the stored value with the
+   * freshest token.
+   *
+   * Note: resume only re-establishes the session, not its
+   * `resources/subscribe` bindings. The {@link useTesseronResource} hook
+   * re-registers subscriptions naturally on remount, so apps using the
+   * provided hooks see no behavioral difference; if you wire subscriptions
+   * by hand against the lower-level client, you must re-subscribe after
+   * each connect.
    */
   resume?: boolean | string | ResumeStorage;
 }
+
+/**
+ * Outcome of the resume attempt that produced the current connection.
+ * - `'none'` - no resume was attempted (no stored creds or `resume` disabled).
+ * - `'resumed'` - `tesseron/resume` succeeded; the session was reattached.
+ * - `'failed'` - resume was attempted but the gateway rejected it; the hook
+ *   transparently fell back to a fresh `tesseron/hello`. Useful for telemetry
+ *   and for UIs that want to say "your previous session expired" rather than
+ *   silently displaying a new claim code.
+ */
+export type TesseronResumeStatus = 'none' | 'resumed' | 'failed';
 
 /** Reactive connection state returned from {@link useTesseronConnection}. */
 export interface TesseronConnectionState {
@@ -163,6 +186,12 @@ export interface TesseronConnectionState {
    */
   claimCode?: string;
   error?: Error;
+  /**
+   * Set when `status === 'open'`. Indicates whether the current session is a
+   * resumed one, a fresh fallback after a failed resume, or a plain hello.
+   * See {@link TesseronResumeStatus}.
+   */
+  resumeStatus?: TesseronResumeStatus;
 }
 
 const DEFAULT_RESUME_STORAGE_KEY = 'tesseron:resume';
@@ -244,52 +273,72 @@ export function useTesseronConnection(
 
     const storage = resolveResumeStorage(resumeRef.current);
 
-    void (async () => {
-      try {
-        let saved: ResumeCredentials | null = null;
-        if (storage) {
-          try {
-            saved = await storage.load();
-          } catch {
-            // A throwing custom backend shouldn't break the connection; fall
-            // through to a fresh hello.
-            saved = null;
-          }
-        }
-
-        let welcome: WelcomeResult;
+    const run = async (): Promise<void> => {
+      let saved: ResumeCredentials | null = null;
+      if (storage) {
         try {
-          welcome = await client.connect(url, saved ? { resume: saved } : undefined);
-        } catch (err) {
-          if (
-            saved &&
-            err instanceof TesseronError &&
-            err.code === TesseronErrorCode.ResumeFailed
-          ) {
-            // Stored creds are stale (TTL elapsed, gateway restarted, token
-            // already rotated by another tab). Clear and start fresh.
-            await storage?.clear();
-            if (cancelled) return;
-            welcome = await client.connect(url);
-          } else {
-            throw err;
-          }
+          saved = (await storage.load()) ?? null;
+        } catch {
+          // A throwing custom backend shouldn't break the connection; treat
+          // as no saved creds and proceed to a fresh hello.
+          saved = null;
         }
+      }
 
-        if (cancelled) return;
-        if (storage && welcome.resumeToken) {
+      let welcome: WelcomeResult;
+      let resumeStatus: TesseronResumeStatus = 'none';
+      try {
+        welcome = await client.connect(url, saved ? { resume: saved } : undefined);
+        if (saved) resumeStatus = 'resumed';
+      } catch (err) {
+        if (saved && err instanceof TesseronError && err.code === TesseronErrorCode.ResumeFailed) {
+          // Stored creds are stale (TTL elapsed, gateway restarted, session
+          // never claimed, token already rotated by another tab). Best-effort
+          // clear and start fresh; clear failures must not block the fallback.
+          if (storage) {
+            try {
+              await storage.clear();
+            } catch {
+              // Cleanup is non-fatal - the next successful save() overwrites
+              // the stale entry anyway.
+            }
+          }
+          if (cancelled) return;
+          welcome = await client.connect(url);
+          resumeStatus = 'failed';
+        } else {
+          throw err;
+        }
+      }
+
+      if (cancelled) return;
+      if (storage && welcome.resumeToken) {
+        try {
           await storage.save({
             sessionId: welcome.sessionId,
             resumeToken: welcome.resumeToken,
           });
+        } catch {
+          // Persistence failure is non-fatal - the live session still works
+          // for this page load; it just won't survive the next refresh.
         }
-        if (cancelled) return;
-        setState({ status: 'open', welcome, claimCode: welcome.claimCode });
-      } catch (error) {
-        if (cancelled) return;
-        setState({ status: 'error', error: error as Error });
       }
-    })();
+      if (cancelled) return;
+      setState({
+        status: 'open',
+        welcome,
+        claimCode: welcome.claimCode,
+        resumeStatus,
+      });
+    };
+
+    run().catch((error: unknown) => {
+      if (cancelled) return;
+      setState({
+        status: 'error',
+        error: error instanceof Error ? error : new Error(String(error)),
+      });
+    });
 
     return () => {
       cancelled = true;

--- a/packages/react/test/use-tesseron-connection.test.tsx
+++ b/packages/react/test/use-tesseron-connection.test.tsx
@@ -107,6 +107,7 @@ describe('useTesseronConnection - default behaviour (no resume)', () => {
     expect(state.status).toBe('open');
     expect(state.welcome).toEqual(welcome);
     expect(state.claimCode).toBe('AAA-BBB');
+    expect(state.resumeStatus).toBe('none');
     expect(calls).toHaveLength(1);
     expect(calls[0]).toEqual({ url: 'ws://x/y', options: undefined });
     expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
@@ -171,6 +172,7 @@ describe('useTesseronConnection - resume: true (localStorage default)', () => {
     const state = await renderUntilOpenOrError({ resume: true }, client);
 
     expect(state.status).toBe('open');
+    expect(state.resumeStatus).toBe('resumed');
     expect(calls).toHaveLength(1);
     expect(calls[0]?.options).toEqual({
       resume: { sessionId: 's1', resumeToken: 'tok-old' },
@@ -197,6 +199,7 @@ describe('useTesseronConnection - resume: true (localStorage default)', () => {
     const state = await renderUntilOpenOrError({ resume: true }, client);
 
     expect(state.status).toBe('open');
+    expect(state.resumeStatus).toBe('failed');
     expect(state.welcome?.sessionId).toBe('s-new');
     expect(calls).toHaveLength(2);
     expect(calls[0]?.options?.resume).toEqual({
@@ -322,5 +325,59 @@ describe('useTesseronConnection - resume: ResumeStorage (custom backend)', () =>
     expect(state.status).toBe('open');
     expect(calls[0]?.options).toBeUndefined();
     expect(backend.save).toHaveBeenCalled();
+  });
+
+  it('treats a load() returning undefined as no saved creds', async () => {
+    const backend: ResumeStorage = {
+      load: vi.fn(() => undefined),
+      save: vi.fn(),
+      clear: vi.fn(),
+    };
+    const fresh = makeWelcome({ resumeToken: 'tok-A' });
+    const { client, calls } = makeFakeClient([fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(state.status).toBe('open');
+    expect(calls[0]?.options).toBeUndefined();
+  });
+
+  it('does not fail the connection when save() throws', async () => {
+    const backend: ResumeStorage = {
+      load: vi.fn(() => null),
+      save: vi.fn(() => {
+        throw new Error('quota exceeded');
+      }),
+      clear: vi.fn(),
+    };
+    const fresh = makeWelcome({ resumeToken: 'tok-A' });
+    const { client } = makeFakeClient([fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(state.status).toBe('open');
+    expect(state.welcome).toEqual(fresh);
+    expect(backend.save).toHaveBeenCalled();
+  });
+
+  it('still falls back to a fresh hello when clear() throws during ResumeFailed recovery', async () => {
+    const backend: ResumeStorage = {
+      load: vi.fn(() => ({ sessionId: 's-stale', resumeToken: 'tok-stale' })),
+      save: vi.fn(),
+      clear: vi.fn(() => {
+        throw new Error('cannot clear');
+      }),
+    };
+    const resumeFailed = new TesseronError(TesseronErrorCode.ResumeFailed, 'token mismatch');
+    const fresh = makeWelcome({ sessionId: 's-new', resumeToken: 'tok-new' });
+    const { client, calls } = makeFakeClient([resumeFailed, fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(state.status).toBe('open');
+    expect(state.resumeStatus).toBe('failed');
+    expect(state.welcome?.sessionId).toBe('s-new');
+    expect(calls).toHaveLength(2);
+    expect(backend.clear).toHaveBeenCalled();
   });
 });

--- a/packages/react/test/use-tesseron-connection.test.tsx
+++ b/packages/react/test/use-tesseron-connection.test.tsx
@@ -1,0 +1,326 @@
+import {
+  type ConnectOptions,
+  type ResumeCredentials,
+  TesseronError,
+  TesseronErrorCode,
+  type WebTesseronClient,
+  type WelcomeResult,
+} from '@tesseron/web';
+import { act, render, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type ResumeStorage,
+  type TesseronConnectionState,
+  type UseTesseronConnectionOptions,
+  useTesseronConnection,
+} from '../src/index.js';
+
+const STORAGE_KEY = 'tesseron:resume';
+
+function makeWelcome(overrides: Partial<WelcomeResult> = {}): WelcomeResult {
+  return {
+    sessionId: 'sess-1',
+    protocolVersion: '1.0.0',
+    capabilities: {
+      streaming: true,
+      subscriptions: true,
+      sampling: false,
+      elicitation: false,
+    },
+    agent: { id: 'test-agent', name: 'Test Agent' },
+    claimCode: 'AAA-BBB',
+    resumeToken: 'tok-fresh',
+    ...overrides,
+  };
+}
+
+interface ConnectCall {
+  url?: string;
+  options?: ConnectOptions;
+}
+
+function makeFakeClient(plan: Array<WelcomeResult | TesseronError | Error>): {
+  client: WebTesseronClient;
+  calls: ConnectCall[];
+} {
+  const calls: ConnectCall[] = [];
+  let i = 0;
+  const client = {
+    connect: vi.fn(async (url?: string, options?: ConnectOptions) => {
+      calls.push({ url, options });
+      const next = plan[i++];
+      if (!next) throw new Error('no more planned responses');
+      if (next instanceof Error) throw next;
+      return next;
+    }),
+  } as unknown as WebTesseronClient;
+  return { client, calls };
+}
+
+function ConnectionProbe(props: {
+  options?: UseTesseronConnectionOptions;
+  client: WebTesseronClient;
+  onState: (state: TesseronConnectionState) => void;
+}): null {
+  const state = useTesseronConnection(props.options, props.client);
+  props.onState(state);
+  return null;
+}
+
+async function renderUntilOpenOrError(
+  options: UseTesseronConnectionOptions | undefined,
+  client: WebTesseronClient,
+): Promise<TesseronConnectionState> {
+  let latest: TesseronConnectionState = { status: 'idle' };
+  await act(async () => {
+    render(
+      <ConnectionProbe
+        options={options}
+        client={client}
+        onState={(s) => {
+          latest = s;
+        }}
+      />,
+    );
+  });
+  await waitFor(() => {
+    expect(['open', 'error']).toContain(latest.status);
+  });
+  return latest;
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useTesseronConnection - default behaviour (no resume)', () => {
+  it('calls connect(url) with no second argument', async () => {
+    const welcome = makeWelcome();
+    const { client, calls } = makeFakeClient([welcome]);
+
+    const state = await renderUntilOpenOrError({ url: 'ws://x/y' }, client);
+
+    expect(state.status).toBe('open');
+    expect(state.welcome).toEqual(welcome);
+    expect(state.claimCode).toBe('AAA-BBB');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({ url: 'ws://x/y', options: undefined });
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it('skips connecting when enabled is false', async () => {
+    const { client, calls } = makeFakeClient([]);
+
+    let latest: TesseronConnectionState = { status: 'idle' };
+    await act(async () => {
+      render(
+        <ConnectionProbe
+          options={{ enabled: false }}
+          client={client}
+          onState={(s) => {
+            latest = s;
+          }}
+        />,
+      );
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(latest.status).toBe('idle');
+  });
+
+  it('surfaces non-resume errors as status:error', async () => {
+    const err = new Error('gateway unavailable');
+    const { client } = makeFakeClient([err]);
+
+    const state = await renderUntilOpenOrError(undefined, client);
+
+    expect(state.status).toBe('error');
+    expect(state.error).toBe(err);
+  });
+});
+
+describe('useTesseronConnection - resume: true (localStorage default)', () => {
+  it('persists sessionId/resumeToken after a successful fresh hello', async () => {
+    const welcome = makeWelcome({ sessionId: 's1', resumeToken: 'tok-A' });
+    const { client, calls } = makeFakeClient([welcome]);
+
+    await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(calls[0]?.options).toBeUndefined();
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+    expect(stored).not.toBeNull();
+    expect(JSON.parse(stored!)).toEqual({ sessionId: 's1', resumeToken: 'tok-A' });
+  });
+
+  it('sends tesseron/resume when stored credentials exist', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ sessionId: 's1', resumeToken: 'tok-old' }),
+    );
+    const resumed = makeWelcome({
+      sessionId: 's1',
+      resumeToken: 'tok-rotated',
+      claimCode: undefined,
+    });
+    const { client, calls } = makeFakeClient([resumed]);
+
+    const state = await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(state.status).toBe('open');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.options).toEqual({
+      resume: { sessionId: 's1', resumeToken: 'tok-old' },
+    });
+    expect(state.claimCode).toBeUndefined();
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+      sessionId: 's1',
+      resumeToken: 'tok-rotated',
+    });
+  });
+
+  it('falls back to fresh hello on ResumeFailed and clears storage of stale creds', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ sessionId: 's-stale', resumeToken: 'tok-stale' }),
+    );
+    const resumeFailed = new TesseronError(
+      TesseronErrorCode.ResumeFailed,
+      'No resumable session "s-stale".',
+    );
+    const fresh = makeWelcome({ sessionId: 's-new', resumeToken: 'tok-new' });
+    const { client, calls } = makeFakeClient([resumeFailed, fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(state.status).toBe('open');
+    expect(state.welcome?.sessionId).toBe('s-new');
+    expect(calls).toHaveLength(2);
+    expect(calls[0]?.options?.resume).toEqual({
+      sessionId: 's-stale',
+      resumeToken: 'tok-stale',
+    });
+    expect(calls[1]?.options).toBeUndefined();
+    expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+      sessionId: 's-new',
+      resumeToken: 'tok-new',
+    });
+  });
+
+  it('does not fall back when a non-resume error fires', async () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ sessionId: 's1', resumeToken: 'tok-A' }),
+    );
+    const transportErr = new Error('socket closed');
+    const { client, calls } = makeFakeClient([transportErr]);
+
+    const state = await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(state.status).toBe('error');
+    expect(state.error).toBe(transportErr);
+    expect(calls).toHaveLength(1);
+    // Storage retained for the next reconnect attempt.
+    expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull();
+  });
+
+  it('ignores corrupted localStorage entries and starts fresh', async () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not json');
+    const fresh = makeWelcome({ resumeToken: 'tok-A' });
+    const { client, calls } = makeFakeClient([fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(state.status).toBe('open');
+    expect(calls[0]?.options).toBeUndefined();
+  });
+
+  it('skips persistence when the gateway returns no resumeToken', async () => {
+    const oldGateway = makeWelcome({ resumeToken: undefined });
+    const { client } = makeFakeClient([oldGateway]);
+
+    await renderUntilOpenOrError({ resume: true }, client);
+
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('useTesseronConnection - resume: <string> (custom storage key)', () => {
+  it('uses the provided key', async () => {
+    const fresh = makeWelcome({ resumeToken: 'tok-A' });
+    const { client } = makeFakeClient([fresh]);
+
+    await renderUntilOpenOrError({ resume: 'tesseron:my-app' }, client);
+
+    expect(window.localStorage.getItem('tesseron:my-app')).not.toBeNull();
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe('useTesseronConnection - resume: ResumeStorage (custom backend)', () => {
+  it('routes load/save through the provided callbacks', async () => {
+    const stored: { value: ResumeCredentials | null } = { value: null };
+    const backend: ResumeStorage = {
+      load: vi.fn(() => stored.value),
+      save: vi.fn((c: ResumeCredentials) => {
+        stored.value = c;
+      }),
+      clear: vi.fn(() => {
+        stored.value = null;
+      }),
+    };
+    const fresh = makeWelcome({ sessionId: 's1', resumeToken: 'tok-A' });
+    const { client } = makeFakeClient([fresh]);
+
+    await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(backend.load).toHaveBeenCalledTimes(1);
+    expect(backend.save).toHaveBeenCalledWith({ sessionId: 's1', resumeToken: 'tok-A' });
+    expect(stored.value).toEqual({ sessionId: 's1', resumeToken: 'tok-A' });
+  });
+
+  it('clears the backend when ResumeFailed fires', async () => {
+    const stored: { value: ResumeCredentials | null } = {
+      value: { sessionId: 's-stale', resumeToken: 'tok-stale' },
+    };
+    const backend: ResumeStorage = {
+      load: vi.fn(() => stored.value),
+      save: vi.fn((c: ResumeCredentials) => {
+        stored.value = c;
+      }),
+      clear: vi.fn(() => {
+        stored.value = null;
+      }),
+    };
+    const resumeFailed = new TesseronError(TesseronErrorCode.ResumeFailed, 'token mismatch');
+    const fresh = makeWelcome({ sessionId: 's-new', resumeToken: 'tok-new' });
+    const { client } = makeFakeClient([resumeFailed, fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(state.status).toBe('open');
+    expect(backend.clear).toHaveBeenCalled();
+    expect(stored.value).toEqual({ sessionId: 's-new', resumeToken: 'tok-new' });
+  });
+
+  it('treats a throwing load() as no saved creds', async () => {
+    const backend: ResumeStorage = {
+      load: vi.fn(() => {
+        throw new Error('keychain locked');
+      }),
+      save: vi.fn(),
+      clear: vi.fn(),
+    };
+    const fresh = makeWelcome({ resumeToken: 'tok-A' });
+    const { client, calls } = makeFakeClient([fresh]);
+
+    const state = await renderUntilOpenOrError({ resume: backend }, client);
+
+    expect(state.status).toBe('open');
+    expect(calls[0]?.options).toBeUndefined();
+    expect(backend.save).toHaveBeenCalled();
+  });
+});

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,7 +243,7 @@ importers:
     devDependencies:
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@24.12.2)
+        version: 2.1.9(@types/node@24.12.2)(jsdom@25.0.1)
 
   packages/create-tesseron:
     devDependencies:
@@ -283,7 +283,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/mcp:
     dependencies:
@@ -317,7 +317,7 @@ importers:
         version: 4.21.0
       vitest:
         specifier: ^2.1.0
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/react:
     dependencies:
@@ -330,13 +330,28 @@ importers:
       '@tesseron/web':
         specifier: workspace:*
         version: link:../web
-      react:
-        specifier: '>=18'
-        version: 19.2.5
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.0
         version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.0
+        version: 18.3.7(@types/react@18.3.28)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      react:
+        specifier: ^18.3.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.0
+        version: 18.3.1(react@18.3.1)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@24.12.2)(jsdom@25.0.1)
 
   packages/server:
     dependencies:
@@ -418,6 +433,9 @@ packages:
 
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@astrojs/check@0.9.8':
     resolution: {integrity: sha512-LDng8446QLS5ToKjRHd3bgUdirvemVVExV7nRyJfW2wV36xuv7vDxwy5NWN9zqeSEDgg0Tv84sP+T3yEq+Zlkw==}
@@ -709,6 +727,34 @@ packages:
 
   '@chevrotain/utils@12.0.0':
     resolution: {integrity: sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
@@ -1768,6 +1814,25 @@ packages:
       svelte: ^5.0.0-next.96 || ^5.0.0
       vite: ^5.0.0
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
     cpu: [x64]
@@ -1797,6 +1862,9 @@ packages:
     resolution: {integrity: sha512-1XUUyWW0W6FTSqGEhU8RHVqb2wP1SPkr7hIvBlMEwH9jr+sJQK5kqeosLJ/QaUv4ecSAd1ZhIrLoW7qslAzT4A==}
     cpu: [arm64]
     os: [win32]
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2148,6 +2216,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
     peerDependencies:
@@ -2189,6 +2261,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -2208,6 +2284,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   aria-query@5.3.1:
     resolution: {integrity: sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g==}
@@ -2244,6 +2323,9 @@ packages:
     resolution: {integrity: sha512-m4VWilWZ+Xt6NPoYzC4CgGZim/zQUO7WFL0RHCH0AiEavF1153iC3+me2atDvXpf/yX4PyGUeD8wZLq1cirT3g==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0, npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -2409,6 +2491,10 @@ packages:
     resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
     engines: {node: '>=12.5.0'}
 
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
@@ -2514,6 +2600,10 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
@@ -2674,6 +2764,10 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
 
@@ -2700,6 +2794,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
@@ -2716,6 +2813,10 @@ packages:
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -2764,6 +2865,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2850,6 +2954,10 @@ packages:
 
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
+
+  es-set-tostringtag@2.1.0:
+    resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
   esast-util-from-estree@2.0.0:
@@ -3022,6 +3130,10 @@ packages:
     resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
     engines: {node: '>=20'}
 
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3105,6 +3217,10 @@ packages:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
 
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -3180,6 +3296,10 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@3.0.3:
     resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
 
@@ -3195,6 +3315,14 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-id@4.1.3:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
@@ -3295,6 +3423,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
 
@@ -3333,6 +3464,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3426,12 +3566,19 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   lru-cache@11.3.5:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -3749,6 +3896,9 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3945,6 +4095,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   prismjs@1.30.0:
     resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
     engines: {node: '>=6'}
@@ -3959,6 +4113,10 @@ packages:
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  punycode@2.3.1:
+    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
+    engines: {node: '>=6'}
 
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
@@ -3994,16 +4152,15 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
-    engines: {node: '>=0.10.0'}
-
-  react@19.2.5:
-    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -4142,6 +4299,12 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -4161,6 +4324,10 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -4356,6 +4523,9 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   term-size@2.2.1:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
@@ -4396,6 +4566,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4404,8 +4581,16 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4860,11 +5045,32 @@ packages:
       typescript:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4909,6 +5115,13 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
@@ -4983,6 +5196,14 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@astrojs/check@0.9.8(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -5508,6 +5729,26 @@ snapshots:
   '@chevrotain/types@12.0.0': {}
 
   '@chevrotain/utils@12.0.0': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@ctrl/tinycolor@4.2.0': {}
 
@@ -6320,6 +6561,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@turbo/darwin-64@2.9.6':
     optional: true
 
@@ -6337,6 +6599,8 @@ snapshots:
 
   '@turbo/windows-arm64@2.9.6':
     optional: true
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6815,6 +7079,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-draft-04@1.0.0(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -6846,6 +7112,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
@@ -6862,6 +7130,10 @@ snapshots:
       sprintf-js: 1.0.3
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   aria-query@5.3.1: {}
 
@@ -6983,6 +7255,8 @@ snapshots:
       - typescript
       - uploadthing
       - yaml
+
+  asynckit@0.4.0: {}
 
   axobject-query@4.1.0: {}
 
@@ -7164,6 +7438,10 @@ snapshots:
       color-convert: 2.0.1
       color-string: 1.9.1
 
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
+
   comma-separated-tokens@2.0.3: {}
 
   commander@11.1.0: {}
@@ -7250,6 +7528,11 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
 
   csstype@3.2.3: {}
 
@@ -7437,6 +7720,11 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   dataloader@1.4.0: {}
 
   dayjs@1.11.20: {}
@@ -7451,6 +7739,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-named-character-reference@1.3.0:
     dependencies:
       character-entities: 2.0.2
@@ -7464,6 +7754,8 @@ snapshots:
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
+
+  delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -7496,6 +7788,8 @@ snapshots:
   direction@2.0.1: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7570,6 +7864,13 @@ snapshots:
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
+
+  es-set-tostringtag@2.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -7887,6 +8188,14 @@ snapshots:
     dependencies:
       tiny-inflate: 1.0.3
 
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -7979,6 +8288,10 @@ snapshots:
   hachure-fill@0.5.2: {}
 
   has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.3:
     dependencies:
@@ -8194,6 +8507,10 @@ snapshots:
 
   hono@4.12.14: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@3.0.3: {}
 
   html-void-elements@3.0.0: {}
@@ -8209,6 +8526,20 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-id@4.1.3: {}
 
@@ -8279,6 +8610,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-promise@4.0.0: {}
 
   is-reference@3.0.3:
@@ -8311,6 +8644,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -8379,11 +8740,15 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -8976,6 +9341,8 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
+  nwsapi@2.2.23: {}
+
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -9149,6 +9516,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   prismjs@1.30.0: {}
 
   prompts@2.4.2:
@@ -9162,6 +9535,8 @@ snapshots:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  punycode@2.3.1: {}
 
   qs@6.14.2:
     dependencies:
@@ -9199,13 +9574,13 @@ snapshots:
       react: 18.3.1
       scheduler: 0.23.2
 
+  react-is@17.0.2: {}
+
   react-refresh@0.17.0: {}
 
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
-
-  react@19.2.5: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -9458,6 +9833,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -9473,6 +9852,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -9808,6 +10191,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  symbol-tree@3.2.4: {}
+
   term-size@2.2.1: {}
 
   thenify-all@1.6.0:
@@ -9837,13 +10222,27 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -10127,7 +10526,7 @@ snapshots:
     optionalDependencies:
       vite: 6.4.2(@types/node@24.12.2)(tsx@4.21.0)(yaml@2.8.3)
 
-  vitest@2.1.9(@types/node@22.19.17):
+  vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
@@ -10151,6 +10550,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -10162,7 +10562,7 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@24.12.2):
+  vitest@2.1.9(@types/node@24.12.2)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@24.12.2))
@@ -10186,6 +10586,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -10310,9 +10711,26 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-namespaces@2.0.1: {}
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -10349,6 +10767,10 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xxhash-wasm@1.1.0: {}
 


### PR DESCRIPTION
## Summary

- Adds opt-in `resume` support to `useTesseronConnection` so React apps survive page refresh / HMR without losing their claimed session. The `tesseron/resume` primitive already existed in the protocol and `@tesseron/web`, but the React hook didn't surface it. After this change, passing `resume: true` is enough.
- Sets up vitest for `@tesseron/react` (no tests existed there) and adds 13 hook tests covering fresh hello, resume, token rotation, `ResumeFailed` fallback, custom backends, corrupted storage entries, and old-gateway no-`resumeToken` responses.
- Updates `examples/react-todo` to demonstrate the new option, plus the docs in `sdk/typescript/react.md` and a cross-link from `protocol/resume.mdx`.
- Small kaizen pass on stale TypeScript diagnostics surfaced in the editor: drop unused `<I, O>` type params on `ActionBuilderInit`, remove an unused `TesseronErrorCode` import in `mcp-bridge.ts`, and fix an editor-only type error in `packages/mcp/test/integration.test.ts`.

## Why

`useTesseronConnection` previously called `client.connect(url)` with no second argument, so every page refresh / Vite HMR re-run produced a fresh `tesseron/hello`, a brand-new `sessionId`, and a brand-new claim code. Apps that had already paired with an agent had to re-pair on every reload, which is the wrong default for the local-dev React loop the package is built for.

The protocol-level `tesseron/resume` mechanism already handles this end-to-end, with token rotation, a 90s zombie TTL, and a typed `ResumeFailed` fallback. The change is purely about plumbing it through the React layer.

## API

```ts
interface UseTesseronConnectionOptions {
  url?: string;
  enabled?: boolean;
  resume?: boolean | string | ResumeStorage;
}

interface ResumeStorage {
  load: () => ResumeCredentials | null | Promise<ResumeCredentials | null>;
  save: (credentials: ResumeCredentials) => void | Promise<void>;
  clear: () => void | Promise<void>;
}
```

| Form | Behaviour |
|---|---|
| omitted / `false` | No persistence (current default). |
| `true` | localStorage under `tesseron:resume`. |
| `string` | localStorage under that exact key. |
| `ResumeStorage` | Custom backend - Electron, OS keychain, iframe partition, etc. |

The hook persists `welcome.resumeToken` after every successful handshake (rotation is one-shot per the protocol), clears stale credentials on `ResumeFailed`, and falls back to a fresh `tesseron/hello` automatically. SSR-safe (`typeof window === 'undefined'` guards) and quota / private-mode safe (try/catch around localStorage with a comment explaining why each catch is non-fatal).

## Test plan

- [x] `pnpm exec turbo run test typecheck --force` from the repo root: 30 tasks, all green. Includes the new 13-test suite at `packages/react/test/use-tesseron-connection.test.tsx` and the existing 67-test `@tesseron/mcp` integration suite (which exercises gateway-side resume).
- [x] `pnpm lint` clean.
- [x] Loaded `examples/react-todo` in a real browser, confirmed:
  - On first connect, `localStorage["tesseron:resume"]` is populated with `{ sessionId, resumeToken }`.
  - After a page refresh, the hook attempts `tesseron/resume` and (when the session was unclaimed) cleanly falls back to a fresh hello, rewriting localStorage with new credentials. The success branch (claimed session resumes with `claimCode: undefined`) is covered exhaustively by the unit tests with a mocked client.

## Compatibility

- Pure addition. Existing `useTesseronConnection()` call sites are unchanged in behaviour: no persistence, no resume, identical to today.
- Adds devDeps to `@tesseron/react`: `vitest`, `jsdom`, `@testing-library/react`, `react`, `react-dom`, `@types/react-dom`. No new runtime deps.

Generated with Claude Code.
