### PR TITLE
feat: tesseron/claimed notification clears spent claim codes from UI

### DIFF
--- a/.changeset/feat-tesseron-claimed-notification.md
+++ b/.changeset/feat-tesseron-claimed-notification.md
@@ -1,0 +1,13 @@
+---
+'@tesseron/core': minor
+'@tesseron/mcp': minor
+'@tesseron/react': minor
+---
+
+Add `tesseron/claimed` notification (gateway → SDK) so apps can clear the spent claim code from their UI once an agent has redeemed it.
+
+Previously, `useTesseronConnection`'s `claimCode` field reflected whatever was in the welcome forever - the SDK had no way to learn that the code had been consumed. Apps rendering a "Connect Claude" banner would keep showing a dead string, and users would keep trying to type it at the agent (which would correctly reject it as "already claimed", but only after a confusing round-trip).
+
+The gateway now emits a `tesseron/claimed` notification carrying `{ agent, claimedAt }` when `tesseron__claim_session` succeeds. The SDK patches the cached `WelcomeResult` in place (clearing `claimCode`, updating `agent`) and fires any listener registered via the new `client.onWelcomeChange(...)` API. `@tesseron/react`'s `useTesseronConnection` propagates the change so `connection.claimCode` becomes `undefined` and `connection.welcome.agent` reflects the claiming agent's identity.
+
+Resolves concern (5) from tesseron#53. No protocol-version bump - this is a new optional notification that older SDKs simply ignore.

--- a/docs/src/content/docs/protocol/handshake.mdx
+++ b/docs/src/content/docs/protocol/handshake.mdx
@@ -122,9 +122,29 @@ The agent calls the built-in `tesseron__claim_session` MCP tool with `{ code: "A
 - Marks the session `claimed: true`.
 - Sets `agent` on the session to the agent's identity.
 - Emits `notifications/tools/list_changed` so the agent refreshes its tool list.
+- Sends a `tesseron/claimed` notification to the SDK (see below) so the app can clear the spent claim code from its UI.
 - From this point, `tools/call <app_id>__<action>` is allowed.
 
 If the code doesn't match (expired, wrong app, already used): error `-32009 Unauthorized`.
+
+## The `tesseron/claimed` notification
+
+Once a session is claimed, the previously-issued `claimCode` is consumed and no longer redeemable. The gateway notifies the SDK so the app can update any UI that displays the code (otherwise users keep trying to type a dead string into the agent).
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "tesseron/claimed",
+  "params": {
+    "agent": { "id": "claude-code", "name": "Claude Code" },
+    "claimedAt": 1714145210123
+  }
+}
+```
+
+`@tesseron/web` and `@tesseron/core` handle this internally: the cached `WelcomeResult` is patched in place (`agent` updated, `claimCode` cleared) and any listener registered via `client.onWelcomeChange(...)` fires. `@tesseron/react`'s `useTesseronConnection` clears `connection.claimCode` and updates `connection.welcome.agent` on the next render. Apps wiring the lower-level client directly should subscribe with `client.onWelcomeChange(...)` to drive their own UI updates.
+
+The notification only fires on a fresh-hello path. After a successful `tesseron/resume` the welcome carries no `claimCode` to begin with, so no further notification is needed.
 
 ## Why out-of-band claim?
 

