### PR TITLE
fix: cascade transport close on send failure to prevent silent hangs

### DIFF
--- a/.changeset/fix-silent-hang-on-send-failure.md
+++ b/.changeset/fix-silent-hang-on-send-failure.md
@@ -1,0 +1,11 @@
+---
+'@tesseron/core': patch
+'@tesseron/mcp': patch
+'@tesseron/vite': patch
+---
+
+Fix silent hangs when a transport send fails mid-request. Three places used to swallow `transport.send` failures with no signal: the gateway's session-dispatcher wrapper (bare `catch {}`), the SDK client's session-dispatcher wrapper (no try/catch at all), and the Vite plugin's gateway-to-browser bridge (silently dropped frames when `browserWs.readyState !== OPEN`). When a response failed to send, the peer's pending request would wait forever - the user-visible symptom was `tesseron__read_resource` hanging indefinitely after a Vite HMR cycle that left the browser WebSocket in a non-OPEN state.
+
+All three paths now close the channel on send failure so the peer's `transport.onClose` handler fires, `rejectAllPending` rejects every outstanding request with `TransportClosedError`, and the bridge / MCP tool surfaces a real error instead of hanging. Also reverts the 30s `DEFAULT_RESOURCE_READ_TIMEOUT_MS` band-aid added in #47 - it would have papered over genuine hangs by silently failing legitimate slow reads, and the cascade-on-send-failure fix is what actually addresses the root cause.
+
+`JsonRpcDispatcher.receive()` no longer leaves `handleRequest` rejections as unhandled promise rejections - the transport wrappers now handle the recovery, so we attach an empty `.catch` to suppress noise.

--- a/.changeset/resource-read-timeout.md
+++ b/.changeset/resource-read-timeout.md
@@ -1,7 +1,0 @@
----
-'@tesseron/core': minor
----
-
-Resource reads now have a default 30s wall-clock cap (`DEFAULT_RESOURCE_READ_TIMEOUT_MS`). A `.read()` handler that hangs - stuck promise, awaited state setter that never settles, slow IPC - rejects with a typed `TesseronError` of code `Timeout` instead of parking the gateway, the bridge, the MCP tool call, and the agent indefinitely. Synchronous and quick async reads are unaffected.
-
-`TimeoutError` now accepts an optional `subject` argument so the message points at the actual operation (`Resource read "compositions" timed out after 30000ms.` rather than always saying "Action"). The single-arg form is preserved for backwards compatibility - existing call sites that throw `new TimeoutError(ms)` keep working unchanged.

--- a/.gitignore
+++ b/.gitignore
@@ -54,7 +54,6 @@ yarn-error.log*
 .claude/settings.local.json
 .claude/worktrees/
 .claude/skills/reddit-author/
-.claude/scheduled_tasks.lock
 
 # Project-specific internals (not for public consumption)
 /outputs/

--- a/docs/src/content/docs/protocol/resources.mdx
+++ b/docs/src/content/docs/protocol/resources.mdx
@@ -141,10 +141,6 @@ tesseron.resource('search')
 
 If the value is expensive to produce, remember that `.read()` runs every time the agent fetches. Cache inside the handler, or use `.subscribe()` as the source of truth and cache the latest emitted value in-memory.
 
-## Read timeout
-
-The SDK caps every `resources/read` handler at **30 seconds** (`DEFAULT_RESOURCE_READ_TIMEOUT_MS`). A handler that hangs - a stuck promise, an awaited state setter that never settles, a cross-process call that never returns - rejects with a typed `TesseronError` of code `Timeout` (`-32007`) instead of parking the agent indefinitely. Resources are expected to be cheap projections of in-memory state; if a real read genuinely needs longer, the right move is to back the resource by a cached value populated out-of-band (a websocket, an interval) and have `.read()` return that cache.
-
 ## Capability gate
 
 Subscriptions require `agentCapabilities.subscriptions`. Reads do not. If the agent can't subscribe, it will only call `resources/read` and your `.subscribe()` handler is never invoked.

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -234,7 +234,27 @@ export class TesseronClient implements BuilderRegistry {
       this.transport.close();
     }
     this.transport = transport;
