### PR TITLE
fix(core): cap resources/read at 30s so a stuck reader can't hang the agent

### DIFF
--- a/.changeset/resource-read-timeout.md
+++ b/.changeset/resource-read-timeout.md
@@ -1,0 +1,7 @@
+---
+'@tesseron/core': minor
+---
+
+Resource reads now have a default 30s wall-clock cap (`DEFAULT_RESOURCE_READ_TIMEOUT_MS`). A `.read()` handler that hangs - stuck promise, awaited state setter that never settles, slow IPC - rejects with a typed `TesseronError` of code `Timeout` instead of parking the gateway, the bridge, the MCP tool call, and the agent indefinitely. Synchronous and quick async reads are unaffected.
+
+`TimeoutError` now accepts an optional `subject` argument so the message points at the actual operation (`Resource read "compositions" timed out after 30000ms.` rather than always saying "Action"). The single-arg form is preserved for backwards compatibility - existing call sites that throw `new TimeoutError(ms)` keep working unchanged.

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"772ee677-fd15-401d-9b6d-4bcb291ceab5","pid":100736,"acquiredAt":1777152512639}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"772ee677-fd15-401d-9b6d-4bcb291ceab5","pid":100736,"acquiredAt":1777152512639}

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ yarn-error.log*
 .claude/settings.local.json
 .claude/worktrees/
 .claude/skills/reddit-author/
+.claude/scheduled_tasks.lock
 
 # Project-specific internals (not for public consumption)
 /outputs/

--- a/docs/src/content/docs/protocol/resources.mdx
+++ b/docs/src/content/docs/protocol/resources.mdx
@@ -141,6 +141,10 @@ tesseron.resource('search')
 
 If the value is expensive to produce, remember that `.read()` runs every time the agent fetches. Cache inside the handler, or use `.subscribe()` as the source of truth and cache the latest emitted value in-memory.
 
+## Read timeout
+
+The SDK caps every `resources/read` handler at **30 seconds** (`DEFAULT_RESOURCE_READ_TIMEOUT_MS`). A handler that hangs - a stuck promise, an awaited state setter that never settles, a cross-process call that never returns - rejects with a typed `TesseronError` of code `Timeout` (`-32007`) instead of parking the agent indefinitely. Resources are expected to be cheap projections of in-memory state; if a real read genuinely needs longer, the right move is to back the resource by a cached value populated out-of-band (a websocket, an interval) and have `.read()` return that cache.
+
 ## Capability gate
 
 Subscriptions require `agentCapabilities.subscriptions`. Reads do not. If the agent can't subscribe, it will only call `resources/read` and your `.subscribe()` handler is never invoked.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -505,39 +505,27 @@ export class TesseronClient implements BuilderRegistry {
         `Resource not readable: ${params.name}`,
       );
     }
-    const reader = resource.reader;
     // Bound the read against a wall-clock budget. A reader that hangs (a stuck
     // promise, an awaited state setter that never settles) would otherwise
     // park the gateway's `resources/read` request forever, which in turn parks
     // the bridge's MCP tool call and the agent. Surface a typed Timeout
     // instead so the agent can recover and the bug is visible.
-    const value = await new Promise<unknown>((resolve, reject) => {
-      let settled = false;
-      const timer = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        reject(
-          new TimeoutError(DEFAULT_RESOURCE_READ_TIMEOUT_MS, `Resource read "${params.name}"`),
-        );
-      }, DEFAULT_RESOURCE_READ_TIMEOUT_MS);
-      Promise.resolve()
-        .then(() => reader())
-        .then(
-          (result) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            resolve(result);
-          },
-          (err: unknown) => {
-            if (settled) return;
-            settled = true;
-            clearTimeout(timer);
-            reject(err instanceof Error ? err : new Error(String(err)));
-          },
-        );
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(
+        () =>
+          reject(
+            new TimeoutError(DEFAULT_RESOURCE_READ_TIMEOUT_MS, `Resource read "${params.name}"`),
+          ),
+        DEFAULT_RESOURCE_READ_TIMEOUT_MS,
+      );
     });
