### PR TITLE
fix(mcp): stop dialers from swallowing transport.send failures

### DIFF
--- a/.changeset/fix-dialer-silent-send-swallow.md
+++ b/.changeset/fix-dialer-silent-send-swallow.md
@@ -1,0 +1,7 @@
+---
+'@tesseron/mcp': patch
+---
+
+Stop swallowing `transport.send` failures inside `WsDialer` and `UdsDialer`. Both dialer transports had a bare `catch {}` around `ws.send` / `socket.write` with the comment "socket likely closed; ignore". That defeated the cascade-on-send-failure fix in 2.2.1: the session-dispatcher wrapper in `gateway.ts` was supposed to close the channel when send threw, but the wrapper never saw a throw because the dialer ate it first. The user-visible symptom was `tesseron__read_resource` (and `tesseron__invoke_action`) hanging indefinitely after a Vite HMR cycle that left the gateway-side socket in a `CLOSING` / `CLOSED` state that silently no-op'd subsequent sends.
+
+Both dialers now let `ws.send` / `socket.write` throws propagate to the dispatcher wrapper, which closes the channel, fires `transport.onClose`, and `rejectAllPending` rejects every outstanding request with `TransportClosedError`.

--- a/packages/mcp/src/dialer.ts
+++ b/packages/mcp/src/dialer.ts
@@ -84,11 +84,14 @@ export class WsDialer implements GatewayDialer<'ws'> {
 
     const transport: Transport = {
       send(message: unknown): void {
-        try {
-          ws.send(JSON.stringify(message));
-        } catch {
-          // socket likely closed; ignore — onClose will fire and unwind pending requests
-        }
+        // Let `ws.send` throw escape: the underlying socket may be in a state
+        // where the send silently no-ops (CLOSING) but emits no `close` event
+        // for a long time, or `JSON.stringify` may throw on a circular result.
+        // Swallowing here strands whichever pending request was waiting on
+        // this response. The session-dispatcher wrapper in `gateway.ts` catches
+        // the throw and closes the channel so `rejectAllPending` rejects the
+        // request with `TransportClosedError` instead of hanging.
+        ws.send(JSON.stringify(message));
       },
       onMessage(handler: (message: unknown) => void): void {
         messageHandlers.push(handler);
@@ -169,11 +172,10 @@ export class UdsDialer implements GatewayDialer<'uds'> {
 
     const transport: Transport = {
       send(message: unknown): void {
-        try {
-          socket.write(`${JSON.stringify(message)}\n`);
-        } catch {
-          // socket likely closed; ignore
-        }
+        // Same rationale as WsDialer.send: let the throw escape so the
+        // session-dispatcher wrapper in `gateway.ts` can close the channel
+        // and unblock the peer. Silent swallow strands pending requests.
+        socket.write(`${JSON.stringify(message)}\n`);
       },
       onMessage(handler: (message: unknown) => void): void {
         messageHandlers.push(handler);

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19135,10 +19135,7 @@ var WsDialer = class {
     });
     const transport = {
       send(message) {
-        try {
-          ws.send(JSON.stringify(message));
-        } catch {
-        }
+        ws.send(JSON.stringify(message));
       },
       onMessage(handler) {
         messageHandlers.push(handler);
@@ -19201,11 +19198,8 @@ var UdsDialer = class {
     });
     const transport = {
       send(message) {
-        try {
-          socket.write(`${JSON.stringify(message)}
+        socket.write(`${JSON.stringify(message)}
 `);
-        } catch {
-        }
       },
       onMessage(handler) {
         messageHandlers.push(handler);


### PR DESCRIPTION
## Summary

The cascade-on-send-failure fix in #49 / 2.2.1 was incomplete. Both `WsDialer` and `UdsDialer` (in `packages/mcp/src/dialer.ts`) wrapped their inner send (`ws.send` / `socket.write`) in a bare `try/catch` that swallowed everything with the comment "socket likely closed; ignore". The session-dispatcher wrapper at `gateway.ts:572` was supposed to close the channel when `transport.send` threw, but it never saw a throw - the dialer ate it first.

User symptom: `tesseron__read_resource` and `tesseron__invoke_action` keep hanging indefinitely after a Vite HMR cycle / browser refresh, even on `@tesseron/*@2.2.1` with the previous fix in place.

This PR removes the swallows. The dispatcher wrapper now actually catches the inner throw, closes the channel, fires `transport.onClose`, and `rejectAllPending` rejects every outstanding request with `TransportClosedError`. The bridge / MCP tool surfaces a real error instead of a hang.

## Why was this missed in #49?

#49 added the `try/catch` around the dispatcher's send wrapper assuming `transport.send` would let throws propagate naturally - which is what the SDK-side transport (`packages/web/src/transport.ts`) does. The gateway-side dialers had their own swallow layer that wasn't audited at the time.

## Test plan

- [x] `pnpm exec turbo run test typecheck --force`: 30 tasks green. Includes the 67-test `@tesseron/mcp` integration suite that exercises real dial/connect flows over both `ws` and `uds` transports.
- [x] `pnpm lint` clean.
- [x] Plugin bundle (`plugin/server/index.cjs`) rebuilt to pick up the change.

## Compatibility

Pure runtime fix. No public API surface changed.

Generated with Claude Code.