-    const dispatcher = new JsonRpcDispatcher((message) => transport.send(message));
+    const dispatcher = new JsonRpcDispatcher((message) => {
+      try {
+        transport.send(message);
+      } catch (err) {
+        // The transport rejected the write (closing socket, JSON
+        // serialisation failure on a circular result, etc.). If we let the
+        // throw propagate up through `handleRequest`'s `void`-discarded
+        // promise, the request's response is silently dropped and the peer's
+        // pending dispatcher entry waits forever. Close the transport so the
+        // peer sees a close, fires `rejectAllPending`, and surfaces the
+        // failure as `TransportClosedError` instead of a hang. Outgoing
+        // request paths (`dispatcher.request`) catch synchronous send
+        // failures themselves; this rethrow preserves that behaviour.
+        try {
+          transport.close();
+        } catch {
+          // Already in a bad state; nothing more to do.
+        }
+        throw err;
+      }
+    });
     this.dispatcher = dispatcher;
 
     transport.onMessage((message) => dispatcher.receive(message));

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -111,14 +111,6 @@ export const SDK_CAPABILITIES: TesseronCapabilities = {
   elicitation: true,
 };
 
-/**
- * Default wall-clock cap on a single `resources/read` handler. Resource reads
- * are expected to be cheap projections of in-memory state - 30s is generous
- * but bounded so a stuck `read()` cannot hang the agent indefinitely. Distinct
- * from {@link ActionBuilder.timeout}, which the caller configures per action.
- */
-export const DEFAULT_RESOURCE_READ_TIMEOUT_MS = 30_000;
-
 interface ActionDefinitionWithSchema extends ActionDefinition {
   inputJsonSchema?: unknown;
   outputJsonSchema?: unknown;
@@ -505,27 +497,8 @@ export class TesseronClient implements BuilderRegistry {
         `Resource not readable: ${params.name}`,
       );
     }