--- a/docs/src/content/docs/sdk/typescript/react.md
+++ b/docs/src/content/docs/sdk/typescript/react.md
@@ -61,6 +61,8 @@ interface TesseronConnectionState {
 - `'resumed'` - `tesseron/resume` succeeded; the prior session was reattached.
 - `'failed'` - resume was attempted but the gateway rejected it; the hook fell back to a fresh `tesseron/hello` and persisted the new credentials. Useful for telemetry, and for UIs that want to show "your previous session expired" instead of silently switching to a new claim code.
 
+`claimCode` clears automatically once the session has been claimed by an agent. The gateway sends a `tesseron/claimed` notification (see [protocol/handshake](/protocol/handshake/)) and the hook updates `claimCode` to `undefined` and merges the new `agent` identity into `welcome.agent` on the next render. Render the claim banner with `connection.claimCode != null` (rather than from a snapshot taken at mount time) and it will disappear on its own after the agent claims.
+
 Options:
 
 ```ts

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -25,6 +25,7 @@ import {
   type ActionManifestEntry,
   type ActionResultPayload,
   type AppMetadata,
+  type ClaimedParams,
   type HelloParams,
   PROTOCOL_VERSION,
   type ResourceManifestEntry,
@@ -148,6 +149,7 @@ export class TesseronClient implements BuilderRegistry {
   private readonly resources = new Map<string, ResourceDefinitionWithSchema>();
   private readonly invocations = new Map<string, AbortController>();
   private readonly subscriptions = new Map<string, ActiveSubscription>();
+  private readonly welcomeListeners = new Set<(welcome: WelcomeResult) => void>();
 
   private dispatcher?: JsonRpcDispatcher;
   private transport?: Transport;
@@ -288,6 +290,30 @@ export class TesseronClient implements BuilderRegistry {
       return undefined;
     });
 
+    // The gateway fires `tesseron/claimed` when an MCP agent calls
+    // `tesseron__claim_session` with our pending claim code. After this
+    // arrives the code is consumed - merge the agent identity into the
+    // welcome and clear `claimCode` so consumers (e.g. `useTesseronConnection`'s
+    // `claimCode` field) stop displaying a code that can no longer be redeemed.
+    dispatcher.onNotification('tesseron/claimed', (params) => {
+      const claimed = params as ClaimedParams;
+      if (!this.welcome) return;
+      this.welcome = {
+        ...this.welcome,
+        agent: claimed.agent,
+        claimCode: undefined,
+      };
+      for (const listener of this.welcomeListeners) {
+        try {
+          listener(this.welcome);
+        } catch {
+          // Listener errors must not abort the others or leave us in a
+          // half-notified state. Application bugs in user listeners are not
+          // the SDK's problem to surface.
+        }
+      }
+    });
+
     const baseParams = {
       protocolVersion: PROTOCOL_VERSION,
       app: this.appConfig,
@@ -316,6 +342,24 @@ export class TesseronClient implements BuilderRegistry {
 
   getWelcome(): WelcomeResult | undefined {
     return this.welcome;
+  }
+
+  /**
+   * Subscribe to changes in {@link WelcomeResult}. The listener fires on
+   * server-driven welcome updates after the initial connect resolves -
+   * currently only the `tesseron/claimed` notification, which clears
+   * `claimCode` and updates `agent`. Returns an unsubscribe function.
+   *
+   * Use this to drive UI state that depends on the welcome (e.g. a claim-code
+   * banner that should disappear once the session has been claimed). The
+   * listener is NOT called for the initial value returned from `connect()` -
+   * read that from the resolved welcome directly.
+   */
+  onWelcomeChange(listener: (welcome: WelcomeResult) => void): () => void {
+    this.welcomeListeners.add(listener);
+    return () => {
+      this.welcomeListeners.delete(listener);
+    };
   }
 
   private actionManifest(): ActionManifestEntry[] {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -306,10 +306,11 @@ export class TesseronClient implements BuilderRegistry {
       for (const listener of this.welcomeListeners) {
         try {
           listener(this.welcome);
-        } catch {
+        } catch (err) {
           // Listener errors must not abort the others or leave us in a
-          // half-notified state. Application bugs in user listeners are not
-          // the SDK's problem to surface.
+          // half-notified state, but a thrown listener is almost always an
+          // app bug worth surfacing. Warn-and-continue.
+          console.warn('[tesseron] welcome listener threw', err);
         }
       }
     });

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -291,11 +291,26 @@ export interface TesseronMethods {
   'resources/unsubscribe': { params: ResourceUnsubscribeParams; result: undefined };
 }
 
+/**
+ * Parameters of the `tesseron/claimed` notification sent by the gateway to the
+ * SDK when an agent calls `tesseron__claim_session` on a session that was
+ * previously in the awaiting-claim state. After this notification fires, the
+ * session's `claimCode` is consumed and no longer claimable; consumers
+ * displaying the code should clear it.
+ */
+export interface ClaimedParams {
+  /** Identity of the agent that just claimed this session. */
+  agent: AgentIdentity;
+  /** Wall-clock timestamp (ms) at which the claim was processed. */
+  claimedAt: number;
+}
+
 export interface TesseronNotifications {
   'actions/progress': ActionProgressParams;
   'actions/cancel': ActionCancelParams;
   'actions/list_changed': { actions: ActionManifestEntry[] };
   'resources/list_changed': { resources: ResourceManifestEntry[] };
   'resources/updated': ResourceUpdatedParams;
+  'tesseron/claimed': ClaimedParams;
   log: LogParams;
 }

--- a/packages/core/src/protocol.ts
+++ b/packages/core/src/protocol.ts
@@ -301,7 +301,7 @@ export interface TesseronMethods {
 export interface ClaimedParams {
   /** Identity of the agent that just claimed this session. */
   agent: AgentIdentity;
-  /** Wall-clock timestamp (ms) at which the claim was processed. */
+  /** Unix epoch milliseconds at which the gateway processed the claim. */
   claimedAt: number;
 }
 

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -196,4 +196,51 @@ describe('TesseronClient end-to-end', () => {
 
     expect(closed).toBe(true);
   });
+
+  it('clears welcome.claimCode and updates agent when tesseron/claimed arrives', async () => {
+    const client = new TesseronClient();
+    client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+
+    let clientMessageHandler: ((m: unknown) => void) | undefined;
+    const gateway = new JsonRpcDispatcher((m) => {
+      queueMicrotask(() => clientMessageHandler?.(m));
+    });
+    gateway.on('tesseron/hello', () => ({
+      sessionId: 'test',
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+      agent: { id: 'pending', name: 'Awaiting agent' },
+      claimCode: 'CWGS-ND',
+    }));
+
+    const transport: Transport = {
+      send: (m) => queueMicrotask(() => gateway.receive(m)),
+      onMessage: (h) => {
+        clientMessageHandler = h;
+      },
+      onClose: () => {},
+      close: () => {},
+    };
+
+    const welcome = await client.connect(transport);
+    expect(welcome.claimCode).toBe('CWGS-ND');
+    expect(client.getWelcome()?.claimCode).toBe('CWGS-ND');
+
+    const observed: Array<{ agentId: string; claimCode?: string }> = [];
+    client.onWelcomeChange((w) => {
+      observed.push({ agentId: w.agent.id, claimCode: w.claimCode });
+    });
+
+    // Gateway fires tesseron/claimed when an agent claims the session.
+    gateway.notify('tesseron/claimed', {
+      agent: { id: 'claude-code', name: 'Claude Code' },
+      claimedAt: 1000,
+    });
+    // Drain the queueMicrotask cascade.
+    await new Promise((r) => setImmediate(r));
+
+    expect(observed).toEqual([{ agentId: 'claude-code', claimCode: undefined }]);
+    expect(client.getWelcome()?.claimCode).toBeUndefined();
+    expect(client.getWelcome()?.agent).toEqual({ id: 'claude-code', name: 'Claude Code' });
+  });
 });

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -445,21 +445,24 @@ export class TesseronGateway extends EventEmitter {
     // Tell the SDK side the session is now claimed. The browser app's
     // `useTesseronConnection` hook clears `connection.claimCode` on receipt
     // so the UI stops displaying a code that can no longer be redeemed.
-    // Catching exceptions defensively: notify is fire-and-forget but we
-    // never want a transport hiccup here to abort the claim transition.
-    try {
-      session.dispatcher.notify('tesseron/claimed', {
-        agent: {
-          id: this.agentCapabilities.clientName ?? 'unknown',
-          name: this.agentCapabilities.clientName ?? 'unknown',
-        },
-        claimedAt: session.claimedAt,
-      });
-    } catch (err) {
-      logToStderr(
-        `[tesseron] failed to notify SDK of claim for ${session.id}: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
+    // notify() is fire-and-forget; the dispatcher's send wrapper handles any
+    // transport-level failures by closing the channel, so no try/catch here.
+    //
+    // Use the same `pending` / `Awaiting agent` fallback the welcome uses
+    // (gateway.ts:731-734) when `clientName` isn't populated. The MCP
+    // `initialize` always runs before `tools/call`, so in practice
+    // `clientName` is set by the time we get here, but the symmetric
+    // fallback avoids silently regressing a previously-meaningful welcome
+    // agent if some embedder reaches `claimSession` without an `initialize`
+    // having happened.
+    const clientName = this.agentCapabilities.clientName;
+    session.dispatcher.notify('tesseron/claimed', {
+      agent: {
+        id: clientName ?? 'pending',
+        name: clientName ?? 'Awaiting agent',
+      },
+      claimedAt: session.claimedAt,
+    });
     this.emit('sessions-changed');
     return session;
   }

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -431,7 +431,8 @@ export class TesseronGateway extends EventEmitter {
   /**
    * Attempts to claim a pending session by its claim code. Returns the claimed
    * session, or `null` if the code is unknown or already consumed. Emits
-   * `sessions-changed` on success.
+   * `sessions-changed` on success and a `tesseron/claimed` notification to the
+   * SDK so consumers can clear the now-spent `claimCode` from their UI.
    */
   claimSession(claimCode: string): Session | null {
     const sessionId = this.pendingClaims.get(claimCode.toUpperCase());
@@ -441,6 +442,24 @@ export class TesseronGateway extends EventEmitter {
     session.claimed = true;
     session.claimedAt = Date.now();
     this.pendingClaims.delete(claimCode.toUpperCase());
+    // Tell the SDK side the session is now claimed. The browser app's
+    // `useTesseronConnection` hook clears `connection.claimCode` on receipt
+    // so the UI stops displaying a code that can no longer be redeemed.
+    // Catching exceptions defensively: notify is fire-and-forget but we
+    // never want a transport hiccup here to abort the claim transition.
+    try {
+      session.dispatcher.notify('tesseron/claimed', {
+        agent: {
+          id: this.agentCapabilities.clientName ?? 'unknown',
+          name: this.agentCapabilities.clientName ?? 'unknown',
+        },
+        claimedAt: session.claimedAt,
+      });
+    } catch (err) {
+      logToStderr(
+        `[tesseron] failed to notify SDK of claim for ${session.id}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
     this.emit('sessions-changed');
     return session;
   }

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -340,8 +340,24 @@ export function useTesseronConnection(
       });
     });
 
+    // Subscribe to server-driven welcome updates. Currently only fires on
+    // `tesseron/claimed` (which clears `claimCode` and updates `agent`),
+    // but the API is generic so future welcome-mutating notifications get
+    // surfaced for free. The unsubscribe runs on unmount or dep change.
+    const unsubscribe = client.onWelcomeChange((welcome) => {
+      if (cancelled) return;
+      setState((prev) => {
+        // Only patch when we're already 'open'; otherwise the welcome update
+        // arrived during connect() and the run() block above will deliver
+        // the consistent state.
+        if (prev.status !== 'open') return prev;
+        return { ...prev, welcome, claimCode: welcome.claimCode };
+      });
+    });
+
     return () => {
       cancelled = true;
+      unsubscribe();
     };
   }, [enabled, url, client]);
 

--- a/packages/react/test/use-tesseron-connection.test.tsx
+++ b/packages/react/test/use-tesseron-connection.test.tsx
@@ -42,8 +42,10 @@ interface ConnectCall {
 function makeFakeClient(plan: Array<WelcomeResult | TesseronError | Error>): {
   client: WebTesseronClient;
   calls: ConnectCall[];
+  emitWelcomeChange: (welcome: WelcomeResult) => void;
 } {
   const calls: ConnectCall[] = [];
+  const welcomeListeners = new Set<(w: WelcomeResult) => void>();
   let i = 0;
   const client = {
     connect: vi.fn(async (url?: string, options?: ConnectOptions) => {
@@ -53,8 +55,17 @@ function makeFakeClient(plan: Array<WelcomeResult | TesseronError | Error>): {
       if (next instanceof Error) throw next;
       return next;
     }),
+    onWelcomeChange: (listener: (w: WelcomeResult) => void) => {
+      welcomeListeners.add(listener);
+      return () => {
+        welcomeListeners.delete(listener);
+      };
+    },
   } as unknown as WebTesseronClient;
-  return { client, calls };
+  const emitWelcomeChange = (welcome: WelcomeResult): void => {
+    for (const l of welcomeListeners) l(welcome);
+  };
+  return { client, calls, emitWelcomeChange };
 }
 
 function ConnectionProbe(props: {
@@ -358,6 +369,41 @@ describe('useTesseronConnection - resume: ResumeStorage (custom backend)', () =>
     expect(state.status).toBe('open');
     expect(state.welcome).toEqual(fresh);
     expect(backend.save).toHaveBeenCalled();
+  });
+
+  it('clears claimCode and updates agent when the gateway emits tesseron/claimed', async () => {
+    const fresh = makeWelcome({ resumeToken: 'tok-A', claimCode: 'AAA-BBB' });
+    const { client, emitWelcomeChange } = makeFakeClient([fresh]);
+
+    let latest: TesseronConnectionState = { status: 'idle' };
+    await act(async () => {
+      render(
+        <ConnectionProbe
+          client={client}
+          onState={(s) => {
+            latest = s;
+          }}
+        />,
+      );
+    });
+    await waitFor(() => {
+      expect(latest.status).toBe('open');
+    });
+    expect(latest.claimCode).toBe('AAA-BBB');
+
+    // The gateway-side claim handler triggers tesseron/claimed; the SDK
+    // updates `welcome` and our hook should clear claimCode in state.
+    await act(async () => {
+      emitWelcomeChange({
+        ...fresh,
+        agent: { id: 'claude-code', name: 'Claude Code' },
+        claimCode: undefined,
+      });
+    });
+
+    expect(latest.status).toBe('open');
+    expect(latest.claimCode).toBeUndefined();
+    expect(latest.welcome?.agent).toEqual({ id: 'claude-code', name: 'Claude Code' });
   });
 
   it('still falls back to a fresh hello when clear() throws during ResumeFailed recovery', async () => {

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19504,7 +19504,8 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
   /**
    * Attempts to claim a pending session by its claim code. Returns the claimed
    * session, or `null` if the code is unknown or already consumed. Emits
-   * `sessions-changed` on success.
+   * `sessions-changed` on success and a `tesseron/claimed` notification to the
+   * SDK so consumers can clear the now-spent `claimCode` from their UI.
    */
   claimSession(claimCode) {
     const sessionId = this.pendingClaims.get(claimCode.toUpperCase());
@@ -19514,6 +19515,19 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     session.claimed = true;
     session.claimedAt = Date.now();
     this.pendingClaims.delete(claimCode.toUpperCase());
+    try {
+      session.dispatcher.notify("tesseron/claimed", {
+        agent: {
+          id: this.agentCapabilities.clientName ?? "unknown",
+          name: this.agentCapabilities.clientName ?? "unknown"
+        },
+        claimedAt: session.claimedAt
+      });
+    } catch (err) {
+      logToStderr(
+        `[tesseron] failed to notify SDK of claim for ${session.id}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
     this.emit("sessions-changed");
     return session;
   }

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19515,19 +19515,14 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     session.claimed = true;
     session.claimedAt = Date.now();
     this.pendingClaims.delete(claimCode.toUpperCase());
-    try {
-      session.dispatcher.notify("tesseron/claimed", {
-        agent: {
-          id: this.agentCapabilities.clientName ?? "unknown",
-          name: this.agentCapabilities.clientName ?? "unknown"
-        },
-        claimedAt: session.claimedAt
-      });
-    } catch (err) {
-      logToStderr(
-        `[tesseron] failed to notify SDK of claim for ${session.id}: ${err instanceof Error ? err.message : String(err)}`
-      );
-    }
+    const clientName = this.agentCapabilities.clientName;
+    session.dispatcher.notify("tesseron/claimed", {
+      agent: {
+        id: clientName ?? "pending",
+        name: clientName ?? "Awaiting agent"
+      },
+      claimedAt: session.claimedAt
+    });
     this.emit("sessions-changed");
     return session;
   }


### PR DESCRIPTION
Closes the second concern of tesseron#53 (concern 5 in the issue's list of fix directions).

## Summary

Apps rendering a claim banner from `useTesseronConnection`'s `claimCode` were stuck displaying a string that no longer redeemed once the session was claimed. The SDK had no way to learn the code had been consumed; the welcome was a one-shot that captured pre-claim state forever. Users would keep trying to type the same code at agents, getting "already claimed" errors after a confusing round-trip.

This PR adds a `tesseron/claimed` notification (gateway → SDK) that fires when `tesseron__claim_session` succeeds. The SDK clears `claimCode` from its cached `WelcomeResult`, updates `agent` to the claiming identity, and fires every listener registered via a new `client.onWelcomeChange(...)` API. `@tesseron/react`'s `useTesseronConnection` propagates the change so the banner disappears on its own.

## Wire format

```json
{
  "jsonrpc": "2.0",
  "method": "tesseron/claimed",
  "params": {
    "agent": { "id": "claude-code", "name": "Claude Code" },
    "claimedAt": 1714145210123
  }
}
```

This is a **new optional notification** - older SDKs simply ignore unknown methods, so there's no protocol major/minor bump. The notification only fires on the fresh-hello path; resume welcomes already carry no `claimCode`.

## API additions

```ts
// @tesseron/core
client.onWelcomeChange((welcome) => {
  // fired on tesseron/claimed; future welcome-mutating notifications too
});

// @tesseron/react
const conn = useTesseronConnection();
// conn.claimCode is undefined after the agent claims
// conn.welcome.agent reflects the claiming agent's identity
```

App code that already renders the banner with `connection.claimCode != null` works unchanged and gets the new disappear-on-claim behavior for free.

## Test plan

- [x] `pnpm exec turbo run test typecheck --force`: 30 tasks green. New tests: 1 in `@tesseron/core` (notification handler clears welcome + fires listener), 1 in `@tesseron/react` (hook propagates change to state). 32 + 17 tests passing.
- [x] `pnpm lint` clean.
- [x] Plugin bundle (`plugin/server/index.cjs`) rebuilt to pick up the gateway change.
- [x] Docs: `protocol/handshake.mdx` documents the notification + wire format; `sdk/typescript/react.md` documents the hook behavior.

## Compatibility

Pure addition. No public API removed or renamed. `WelcomeResult` shape unchanged - the gateway just mutates the SDK-side cached value. Apps that don't subscribe via `onWelcomeChange` and don't use the React hook continue to see the original welcome's `claimCode` indefinitely (the prior behavior).

Generated with Claude Code.