-    return { value };
+    try {
+      const value = await Promise.race([Promise.resolve(resource.reader()), timeout]);
+      return { value };
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   private handleResourceSubscribe(params: ResourceSubscribeParams): void {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -111,6 +111,14 @@ export const SDK_CAPABILITIES: TesseronCapabilities = {
   elicitation: true,
 };
 
+/**
+ * Default wall-clock cap on a single `resources/read` handler. Resource reads
+ * are expected to be cheap projections of in-memory state - 30s is generous
+ * but bounded so a stuck `read()` cannot hang the agent indefinitely. Distinct
+ * from {@link ActionBuilder.timeout}, which the caller configures per action.
+ */
+export const DEFAULT_RESOURCE_READ_TIMEOUT_MS = 30_000;
+
 interface ActionDefinitionWithSchema extends ActionDefinition {
   inputJsonSchema?: unknown;
   outputJsonSchema?: unknown;
@@ -497,7 +505,38 @@ export class TesseronClient implements BuilderRegistry {
         `Resource not readable: ${params.name}`,
       );
     }
-    const value = await resource.reader();
+    const reader = resource.reader;
+    // Bound the read against a wall-clock budget. A reader that hangs (a stuck
+    // promise, an awaited state setter that never settles) would otherwise
+    // park the gateway's `resources/read` request forever, which in turn parks
+    // the bridge's MCP tool call and the agent. Surface a typed Timeout
+    // instead so the agent can recover and the bug is visible.
+    const value = await new Promise<unknown>((resolve, reject) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        reject(
+          new TimeoutError(DEFAULT_RESOURCE_READ_TIMEOUT_MS, `Resource read "${params.name}"`),
+        );
+      }, DEFAULT_RESOURCE_READ_TIMEOUT_MS);
+      Promise.resolve()
+        .then(() => reader())
+        .then(
+          (result) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            resolve(result);
+          },
+          (err: unknown) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            reject(err instanceof Error ? err : new Error(String(err)));
+          },
+        );
+    });
     return { value };
   }
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -114,12 +114,22 @@ export class CancelledError extends TesseronError {
 }
 
 /**
- * Thrown when an invocation exceeds the timeout configured via
- * {@link ActionBuilder.timeout}. `ctx.signal` aborts with this as its `reason`.
+ * Thrown when an action invocation or resource read exceeds its timeout.
+ * For action invocations the timeout is configured via
+ * {@link ActionBuilder.timeout} and `ctx.signal` aborts with this as its
+ * `reason`. For resource reads the SDK enforces a default cap so a stuck
+ * `read()` handler can't hang the agent indefinitely.
  */
 export class TimeoutError extends TesseronError {
-  constructor(timeoutMs: number) {
-    super(TesseronErrorCode.Timeout, `Action timed out after ${timeoutMs}ms.`);
+  /**
+   * @param timeoutMs - Wall-clock budget that elapsed.
+   * @param subject - Human-readable subject for the error message. Defaults
+   *   to `'Action'` for backwards compatibility with prior call sites; pass
+   *   e.g. `'Resource read "compositions"'` for resources so the resulting
+   *   error message points at the actual operation.
+   */
+  constructor(timeoutMs: number, subject = 'Action') {
+    super(TesseronErrorCode.Timeout, `${subject} timed out after ${timeoutMs}ms.`);
     this.name = 'TimeoutError';
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,6 +12,7 @@ export * from './errors.js';
 export * from './transport.js';
 export * from './transport-spec.js';
 export {
+  DEFAULT_RESOURCE_READ_TIMEOUT_MS,
   TesseronClient,
   type AppConfig,
   type ConnectOptions,

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { PROTOCOL_VERSION, TesseronClient, type Transport } from '../src/index.js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_RESOURCE_READ_TIMEOUT_MS,
+  PROTOCOL_VERSION,
+  TesseronClient,
+  TesseronErrorCode,
+  type Transport,
+} from '../src/index.js';
 import { JsonRpcDispatcher } from '../src/internal.js';
 
 interface PairedSetup {
@@ -143,5 +149,83 @@ describe('TesseronClient end-to-end', () => {
         invocationId: 'x',
       }),
     ).rejects.toMatchObject({ code: -32003 });
+  });
+});
+
+async function setupConnectedClient(
+  register: (c: TesseronClient) => void,
+): Promise<{ client: TesseronClient; gateway: JsonRpcDispatcher }> {
+  const client = new TesseronClient();
+  client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+  register(client);
+
+  let clientMessageHandler: ((m: unknown) => void) | undefined;
+  const gateway = new JsonRpcDispatcher((m) => {
+    queueMicrotask(() => clientMessageHandler?.(m));
+  });
+  gateway.on('tesseron/hello', () => ({
+    sessionId: 'test',
+    protocolVersion: PROTOCOL_VERSION,
+    capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+    agent: { id: 'a', name: 'a' },
+  }));
+
+  const transport: Transport = {
+    send: (m) => queueMicrotask(() => gateway.receive(m)),
+    onMessage: (h) => {
+      clientMessageHandler = h;
+    },
+    onClose: () => {},
+    close: () => {},
+  };
+
+  await client.connect(transport);
+  return { client, gateway };
+}
+
+describe('TesseronClient resource reads', () => {
+  it('returns the reader value for a quick resource read', async () => {
+    const { gateway } = await setupConnectedClient((c) => {
+      c.resource('compositions').read(() => [{ id: 'cmp1' }, { id: 'cmp2' }]);
+    });
+
+    const result = await gateway.request('resources/read', { name: 'compositions' });
+
+    expect(result).toEqual({ value: [{ id: 'cmp1' }, { id: 'cmp2' }] });
+  });
+
+  it('still surfaces synchronous reader errors as JSON-RPC errors', async () => {
+    const { gateway } = await setupConnectedClient((c) => {
+      c.resource('boom').read(() => {
+        throw new Error('reader exploded');
+      });
+    });
+
+    await expect(gateway.request('resources/read', { name: 'boom' })).rejects.toMatchObject({
+      message: expect.stringContaining('reader exploded'),
+    });
+  });
+
+  it('rejects with TimeoutError when the reader hangs past the default cap', async () => {
+    vi.useFakeTimers();
+    try {
+      const { gateway } = await setupConnectedClient((c) => {
+        c.resource('hangingResource').read(() => new Promise(() => {}));
+      });
+
+      const pending = gateway.request('resources/read', { name: 'hangingResource' });
+      // Swallow rejection asynchronously so vitest doesn't see it as
+      // unhandled while we advance timers.
+      pending.catch(() => {});
+
+      await vi.advanceTimersByTimeAsync(DEFAULT_RESOURCE_READ_TIMEOUT_MS + 10);
+
+      await expect(pending).rejects.toMatchObject({
+        code: TesseronErrorCode.Timeout,
+        message: expect.stringContaining('Resource read "hangingResource"'),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -194,6 +194,25 @@ describe('TesseronClient resource reads', () => {
     expect(result).toEqual({ value: [{ id: 'cmp1' }, { id: 'cmp2' }] });
   });
 
+  it('clears the timeout timer when the reader resolves quickly (no leak)', async () => {
+    vi.useFakeTimers();
+    try {
+      const { gateway } = await setupConnectedClient((c) => {
+        c.resource('quick').read(() => 'ok');
+      });
+
+      const before = vi.getTimerCount();
+      const result = await gateway.request('resources/read', { name: 'quick' });
+
+      expect(result).toEqual({ value: 'ok' });
+      // The race should clear its timer in the `finally` block. If a timer
+      // leaks the count grows by one per call.
+      expect(vi.getTimerCount()).toBe(before);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('still surfaces synchronous reader errors as JSON-RPC errors', async () => {
     const { gateway } = await setupConnectedClient((c) => {
       c.resource('boom').read(() => {


### PR DESCRIPTION
## Summary

- Adds a default 30s wall-clock cap (`DEFAULT_RESOURCE_READ_TIMEOUT_MS`) to the SDK's `resources/read` handler. A `.read()` that hangs - stuck promise, awaited state setter that never settles, slow IPC - rejects with a typed `TesseronError(Timeout)` instead of parking the gateway, the bridge, the MCP tool call, and the agent indefinitely.
- Generalizes `TimeoutError` to take an optional `subject` argument so the error message points at the actual operation (`Resource read "compositions" timed out after 30000ms.`) rather than always saying "Action". Existing single-arg call sites are unaffected.
- 3 new tests in `core/test/client.test.ts` covering the quick-read happy path, sync reader errors still surfacing as JSON-RPC errors, and the hang-and-time-out path (vitest fake timers).
- Drive-by: docs page `protocol/resources` documents the new cap, and `.claude/scheduled_tasks.lock` is gitignored.

## Why

A user hit a real hang in production: their `compositions` resource read hung indefinitely on the agent side. Tracing the stack:

- `mcp-bridge.ts:handleReadResource` calls `gateway.readResource(sessionId, name)`.
- `gateway.ts:readResource` calls `session.dispatcher.request('resources/read', { name })`.
- `dispatcher.ts:request` has no default timeout - the only ways it ever rejects are an abort signal, a synchronous `send()` throw, or `rejectAllPending(...)` (transport close).
- The SDK's `client.ts:handleResourceRead` calls `await resource.reader()` with no timeout protection.

So if the reader returns a never-resolving promise (or anything in between drops a response), the entire chain parks. Actions are protected by their own SDK-side `setTimeout` race against `action.timeoutMs`; resources had no equivalent.

This PR adds the SDK-side timeout - the smallest correct fix. The dispatcher and bridge could grow defense-in-depth too, but those are bigger surface-area changes; the SDK cap is enough on its own to prevent the indefinite-hang failure mode.

## Test plan

- [x] `pnpm exec turbo run test typecheck --force` from the repo root: 30 tasks green. Includes the 3 new tests in `@tesseron/core` and the existing `@tesseron/mcp` integration suite that exercises real resource reads end-to-end.
- [x] `pnpm lint` clean.
- [x] `TimeoutError` backwards compatibility: `new TimeoutError(5000)` still produces `"Action timed out after 5000ms."` (existing call sites in `client.ts:339` and `client.ts:478` unchanged).

## Compatibility

- `DEFAULT_RESOURCE_READ_TIMEOUT_MS` is a new export from `@tesseron/core`. Pure addition.
- `TimeoutError` constructor's second parameter is optional with a default - no existing call site needs to change.
- The 30s cap is a behavioral change: a resource read that previously hung forever now rejects with `Timeout` after 30s. That's the desired behavior change. If an app legitimately needs a longer read, the right fix is to back the resource by an out-of-band cache and have `.read()` return the cached value.

Generated with Claude Code.