-    // Bound the read against a wall-clock budget. A reader that hangs (a stuck
-    // promise, an awaited state setter that never settles) would otherwise
-    // park the gateway's `resources/read` request forever, which in turn parks
-    // the bridge's MCP tool call and the agent. Surface a typed Timeout
-    // instead so the agent can recover and the bug is visible.
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const timeout = new Promise<never>((_resolve, reject) => {
-      timer = setTimeout(
-        () =>
-          reject(
-            new TimeoutError(DEFAULT_RESOURCE_READ_TIMEOUT_MS, `Resource read "${params.name}"`),
-          ),
-        DEFAULT_RESOURCE_READ_TIMEOUT_MS,
-      );
-    });
-    try {
-      const value = await Promise.race([Promise.resolve(resource.reader()), timeout]);
-      return { value };
-    } finally {
-      clearTimeout(timer);
-    }
+    const value = await resource.reader();
+    return { value };
   }
 
   private handleResourceSubscribe(params: ResourceSubscribeParams): void {

--- a/packages/core/src/dispatcher.ts
+++ b/packages/core/src/dispatcher.ts
@@ -112,7 +112,15 @@ export class JsonRpcDispatcher {
     if (!isJsonRpcEnvelope(message)) return;
     if (typeof message.method === 'string') {
       if ('id' in message && message.id !== undefined) {
-        void this.handleRequest(message as unknown as JsonRpcRequest);
+        // Suppress unhandled rejections from `handleRequest`. The transport
+        // wrappers in `@tesseron/core` and `@tesseron/mcp` already close the
+        // channel on send failure so the peer learns about the broken
+        // request via `rejectAllPending`; we don't want a noisy unhandled
+        // rejection on top of that. Any other handler-internal failure has
+        // already been turned into a JSON-RPC error response by
+        // `handleRequest` itself, so there is nothing meaningful left to do
+        // here.
+        this.handleRequest(message as unknown as JsonRpcRequest).catch(() => {});
       } else {
         this.handleNotification(message as unknown as JsonRpcNotification);
       }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -114,22 +114,12 @@ export class CancelledError extends TesseronError {
 }
 
 /**
- * Thrown when an action invocation or resource read exceeds its timeout.
- * For action invocations the timeout is configured via
- * {@link ActionBuilder.timeout} and `ctx.signal` aborts with this as its
- * `reason`. For resource reads the SDK enforces a default cap so a stuck
- * `read()` handler can't hang the agent indefinitely.
+ * Thrown when an invocation exceeds the timeout configured via
+ * {@link ActionBuilder.timeout}. `ctx.signal` aborts with this as its `reason`.
  */
 export class TimeoutError extends TesseronError {
-  /**
-   * @param timeoutMs - Wall-clock budget that elapsed.
-   * @param subject - Human-readable subject for the error message. Defaults
-   *   to `'Action'` for backwards compatibility with prior call sites; pass
-   *   e.g. `'Resource read "compositions"'` for resources so the resulting
-   *   error message points at the actual operation.
-   */
-  constructor(timeoutMs: number, subject = 'Action') {
-    super(TesseronErrorCode.Timeout, `${subject} timed out after ${timeoutMs}ms.`);
+  constructor(timeoutMs: number) {
+    super(TesseronErrorCode.Timeout, `Action timed out after ${timeoutMs}ms.`);
     this.name = 'TimeoutError';
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,7 +12,6 @@ export * from './errors.js';
 export * from './transport.js';
 export * from './transport-spec.js';
 export {
-  DEFAULT_RESOURCE_READ_TIMEOUT_MS,
   TesseronClient,
   type AppConfig,
   type ConnectOptions,

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -144,4 +144,56 @@ describe('TesseronClient end-to-end', () => {
       }),
     ).rejects.toMatchObject({ code: -32003 });
   });
+
+  it('closes the transport when send() throws so the peer is not stranded', async () => {
+    // Regression: an SDK response that fails to send (closing socket, JSON
+    // serialisation failure on a circular result, ...) used to be silently
+    // swallowed, stranding the peer's pending request forever. The wrapped
+    // send must call transport.close() on any throw so transport.onClose
+    // fires on the peer side and its rejectAllPending surfaces an error
+    // instead of a hang.
+    const client = new TesseronClient();
+    client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+    client.resource('compositions').read(() => 'fine');
+
+    let clientMessageHandler: ((m: unknown) => void) | undefined;
+    const gateway = new JsonRpcDispatcher((m) => {
+      queueMicrotask(() => clientMessageHandler?.(m));
+    });
+    gateway.on('tesseron/hello', () => ({
+      sessionId: 'test',
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+      agent: { id: 'a', name: 'a' },
+    }));
+
+    let allowSend = true;
+    let closed = false;
+    const transport: Transport = {
+      send: (m) => {
+        if (!allowSend) throw new Error('socket dead');
+        queueMicrotask(() => gateway.receive(m));
+      },
+      onMessage: (h) => {
+        clientMessageHandler = h;
+      },
+      onClose: () => {},
+      close: () => {
+        closed = true;
+      },
+    };
+
+    await client.connect(transport);
+
+    // Now make subsequent sends fail (simulates the socket dying between the
+    // hello response and the next response).
+    allowSend = false;
+    // Trigger a request the SDK will try to respond to. The send wrapper
+    // should close the transport on the throw.
+    void gateway.request('resources/read', { name: 'compositions' }).catch(() => {});
+    // Drain microtasks so handleResourceRead runs.
+    await new Promise((r) => setImmediate(r));
+
+    expect(closed).toBe(true);
+  });
 });

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -1,11 +1,5 @@
-import { describe, expect, it, vi } from 'vitest';
-import {
-  DEFAULT_RESOURCE_READ_TIMEOUT_MS,
-  PROTOCOL_VERSION,
-  TesseronClient,
-  TesseronErrorCode,
-  type Transport,
-} from '../src/index.js';
+import { describe, expect, it } from 'vitest';
+import { PROTOCOL_VERSION, TesseronClient, type Transport } from '../src/index.js';
 import { JsonRpcDispatcher } from '../src/internal.js';
 
 interface PairedSetup {
@@ -149,102 +143,5 @@ describe('TesseronClient end-to-end', () => {
         invocationId: 'x',
       }),
     ).rejects.toMatchObject({ code: -32003 });
-  });
-});
-
-async function setupConnectedClient(
-  register: (c: TesseronClient) => void,
-): Promise<{ client: TesseronClient; gateway: JsonRpcDispatcher }> {
-  const client = new TesseronClient();
-  client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
-  register(client);
-
-  let clientMessageHandler: ((m: unknown) => void) | undefined;
-  const gateway = new JsonRpcDispatcher((m) => {
-    queueMicrotask(() => clientMessageHandler?.(m));
-  });
-  gateway.on('tesseron/hello', () => ({
-    sessionId: 'test',
-    protocolVersion: PROTOCOL_VERSION,
-    capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
-    agent: { id: 'a', name: 'a' },
-  }));
-
-  const transport: Transport = {
-    send: (m) => queueMicrotask(() => gateway.receive(m)),
-    onMessage: (h) => {
-      clientMessageHandler = h;
-    },
-    onClose: () => {},
-    close: () => {},
-  };
-
-  await client.connect(transport);
-  return { client, gateway };
-}
-
-describe('TesseronClient resource reads', () => {
-  it('returns the reader value for a quick resource read', async () => {
-    const { gateway } = await setupConnectedClient((c) => {
-      c.resource('compositions').read(() => [{ id: 'cmp1' }, { id: 'cmp2' }]);
-    });
-
-    const result = await gateway.request('resources/read', { name: 'compositions' });
-
-    expect(result).toEqual({ value: [{ id: 'cmp1' }, { id: 'cmp2' }] });
-  });
-
-  it('clears the timeout timer when the reader resolves quickly (no leak)', async () => {
-    vi.useFakeTimers();
-    try {
-      const { gateway } = await setupConnectedClient((c) => {
-        c.resource('quick').read(() => 'ok');
-      });
-
-      const before = vi.getTimerCount();
-      const result = await gateway.request('resources/read', { name: 'quick' });
-
-      expect(result).toEqual({ value: 'ok' });
-      // The race should clear its timer in the `finally` block. If a timer
-      // leaks the count grows by one per call.
-      expect(vi.getTimerCount()).toBe(before);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-
-  it('still surfaces synchronous reader errors as JSON-RPC errors', async () => {
-    const { gateway } = await setupConnectedClient((c) => {
-      c.resource('boom').read(() => {
-        throw new Error('reader exploded');
-      });
-    });
-
-    await expect(gateway.request('resources/read', { name: 'boom' })).rejects.toMatchObject({
-      message: expect.stringContaining('reader exploded'),
-    });
-  });
-
-  it('rejects with TimeoutError when the reader hangs past the default cap', async () => {
-    vi.useFakeTimers();
-    try {
-      const { gateway } = await setupConnectedClient((c) => {
-        c.resource('hangingResource').read(() => new Promise(() => {}));
-      });
-
-      const pending = gateway.request('resources/read', { name: 'hangingResource' });
-      // Swallow rejection asynchronously so vitest doesn't see it as
-      // unhandled while we advance timers.
-      pending.catch(() => {});
-
-      await vi.advanceTimersByTimeAsync(DEFAULT_RESOURCE_READ_TIMEOUT_MS + 10);
-
-      await expect(pending).rejects.toMatchObject({
-        code: TesseronErrorCode.Timeout,
-        message: expect.stringContaining('Resource read "hangingResource"'),
-      });
-    } finally {
-      vi.useRealTimers();
-    }
   });
 });

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -569,8 +569,21 @@ export class TesseronGateway extends EventEmitter {
     const dispatcher = new JsonRpcDispatcher((message) => {
       try {
         transport.send(message);
-      } catch {
-        // channel likely closed; ignore
+      } catch (err) {
+        // The channel is in an unrecoverable state (closing socket, broken
+        // pipe, JSON serialisation failure on a circular result, ...). If we
+        // silently swallow we strand whichever pending request just lost its
+        // response, and the bridge waits forever. Tear down the channel so
+        // `transport.onClose` fires below, `rejectAllPending` rejects every
+        // outstanding request with `TransportClosedError`, and the failure
+        // surfaces to the bridge / MCP tool call instead of hanging.
+        const reason = err instanceof Error ? err.message : String(err);
+        logToStderr(`[tesseron] session transport send failed (${reason}); closing channel`);
+        try {
+          transport.close();
+        } catch {
+          // The transport is already in a bad state; nothing more to do.
+        }
       }
     });
 

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -182,7 +182,16 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
               const payload: RawData | string = isBinary ? data : rawDataToString(data);
               if (entry.browserWs.readyState === 1 /* OPEN */) {
                 entry.browserWs.send(payload);
+                return;
               }
+              // The browser side of this instance is no longer accepting
+              // messages (closing or closed). Silently dropping the frame
+              // would orphan whichever request the gateway just sent here -
+              // the gateway's dispatcher would wait forever for a response
+              // that can never arrive. Tear down the gateway WS so the
+              // gateway sees a close, fires `rejectAllPending`, and surfaces
+              // the failure to its caller (the MCP tool call) instead.
+              ws.close(1011, 'Browser side of bridge is not OPEN');
             });
 
             ws.on('close', () => {

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19014,7 +19014,8 @@ var JsonRpcDispatcher = class {
     if (!isJsonRpcEnvelope(message)) return;
     if (typeof message.method === "string") {
       if ("id" in message && message.id !== void 0) {
-        void this.handleRequest(message);
+        this.handleRequest(message).catch(() => {
+        });
       } else {
         this.handleNotification(message);
       }
@@ -19629,7 +19630,13 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     const dispatcher = new JsonRpcDispatcher((message) => {
       try {
         transport.send(message);
-      } catch {
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        logToStderr(`[tesseron] session transport send failed (${reason}); closing channel`);
+        try {
+          transport.close();
+        } catch {
+        }
       }
     });
     let session;


### PR DESCRIPTION
## Summary

Reverts the 30s `DEFAULT_RESOURCE_READ_TIMEOUT_MS` band-aid from #47 and fixes the actual root cause: three places in the transport stack used to silently drop frames or swallow `transport.send` failures, leaving the peer's pending JSON-RPC request waiting forever.

The user-visible symptom: `tesseron__read_resource` hanging indefinitely after a Vite HMR cycle that left the browser WebSocket in a non-OPEN state. The reader itself was sync and trivial. Adding a 30s timeout would have masked this by silently failing legitimate slow reads.

## Three silent-failure sites, all closed

**1. Gateway session-dispatcher wrapper** (`packages/mcp/src/gateway.ts:569`) had a bare `catch {}` ("channel likely closed; ignore"). When the SDK couldn't be reached, the gateway swallowed the failure and the bridge's pending request sat in the dispatcher's `pending` map until the transport happened to close cleanly - which it might not, depending on the failure mode.

**2. SDK client session-dispatcher wrapper** (`packages/core/src/client.ts:237`) had no `try/catch` at all. When `handleRequest` tried to send a response and `transport.send` threw, the throw escaped, the function rejected, the void-discarded promise became an unhandled rejection, and the gateway's pending request hung.

**3. Vite plugin gateway-to-browser bridge** (`packages/vite/src/index.ts:181`) silently dropped frames when `entry.browserWs.readyState !== OPEN`. The opposite direction (browser-to-gateway) buffers in `entry.queue`. The asymmetry meant a gateway request issued while the browser WS was in a non-OPEN state (e.g. a brief HMR reconnect window) was lost without trace, the gateway WS stayed open, and the bridge's pending request never resolved.

All three now close the channel on send failure. `transport.onClose` fires on the peer, `rejectAllPending` rejects every outstanding request with `TransportClosedError`, the bridge / MCP tool call surfaces a real error instead of a hang.

## Why not just add a timeout?

That was PR #47, and Kenny called it correctly: a timeout that auto-rejects after 30s is itself a silent failure for legitimate slow reads, and it doesn't fix the underlying bug class. The cascade-on-send-failure approach makes the broken transport state observable: the peer learns the channel is dead and rejects pending work with a typed `TransportClosedError`, the same way any other channel close is handled today.

## Other changes

- `JsonRpcDispatcher.receive()` attaches a `.catch(() => {})` to the previously void-discarded `handleRequest` promise. The transport wrappers handle recovery; this just silences the (now-rare) unhandled-rejection noise from any handler-internal failure that escapes both the inner try and the sendError fallback.
- 1 new regression test in `core/test/client.test.ts` asserts the SDK transport is closed when `send()` throws on a response.

## Test plan

- [x] `pnpm exec turbo run test typecheck --force`: 30 tasks green. Includes the existing 67-test `@tesseron/mcp` integration suite (which exercises real resource reads) and the 4-test `@tesseron/core` client suite.
- [x] `pnpm lint` clean.

## Compatibility

Pure runtime fix. No public API surface changed. The 30s `DEFAULT_RESOURCE_READ_TIMEOUT_MS` export from #47 is gone (it was added but never released - this revert lands before the next release PR cuts).

Generated with Claude Code.
