### PR TITLE
fix(mcp): tombstone stale instance manifests + surface cross-gateway claim ownership

### DIFF
--- a/.changeset/fix-mcp-stale-manifest-and-claim-record.md
+++ b/.changeset/fix-mcp-stale-manifest-and-claim-record.md
@@ -1,0 +1,14 @@
+---
+'@tesseron/mcp': patch
+'@tesseron/core': patch
+'@tesseron/server': patch
+'@tesseron/vite': patch
+---
+
+Cross-gateway claim-code disambiguation + stale-manifest tombstoning. Two layers, both addressing concerns left open in tesseron#53 after the single-owner binding fix landed in #54:
+
+**Stale instance manifests are now skipped and tombstoned.** The SDK side (`@tesseron/server`'s WS and UDS transports, `@tesseron/vite`) now stamps `pid: process.pid` on every `~/.tesseron/instances/<id>.json` it writes. The MCP gateway probes `process.kill(pid, 0)` on each manifest before dialing. Manifests whose owning process is gone get unlinked instead of dialed, so a long-running gateway no longer pays a connection-refused round-trip every poll tick for browser tabs whose Vite server died without a clean shutdown. Older SDKs without `pid` are still trusted (no regression for in-flight upgrades). The `InstanceManifest` type in `@tesseron/core` gains an optional `pid?: number` field.
+
+**Claim codes now carry a cross-gateway ownership breadcrumb.** When the gateway mints a claim code, it writes `~/.tesseron/claims/<CODE>.json` with `{ sessionId, appId, appName, gatewayPid, mintedAt }`. The breadcrumb is removed atomically when the owning gateway claims the session, when an unclaimed session closes, and when the gateway shuts down. When `tesseron__claim_session` is called on a gateway that doesn't own the code locally, it now reads the breadcrumb and surfaces a useful error: `"Claim code XYZ-12 belongs to a different Tesseron gateway (pid 12345, app \"My App\", minted 2026-04-26T15:16:09Z). Switch to the Claude session that opened this connection..."` instead of the previous opaque "No pending session found". If the breadcrumb's gatewayPid is dead, the error reports a stale claim and tombstones the file. This solves the "guess which Claude window owns this code" problem on multi-session developer machines without introducing a cross-process rendezvous protocol.
+
+`TesseronGateway` exposes a new `describeForeignClaim(code)` method returning `{ kind: 'foreign' | 'stale' | 'unknown', ... }` for embedders that build their own claim UIs, and a new `isPidAlive(pid)` helper export.

--- a/docs/src/content/docs/protocol/handshake.mdx
+++ b/docs/src/content/docs/protocol/handshake.mdx
@@ -150,6 +150,28 @@ The notification only fires on a fresh-hello path. After a successful `tesseron/
 
 Because in-band claim is just security theatre over localhost. Anything running on the user's machine can read `~/.tesseron/instances/` and dial one of those endpoints. The claim code is a **user-typed confirmation** - proof that a human authorised this specific browser tab to be controlled by this specific agent session. It's short enough to read aloud, long enough to resist guessing (~1.5 billion combinations of 6 upper-case alphanumeric minus confusables).
 
+## Multiple gateways on one machine
+
+A developer machine may have several Tesseron MCP gateways alive at once - typically one per running Claude Code session, sometimes more if a dev checkout's `plugin/server/index.cjs` is also loaded. Each gateway watches `~/.tesseron/instances/` and dials the bindings it discovers. The first gateway to upgrade a given browser instance owns the bridge for that session (the Vite plugin rejects subsequent upgrades with `HTTP 409`); the welcome+claim code returns through that one gateway.
+
+Sibling gateways therefore see the user-typed claim code but have no matching pending session locally. Without a hint they would fail with a flat "no pending session", and the user has no way to tell which Claude window minted the code. To make the failure explicit, every gateway drops a breadcrumb at `~/.tesseron/claims/<CODE>.json` when it mints a claim code:
+
+```json
+{
+  "version": 1,
+  "code": "AB3X-7K",
+  "sessionId": "s_a1b2c3de1234567",
+  "appId": "shop",
+  "appName": "Acme Shop",
+  "gatewayPid": 12345,
+  "mintedAt": 1714145210123
+}
+```
+
+A non-owning gateway that receives `tesseron__claim_session` for a code it doesn't own locally reads the breadcrumb and surfaces an error of the form *"Claim code AB3X-7K belongs to a different Tesseron gateway (pid 12345, app 'Acme Shop', minted 2026-04-26T15:16:09Z). Switch to the Claude session that opened this connection..."*. The breadcrumb is removed when the owning gateway claims the session, when an unclaimed session closes, and on gateway shutdown; if the breadcrumb's `gatewayPid` is no longer running, the file is tombstoned and a "stale" error is returned instead.
+
+This is a UX hint, not a transfer protocol - claim ownership stays with the gateway that minted the code. To actually claim, the user has to be in the right Claude session.
+
 ## Protocol version mismatch
 
 The MCP gateway parses `protocolVersion` as `major.minor`:

--- a/docs/src/content/docs/protocol/transport.md
+++ b/docs/src/content/docs/protocol/transport.md
@@ -32,6 +32,7 @@ Every Tesseron app hosts its own endpoint - whatever shape the binding requires 
   "instanceId": "inst-mocythay-v0hh50",
   "appName": "node-prompts",
   "addedAt": 1777038462692,
+  "pid": 24837,
   "transport":
     | { "kind": "ws",  "url":  "ws://127.0.0.1:64872/" }
     | { "kind": "uds", "path": "/tmp/tesseron-Xy7/sock" }
@@ -39,6 +40,8 @@ Every Tesseron app hosts its own endpoint - whatever shape the binding requires 
 ```
 
 The gateway watches that directory, reads each new file, picks the dialer matching `transport.kind`, and connects. The app accepts the one inbound connection; the standard handshake follows.
+
+`pid` is optional and identifies the SDK-side process that owns the instance. Gateways probe it with `process.kill(pid, 0)` and tombstone (unlink) manifests whose owner is gone, so a Vite dev server killed without a clean `httpServer.close` doesn't leave a corpse the gateway re-dials every poll tick. Manifests written by older SDKs (no `pid`) are still trusted.
 
 There is no fixed gateway port. There is no `DEFAULT_GATEWAY_URL` apps dial out to. The gateway itself binds nothing.
 

--- a/docs/src/content/docs/sdk/typescript/mcp.md
+++ b/docs/src/content/docs/sdk/typescript/mcp.md
@@ -47,11 +47,14 @@ Apps announce themselves by writing a JSON v2 manifest to `~/.tesseron/instances
   "instanceId": "inst-abc123",
   "appName": "vue-todo",
   "addedAt": 1777038462692,
+  "pid": 24837,
   "transport":
     | { "kind": "ws",  "url":  "ws://127.0.0.1:64872/" }
     | { "kind": "uds", "path": "/tmp/tesseron-Xy7/sock" }
 }
 ```
+
+`pid` is optional. Gateways probe `process.kill(pid, 0)` on each manifest before dialing and tombstone manifests whose owner is gone, so a dev server killed without a clean shutdown doesn't leave a corpse the gateway re-dials forever. Older SDKs that omit the field stay trusted.
 
 The gateway watches the directory (inotify / `fs.watch`, with a 2-second poll as a platform fallback), notices the new file, picks the dialer matching `transport.kind`, and connects. The app accepts that one connection; the standard `tesseron/hello` → `welcome` handshake follows.
 
@@ -96,6 +99,8 @@ Routing: `tools/call shop__searchProducts` finds the session whose `app.id === "
 ## Claim code generation
 
 Codes are six alphanumeric characters minus confusables (no `0`, `1`, `I`, `L`, `O`), formatted `AAAA-BB`. Drawn from `Math.random()`. Stored on the session, claimed via `gateway.claimSession(code)`, cleaned on claim or session close.
+
+Each minted code also drops a breadcrumb at `~/.tesseron/claims/<CODE>.json` so a sibling gateway (a parallel Claude Code session, a leftover dev gateway) that receives `tesseron__claim_session` for a code it doesn't own locally can surface a "claim code belongs to gateway pid N" error instead of a flat "no pending session". The breadcrumb is removed on successful claim, on unclaimed close, and on `gateway.stop()`. Embedders building their own claim UI can call `gateway.describeForeignClaim(code)` to drive the same behaviour. See the [handshake page](/protocol/handshake/#multiple-gateways-on-one-machine) for the full picture.
 
 ## Where the plugin bundles it
 

--- a/packages/core/src/transport-spec.ts
+++ b/packages/core/src/transport-spec.ts
@@ -36,5 +36,14 @@ export interface InstanceManifest {
   appName: string;
   /** Unix-millis timestamp of when the manifest was written. */
   addedAt: number;
+  /**
+   * Process id of the SDK side that owns this instance (i.e. the Vite dev
+   * server, Node app, etc.). Optional for backward compatibility — older
+   * SDKs omit it; gateways treat absence as "trust" so upgrading the
+   * gateway before the SDK doesn't tombstone working manifests. When
+   * present, gateways probe `process.kill(pid, 0)` and skip / tombstone
+   * manifests whose owning process is gone. See tesseron#53.
+   */
+  pid?: number;
   transport: TransportSpec;
 }

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -3,7 +3,7 @@ import { timingSafeEqual } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { existsSync } from 'node:fs';
 import { watch } from 'node:fs';
-import { readFile, readdir } from 'node:fs/promises';
+import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -189,6 +189,14 @@ export class TesseronGateway extends EventEmitter {
   private readonly dialers: Map<TransportSpec['kind'], GatewayDialer>;
   private discoveryWatchers: Array<ReturnType<typeof watch>> = [];
   private discoveryInterval?: ReturnType<typeof setInterval>;
+  /**
+   * Manifest paths already attempted to tombstone (via `unlink`). Keeps the
+   * 2 s discovery poll from re-logging "tombstoning stale instance manifest"
+   * for a file the OS won't let us delete (EACCES, EBUSY on Windows). Still
+   * re-tries the unlink on every tick — the file might genuinely become
+   * deletable later — but suppresses the repeated stderr line.
+   */
+  private readonly tombstonedManifests = new Set<string>();
 
   constructor(private readonly options: GatewayOptions = {}) {
     super();
@@ -202,7 +210,21 @@ export class TesseronGateway extends EventEmitter {
   /** Closes all sessions, outbound connections, and discovery watchers. */
   async stop(): Promise<void> {
     this.stopped = true;
+    // Capture in-flight breadcrumb writes for unclaimed sessions before we
+    // clear the maps. A sibling gateway that boots after this one shouldn't
+    // keep seeing our codes listed as "live" once we're gone, so sweep
+    // their breadcrumbs explicitly. Awaiting the writes first guarantees a
+    // fast-stop after a fresh hello doesn't unlink-before-write and orphan
+    // the late file. The transport.onClose path on each closed session
+    // would also call removeClaimRecord; the awaitThen helper makes the
+    // double-call idempotent.
+    const pendingClaimRemovals: Array<Promise<void>> = [];
     for (const session of this.sessions.values()) {
+      if (!session.claimed) {
+        pendingClaimRemovals.push(
+          awaitThenRemoveClaimRecord(session.claimRecordWritten, session.claimCode),
+        );
+      }
       session.transport.close('Gateway shutting down');
     }
     this.sessions.clear();
@@ -224,6 +246,10 @@ export class TesseronGateway extends EventEmitter {
       dialed.close('Gateway shutting down');
     }
     this.connected.clear();
+    // Wait for the breadcrumb unlinks to land before resolving stop() —
+    // tests and embedders that delete the home dir straight after stop()
+    // would otherwise race the file system.
+    await Promise.allSettled(pendingClaimRemovals);
   }
 
   /** Installs the handler invoked for `sampling/request`. Pass `undefined` to clear. */
@@ -319,6 +345,38 @@ export class TesseronGateway extends EventEmitter {
             const content = await readFile(join(instancesDir, file), 'utf-8');
             const data = JSON.parse(content) as Partial<InstanceManifest>;
             if (data.version !== 2 || !data.transport) continue;
+            // Skip manifests whose owning process is gone — every gateway
+            // would otherwise keep retrying a dead WS / UDS endpoint forever.
+            // Tombstone the file so subsequent ticks don't re-evaluate it
+            // and so future polls aren't paced by a growing queue of corpses.
+            // pid is optional (older SDKs / v1 manifests) — absent ⇒ trust.
+            // See tesseron#53.
+            if (data.pid !== undefined && !isPidAlive(data.pid)) {
+              const path = join(instancesDir, file);
+              const alreadyLogged = this.tombstonedManifests.has(path);
+              try {
+                await unlink(path);
+                if (!alreadyLogged) {
+                  logToStderr(
+                    `[tesseron] tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`,
+                  );
+                }
+                this.tombstonedManifests.delete(path);
+              } catch (unlinkErr) {
+                // Log the failure once per file so a stuck file (EACCES,
+                // EBUSY from antivirus on Windows) is visible but doesn't
+                // spam stderr every 2 s. Subsequent ticks still retry the
+                // unlink in case the lock clears.
+                if (!alreadyLogged) {
+                  const reason = unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr);
+                  logToStderr(
+                    `[tesseron] could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} — remove the file manually if it persists`,
+                  );
+                  this.tombstonedManifests.add(path);
+                }
+              }
+              continue;
+            }
             const id = data.instanceId ?? instanceId;
             this.connectToApp(id, data.transport).catch((err: Error) => {
               logToStderr(`[tesseron] could not connect to instance ${id}: ${err.message}`);
@@ -429,6 +487,40 @@ export class TesseronGateway extends EventEmitter {
   }
 
   /**
+   * Look up the cross-gateway breadcrumb for `code` in `~/.tesseron/claims/`.
+   * Used by the MCP `tesseron__claim_session` handler when its own
+   * `claimSession` returns null: instead of the previous flat "no pending
+   * session" error, the tool can report "this code was minted by gateway pid
+   * N at HH:MM:SS — switch to that Claude session and try again". On the
+   * `stale` outcome only — never on `foreign` or `unknown` — the breadcrumb
+   * file is unlinked as a side-effect so future probes don't keep reporting
+   * the same dead pid. See tesseron#53.
+   */
+  async describeForeignClaim(code: string): Promise<ForeignClaim> {
+    const record = await readClaimRecord(code);
+    if (!record) return { kind: 'unknown' };
+    if (!isPidAlive(record.gatewayPid)) {
+      // Owning gateway is gone — clean up the breadcrumb so the next probe
+      // doesn't keep reporting the same dead pid. Best-effort.
+      void removeClaimRecord(code);
+      return {
+        kind: 'stale',
+        gatewayPid: record.gatewayPid,
+        mintedAt: record.mintedAt,
+        appId: record.appId,
+        appName: record.appName,
+      };
+    }
+    return {
+      kind: 'foreign',
+      gatewayPid: record.gatewayPid,
+      mintedAt: record.mintedAt,
+      appId: record.appId,
+      appName: record.appName,
+    };
+  }
+
+  /**
    * Attempts to claim a pending session by its claim code. Returns the claimed
    * session, or `null` if the code is unknown or already consumed. Emits
    * `sessions-changed` on success and a `tesseron/claimed` notification to the
@@ -442,6 +534,13 @@ export class TesseronGateway extends EventEmitter {
     session.claimed = true;
     session.claimedAt = Date.now();
     this.pendingClaims.delete(claimCode.toUpperCase());
+    // Drop the cross-gateway breadcrumb so a sibling gateway doesn't keep
+    // pointing the user at this code once it's been spent. Await the
+    // write-promise stashed at hello time first — a fast-claim that beat the
+    // disk write would otherwise unlink-before-write and leave the late
+    // write orphaned forever (post-claim, no path removes it). The remove
+    // itself is still fire-and-forget for the synchronous return value.
+    void awaitThenRemoveClaimRecord(session.claimRecordWritten, claimCode);
     // Tell the SDK side the session is now claimed. The browser app's
     // `useTesseronConnection` hook clears `connection.claimCode` on receipt
     // so the UI stops displaying a code that can no longer be redeemed.
@@ -449,12 +548,11 @@ export class TesseronGateway extends EventEmitter {
     // transport-level failures by closing the channel, so no try/catch here.
     //
     // Use the same `pending` / `Awaiting agent` fallback the welcome uses
-    // (gateway.ts:731-734) when `clientName` isn't populated. The MCP
-    // `initialize` always runs before `tools/call`, so in practice
-    // `clientName` is set by the time we get here, but the symmetric
-    // fallback avoids silently regressing a previously-meaningful welcome
-    // agent if some embedder reaches `claimSession` without an `initialize`
-    // having happened.
+    // when `clientName` isn't populated. The MCP `initialize` always runs
+    // before `tools/call`, so in practice `clientName` is set by the time
+    // we get here, but the symmetric fallback avoids silently regressing a
+    // previously-meaningful welcome agent if some embedder reaches
+    // `claimSession` without an `initialize` having happened.
     const clientName = this.agentCapabilities.clientName;
     session.dispatcher.notify('tesseron/claimed', {
       agent: {
@@ -665,6 +763,16 @@ export class TesseronGateway extends EventEmitter {
         });
       }
 
+      // Drop the cross-gateway breadcrumb if this session never made it to
+      // a successful claim — leaving the file behind would mislead a sibling
+      // gateway into reporting "live elsewhere" for a code that's gone.
+      // Sessions that DID get claimed already removed their record at claim
+      // time; calling unlink twice is harmless. Await the hello-time write
+      // promise first so a tiny disk write in flight doesn't outlive the
+      // unlink (same race the claim-path guards against).
+      if (!session.claimed) {
+        void awaitThenRemoveClaimRecord(session.claimRecordWritten, session.claimCode);
+      }
       this.sessions.delete(session.id);
       this.pendingClaims.delete(session.claimCode);
       // Cancel any active invocations for this session
@@ -718,6 +826,23 @@ export class TesseronGateway extends EventEmitter {
       };
       this.sessions.set(sessionId, session);
       this.pendingClaims.set(claimCode, sessionId);
+      // Drop a cross-gateway breadcrumb so a sibling gateway that receives
+      // tesseron__claim_session with this code (rather than us) can tell the
+      // user which Claude session minted it instead of failing flat. See
+      // tesseron#53. Fire-and-forget against the welcome — the file is a UX
+      // hint, never a correctness gate, so a write failure must not delay
+      // the welcome. The returned promise is stashed on the session so the
+      // claim/close paths can await it before unlinking, otherwise a
+      // fast-claim could beat the disk write and orphan the late file.
+      session.claimRecordWritten = writeClaimRecord({
+        version: 1,
+        code: claimCode,
+        sessionId,
+        appId: helloParams.app.id,
+        appName: helloParams.app.name,
+        gatewayPid: process.pid,
+        mintedAt: Date.now(),
+      });
       logToStderr(
         `[tesseron] new session "${helloParams.app.name}" (${sessionId}) — claim code: ${claimCode}`,
       );
@@ -994,3 +1119,142 @@ function parseProtocolVersion(version: string): [number, number] {
   const minor = Number.parseInt(parts[1] ?? '0', 10);
   return [Number.isFinite(major) ? major : 0, Number.isFinite(minor) ? minor : 0];
 }
+
+/**
+ * True when the OS reports `pid` as a running process, false when it's
+ * definitely gone (`ESRCH`). Any other error (`EPERM`: alive but owned by
+ * another user; missing pid; non-numeric pid; platform quirks) is treated as
+ * "live" — we'd rather waste a dial than tombstone a manifest that still has
+ * a working owner. `process.kill(pid, 0)` is documented as cross-platform on
+ * Windows + POSIX; signal 0 only probes existence.
+ */
+export function isPidAlive(pid: unknown): boolean {
+  if (typeof pid !== 'number' || !Number.isFinite(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return false;
+    return true;
+  }
+}
+
+/**
+ * Persistent breadcrumb the gateway drops in `~/.tesseron/claims/<CODE>.json`
+ * when it mints a claim code. Lets a sibling gateway (different Claude
+ * session, parallel dev shell, …) that receives a `tesseron__claim_session`
+ * call for a code it doesn't own surface a "this code belongs to gateway pid
+ * N — switch to that session" hint instead of the previous flat "no pending
+ * session". Removed atomically when the owning gateway claims the session,
+ * the session closes unclaimed, or the gateway shuts down. See tesseron#53.
+ */
+interface ClaimRecord {
+  version: 1;
+  code: string;
+  sessionId: string;
+  appId: string;
+  appName: string;
+  /** Pid of the gateway process that minted this code. */
+  gatewayPid: number;
+  /** Unix-millis when the gateway sent the welcome carrying this code. */
+  mintedAt: number;
+}
+
+// Resolved lazily so that tests which point HOME / USERPROFILE at a sandbox
+// after this module has loaded still see the redirected directory.
+function claimsDir(): string {
+  return join(homedir(), '.tesseron', 'claims');
+}
+
+function claimFilePath(code: string): string {
+  return join(claimsDir(), `${code.toUpperCase()}.json`);
+}
+
+async function writeClaimRecord(record: ClaimRecord): Promise<void> {
+  const path = claimFilePath(record.code);
+  try {
+    await mkdir(claimsDir(), { recursive: true });
+    await writeFile(path, JSON.stringify(record, null, 2));
+  } catch (err) {
+    // Surfacing the error in stderr is enough — a missing breadcrumb only
+    // degrades the cross-gateway error message; it never blocks claiming a
+    // code on the gateway that minted it. Include the resolved path so a
+    // user hitting EACCES / ENOSPC / EROFS can act on the actual location
+    // rather than guessing where breadcrumbs live.
+    const reason = err instanceof Error ? err.message : String(err);
+    logToStderr(`[tesseron] failed to write claim record at ${path}: ${reason}`);
+  }
+}
+
+async function removeClaimRecord(code: string): Promise<void> {
+  try {
+    await unlink(claimFilePath(code));
+  } catch (err) {
+    // ENOENT is expected when the breadcrumb was never written (write race,
+    // mkdir failed earlier) or already removed by the same code path on a
+    // double-call. Anything else is worth telling the operator about — a
+    // permission-denied unlink leaves a stale file behind that future
+    // describeForeignClaim probes will keep matching, so the user has no
+    // way to recover without manually `rm`ing the path. Include it.
+    const errno = (err as NodeJS.ErrnoException).code;
+    if (errno === 'ENOENT') return;
+    const reason = err instanceof Error ? err.message : String(err);
+    logToStderr(`[tesseron] failed to remove claim record at ${claimFilePath(code)}: ${reason}`);
+  }
+}
+
+/**
+ * Sequence the breadcrumb removal *after* the in-flight write completes, so a
+ * fast-claim that runs before the hello-time write has landed on disk
+ * doesn't unlink-before-write (the unlink would ENOENT, then the late write
+ * would land and live forever — no later cleanup path covers a claimed
+ * session's breadcrumb). Best-effort: if the write rejected, the file
+ * isn't there and the unlink ENOENTs, which we silently swallow.
+ */
+async function awaitThenRemoveClaimRecord(
+  writePromise: Promise<void> | undefined,
+  code: string,
+): Promise<void> {
+  if (writePromise) {
+    try {
+      await writePromise;
+    } catch {
+      // write already failed; the file isn't there, nothing to remove.
+    }
+  }
+  await removeClaimRecord(code);
+}
+
+async function readClaimRecord(code: string): Promise<ClaimRecord | null> {
+  try {
+    const raw = await readFile(claimFilePath(code), 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<ClaimRecord>;
+    if (
+      parsed.version !== 1 ||
+      typeof parsed.code !== 'string' ||
+      typeof parsed.sessionId !== 'string' ||
+      typeof parsed.appId !== 'string' ||
+      typeof parsed.appName !== 'string' ||
+      typeof parsed.gatewayPid !== 'number' ||
+      typeof parsed.mintedAt !== 'number'
+    ) {
+      return null;
+    }
+    return parsed as ClaimRecord;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Outcome of probing `~/.tesseron/claims/<CODE>.json` from a gateway that
+ * doesn't own the code locally. See {@link TesseronGateway.describeForeignClaim}.
+ */
+export type ForeignClaim =
+  /** A live sibling gateway minted this code; tell the user which one to switch to. */
+  | { kind: 'foreign'; gatewayPid: number; mintedAt: number; appId: string; appName: string }
+  /** Record exists but the owning gateway is gone — likely a leftover from a crashed gateway. */
+  | { kind: 'stale'; gatewayPid: number; mintedAt: number; appId: string; appName: string }
+  /** No claim record for this code on disk at all. */
+  | { kind: 'unknown' };

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -19,7 +19,7 @@ import {
   type TesseronStructuredError,
 } from '@tesseron/core';
 import { assertValidElicitSchema } from '@tesseron/core/internal';
-import type { ResourceSubscription, TesseronGateway } from './gateway.js';
+import type { ForeignClaim, ResourceSubscription, TesseronGateway } from './gateway.js';
 import type { Session } from './session.js';
 
 const META_TOOL_CLAIM_SESSION = 'tesseron__claim_session';
@@ -583,16 +583,43 @@ export class McpAgentBridge {
     }
   }
 
-  private handleClaim(args: Record<string, unknown>): {
+  private async handleClaim(args: Record<string, unknown>): Promise<{
     content: Array<{ type: 'text'; text: string }>;
     isError?: boolean;
-  } {
+  }> {
     const code = typeof args['code'] === 'string' ? args['code'] : '';
     if (!code) {
       return errorResult('Missing "code" argument. Provide the 6-character claim code.');
     }
     const session = this.gateway.claimSession(code);
     if (!session) {
+      // Each running gateway has its own pendingClaims map (post-#54 single-
+      // owner binding pins each browser instance to exactly one gateway).
+      // When the user pastes a code into a Claude session whose gateway
+      // didn't mint it, claimSession returns null even though the code is
+      // valid elsewhere on the box. Probe the breadcrumb to tell them
+      // which gateway did. See tesseron#53.
+      let foreign: ForeignClaim;
+      try {
+        foreign = await this.gateway.describeForeignClaim(code);
+      } catch {
+        // A future regression in describeForeignClaim shouldn't *worsen*
+        // the user-facing error compared to the pre-breadcrumb baseline.
+        // Fall through to the legacy "no pending session" path.
+        foreign = { kind: 'unknown' };
+      }
+      if (foreign.kind === 'foreign') {
+        const minted = new Date(foreign.mintedAt).toISOString();
+        return errorResult(
+          `Claim code "${code.toUpperCase()}" belongs to a different Tesseron gateway (pid ${foreign.gatewayPid}, app "${foreign.appName}", minted ${minted}). Switch to the Claude session that opened this connection and run tesseron__claim_session there. Each running Claude session has its own gateway; only the one that minted the code can redeem it. See tesseron#53.`,
+        );
+      }
+      if (foreign.kind === 'stale') {
+        const minted = new Date(foreign.mintedAt).toISOString();
+        return errorResult(
+          `Claim code "${code.toUpperCase()}" was minted at ${minted} by gateway pid ${foreign.gatewayPid}, which is no longer running. Have the web app reconnect to mint a fresh code, then claim that one.`,
+        );
+      }
       return errorResult(
         `No pending session found for code "${code}". Has the web app connected, and is the code current?`,
       );

--- a/packages/mcp/src/session.ts
+++ b/packages/mcp/src/session.ts
@@ -33,6 +33,14 @@ export interface Session {
    */
   resumeToken: string;
   subscriptionCallbacks?: Map<string, (value: unknown) => void>;
+  /**
+   * Resolves once the cross-gateway claim breadcrumb at
+   * `~/.tesseron/claims/<CODE>.json` has finished writing. The hello handler
+   * fires the write and stashes its promise here; the claim/close paths
+   * await it before unlinking, so a fast-claim that beats the disk write
+   * doesn't leak a stale breadcrumb past the session's life. See tesseron#53.
+   */
+  claimRecordWritten?: Promise<void>;
 }
 
 const CLAIM_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';

--- a/packages/mcp/test/discovery-and-claim-record.test.ts
+++ b/packages/mcp/test/discovery-and-claim-record.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Coverage for the cross-gateway discovery + claim-ownership safety net
+ * shipped for tesseron#53. Two pieces:
+ *
+ *   1. SDK writes `pid` into its instance manifest, and the gateway
+ *      tombstones manifests whose pid is gone. This stops a long-running
+ *      gateway from re-dialling dead WS endpoints forever after the SDK
+ *      crashed without unlinking its file.
+ *
+ *   2. When a gateway mints a claim code it drops a breadcrumb at
+ *      `~/.tesseron/claims/<CODE>.json`. A sibling gateway (a parallel
+ *      Claude Code session, a leftover dev gateway) that receives the
+ *      `tesseron__claim_session` for that code now reports "claim code
+ *      belongs to gateway pid N" instead of the previous opaque "no
+ *      pending session". The breadcrumb is removed on successful claim,
+ *      on unclaimed close, and on gateway shutdown.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import { ServerTesseronClient } from '@tesseron/server';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { isPidAlive } from '../src/gateway.js';
+import { McpAgentBridge, TesseronGateway } from '../src/index.js';
+import { type Sandbox, dialSdk, prepareSandbox, waitForInstanceFile } from './setup.js';
+
+let sandbox: Sandbox;
+
+beforeAll(() => {
+  sandbox = prepareSandbox();
+});
+
+afterAll(() => {
+  sandbox.cleanup();
+});
+
+/** Pick a pid that has just exited and is almost certainly not yet recycled.
+ *  Spawn a no-op child synchronously, capture its pid, let it exit. If this
+ *  test ever flakes with `isPidAlive` returning true here, the OS recycled
+ *  the pid between spawn and probe — possible on aggressive-pid-reuse Linux
+ *  containers and short-lived Windows pids, vanishingly rare on a dev box. */
+function deadPid(): number {
+  const child = spawnSync(process.execPath, ['-e', '0'], { stdio: 'ignore' });
+  if (child.pid === undefined) throw new Error('failed to spawn helper to harvest a dead pid');
+  // spawnSync only returns once the child has exited, so child.pid is dead.
+  return child.pid;
+}
+
+describe('SDK manifest carries pid + gateway tombstones dead manifests', () => {
+  it('@tesseron/server writes its own pid into the v2 instance manifest', async () => {
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'pid_check', name: 'pid check', origin: 'http://localhost' });
+    const startedAt = Date.now();
+    const promise = sdk.connect();
+    promise.catch(() => {});
+    const inst = await waitForInstanceFile(sandbox, { since: startedAt });
+    const file = join(sandbox.dir, '.tesseron', 'instances', `${inst.instanceId}.json`);
+    const parsed = JSON.parse(await readFile(file, 'utf-8')) as { pid?: number };
+    expect(parsed.pid).toBe(process.pid);
+    await sdk.disconnect().catch(() => {});
+  });
+
+  it('gateway tombstones a stale manifest whose pid is dead and never dials it', async () => {
+    const dir = join(sandbox.dir, '.tesseron', 'instances');
+    await mkdir(dir, { recursive: true });
+    const dead = deadPid();
+    expect(isPidAlive(dead)).toBe(false);
+    const stalePath = join(dir, 'inst-stale-1.json');
+    await writeFile(
+      stalePath,
+      JSON.stringify({
+        version: 2,
+        instanceId: 'inst-stale-1',
+        appName: 'ghost',
+        addedAt: Date.now() - 60_000,
+        pid: dead,
+        // Bogus URL — we'd see a connect attempt against this if filtering
+        // didn't work. Pinning to an obviously-dead host:port surfaces the
+        // bug as a tested-for "didn't dial".
+        transport: { kind: 'ws', url: 'ws://127.0.0.1:1/never' },
+      }),
+    );
+
+    const gateway = new TesseronGateway();
+    let dialedDead = false;
+    const stop = gateway.watchInstances();
+    const originalConnect = gateway.connectToApp.bind(gateway);
+    gateway.connectToApp = (id, spec) => {
+      if (spec.kind === 'ws' && spec.url.includes('1/never')) {
+        dialedDead = true;
+      }
+      return originalConnect(id, spec);
+    };
+
+    // Give the watcher one polling tick to see the file.
+    await new Promise((r) => setTimeout(r, 200));
+
+    expect(dialedDead).toBe(false);
+    expect(existsSync(stalePath)).toBe(false);
+
+    stop();
+    await gateway.stop();
+  });
+
+  it('gateway leaves manifests without a pid alone (back-compat with older SDKs)', async () => {
+    const dir = join(sandbox.dir, '.tesseron', 'instances');
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, 'inst-legacy-1.json');
+    await writeFile(
+      path,
+      JSON.stringify({
+        version: 2,
+        instanceId: 'inst-legacy-1',
+        appName: 'legacy',
+        addedAt: Date.now(),
+        // No `pid` field.
+        transport: { kind: 'ws', url: 'ws://127.0.0.1:2/legacy' },
+      }),
+    );
+
+    const gateway = new TesseronGateway();
+    const stop = gateway.watchInstances();
+    await new Promise((r) => setTimeout(r, 200));
+    // File must still be there: pid-less manifests are unfiltered (a dial
+    // attempt may still fail against the dead URL, but the manifest itself
+    // doesn't get tombstoned without an explicit liveness signal).
+    expect(existsSync(path)).toBe(true);
+    stop();
+    await gateway.stop();
+  });
+});
+
+describe('claim record breadcrumb in ~/.tesseron/claims/', () => {
+  let gateway: TesseronGateway;
+  let bridge: McpAgentBridge;
+  let client: Client;
+
+  beforeAll(async () => {
+    gateway = new TesseronGateway();
+    bridge = new McpAgentBridge({ gateway });
+    const [agentSide, gatewaySide] = InMemoryTransport.createLinkedPair();
+    await bridge.connect(gatewaySide);
+    client = new Client({ name: 'test-agent', version: '0.0.0' });
+    await client.connect(agentSide);
+  });
+
+  afterAll(async () => {
+    await client.close().catch(() => {});
+    await gateway.stop().catch(() => {});
+  });
+
+  function claimFile(code: string): string {
+    return join(sandbox.dir, '.tesseron', 'claims', `${code.toUpperCase()}.json`);
+  }
+
+  async function callClaim(code: string): Promise<{ text: string; isError: boolean }> {
+    const result = await client.request(
+      { method: 'tools/call', params: { name: 'tesseron__claim_session', arguments: { code } } },
+      CallToolResultSchema,
+    );
+    return {
+      text: result.content.map((c) => (c.type === 'text' ? c.text : `[${c.type}]`)).join(''),
+      isError: result.isError === true,
+    };
+  }
+
+  it('writes a claim record on hello and removes it on successful claim', async () => {
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'claim_record_a', name: 'A', origin: 'http://localhost' });
+    sdk.action('noop').handler(() => 'ok');
+    const welcome = await dialSdk(gateway, sandbox, () => sdk.connect());
+    const code = welcome.claimCode!;
+
+    // Hello fired writeClaimRecord fire-and-forget; give the write a tick.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const path = claimFile(code);
+    expect(existsSync(path)).toBe(true);
+    const parsed = JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+    expect(parsed['code']).toBe(code);
+    expect(parsed['gatewayPid']).toBe(process.pid);
+    expect(parsed['appId']).toBe('claim_record_a');
+
+    // Claim from the same gateway — record must disappear.
+    const result = await callClaim(code);
+    expect(result.isError).toBe(false);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(existsSync(path)).toBe(false);
+
+    await sdk.disconnect().catch(() => {});
+  });
+
+  it('removes the claim record when an unclaimed session closes', async () => {
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'claim_record_b', name: 'B', origin: 'http://localhost' });
+    sdk.action('noop').handler(() => 'ok');
+    const welcome = await dialSdk(gateway, sandbox, () => sdk.connect());
+    const code = welcome.claimCode!;
+    await new Promise((r) => setTimeout(r, 50));
+    expect(existsSync(claimFile(code))).toBe(true);
+
+    // Disconnect before claiming — record must clean itself up.
+    await sdk.disconnect().catch(() => {});
+    await new Promise((r) => setTimeout(r, 100));
+    expect(existsSync(claimFile(code))).toBe(false);
+  });
+
+  it('reports a foreign-pid hint when the claim code belongs to a sibling gateway', async () => {
+    // Simulate a sibling gateway by hand-writing a breadcrumb for a code we
+    // don't own locally. Use this process's own pid so the liveness check
+    // returns alive — `kind: 'foreign'` is what we want to assert on.
+    const code = 'WXYZ-99';
+    const file = claimFile(code);
+    await mkdir(join(sandbox.dir, '.tesseron', 'claims'), { recursive: true });
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        code,
+        sessionId: 's_other',
+        appId: 'other_app',
+        appName: 'Other App',
+        gatewayPid: process.pid,
+        mintedAt: Date.now() - 5_000,
+      }),
+    );
+
+    const result = await callClaim(code);
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('different Tesseron gateway');
+    expect(result.text).toContain(String(process.pid));
+    expect(result.text).toContain('Other App');
+  });
+
+  it('reports a stale-pid hint and tombstones the breadcrumb when the owner is gone', async () => {
+    const code = 'STAL-01';
+    const file = claimFile(code);
+    await mkdir(join(sandbox.dir, '.tesseron', 'claims'), { recursive: true });
+    const dead = deadPid();
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        code,
+        sessionId: 's_stale',
+        appId: 'stale_app',
+        appName: 'Stale App',
+        gatewayPid: dead,
+        mintedAt: Date.now() - 60_000,
+      }),
+    );
+
+    const result = await callClaim(code);
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('no longer running');
+    expect(result.text).toContain(String(dead));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(existsSync(file)).toBe(false);
+  });
+
+  it('falls back to the original "no pending session" message when no breadcrumb exists', async () => {
+    const result = await callClaim('NONE-99');
+    expect(result.isError).toBe(true);
+    expect(result.text).toContain('No pending session found');
+    expect(result.text).not.toContain('different Tesseron gateway');
+    expect(result.text).not.toContain('no longer running');
+  });
+});
+
+describe('gateway.stop() sweeps claim records for unclaimed sessions', () => {
+  it('removes pending claim breadcrumbs by the time stop() resolves', async () => {
+    // Use a fresh gateway (separate from the one bound in the parent suite)
+    // so this test owns the lifecycle and can call stop() without
+    // interfering with subsequent tests.
+    const localGateway = new TesseronGateway();
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'stop_sweep', name: 'Stop Sweep', origin: 'http://localhost' });
+    sdk.action('noop').handler(() => 'ok');
+    const welcome = await dialSdk(localGateway, sandbox, () => sdk.connect());
+    const code = welcome.claimCode!;
+    const path = join(sandbox.dir, '.tesseron', 'claims', `${code.toUpperCase()}.json`);
+    // The hello handler stashes the write promise on the session, so as
+    // long as we let the microtask queue drain once, the file is on disk.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(existsSync(path)).toBe(true);
+
+    // Stop the gateway. The internal sweep awaits the unlink promises, so
+    // by the time stop() resolves the breadcrumb must already be gone —
+    // no extra sleep needed (regression test: a `void`-fire-and-forget
+    // implementation would leave the file there at this point).
+    await localGateway.stop();
+    expect(existsSync(path)).toBe(false);
+
+    await sdk.disconnect().catch(() => {});
+  });
+});

--- a/packages/server/src/transport.ts
+++ b/packages/server/src/transport.ts
@@ -150,6 +150,11 @@ export class NodeWebSocketServerTransport implements Transport {
           instanceId: this.instanceId,
           appName: this.options.appName ?? 'node',
           addedAt: Date.now(),
+          // Stamp the Node app's pid so a gateway can probe liveness with
+          // `process.kill(pid, 0)` and tombstone manifests whose owning
+          // process died without unlinking (e.g. crashed, SIGKILLed). See
+          // tesseron#53.
+          pid: process.pid,
           transport: { kind: 'ws', url: wsUrl },
         },
         null,

--- a/packages/server/src/uds-transport.ts
+++ b/packages/server/src/uds-transport.ts
@@ -199,6 +199,10 @@ export class UnixSocketServerTransport implements Transport {
           instanceId: this.instanceId,
           appName: this.options.appName ?? 'node',
           addedAt: Date.now(),
+          // Stamp the Node app's pid so a gateway can probe liveness with
+          // `process.kill(pid, 0)` and tombstone manifests whose owning
+          // process died without unlinking the socket file. See tesseron#53.
+          pid: process.pid,
           transport: { kind: 'uds', path: socketPath },
         },
         null,

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -33,6 +33,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "tsup",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "pnpm build"
   },
@@ -44,7 +45,8 @@
     "@types/ws": "^8.5.13",
     "tsup": "^8.3.0",
     "typescript": "^5.7.0",
-    "vite": "^5.4.0"
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0"
   },
   "peerDependencies": {
     "vite": ">=4.0.0"

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -29,8 +29,18 @@ interface PendingInstance {
 }
 
 const WS_PATH_PREFIX = '/@tesseron/ws';
-const INSTANCES_DIR = join(homedir(), '.tesseron', 'instances');
 const GATEWAY_SUBPROTOCOL = 'tesseron-gateway';
+
+/**
+ * Resolve the instance-discovery directory at call time rather than module
+ * load. Tests (and long-lived processes that change `$HOME` at runtime) need
+ * this — capturing at load meant a sandbox set via `process.env.HOME` after
+ * the plugin was imported wrote to the host's real `~/.tesseron/instances/`.
+ * Mirrors the lazy pattern in `@tesseron/server`.
+ */
+function getInstancesDir(): string {
+  return join(homedir(), '.tesseron', 'instances');
+}
 
 /** Decode a `ws` text-frame payload back to a string. `ws` always emits a
  * Buffer (or Buffer fragments) for text frames; we just need UTF-8 it. */
@@ -42,12 +52,26 @@ function rawDataToString(data: RawData): string {
 }
 
 async function ensureInstancesDir(): Promise<void> {
-  await mkdir(INSTANCES_DIR, { recursive: true });
+  await mkdir(getInstancesDir(), { recursive: true });
 }
 
-async function writeManifest(inst: PendingInstance): Promise<void> {
+/** Minimal subset of {@link PendingInstance} the manifest writer needs.
+ *  Exported alongside {@link writeInstanceManifest} so a test can call the
+ *  helper directly without standing up a real WebSocket. */
+export interface InstanceManifestInput {
+  instanceId: string;
+  appName?: string;
+  wsUrl: string;
+}
+
+/**
+ * Exported so the manifest contract can be unit-tested without booting a Vite
+ * dev server. `process.pid` and `Date.now()` still come from the runtime, so
+ * a test asserts on the pid stamp by inspecting the produced file.
+ */
+export async function writeInstanceManifest(inst: InstanceManifestInput): Promise<void> {
   await ensureInstancesDir();
-  const file = join(INSTANCES_DIR, `${inst.instanceId}.json`);
+  const file = join(getInstancesDir(), `${inst.instanceId}.json`);
   await writeFile(
     file,
     JSON.stringify(
@@ -56,6 +80,11 @@ async function writeManifest(inst: PendingInstance): Promise<void> {
         instanceId: inst.instanceId,
         appName: inst.appName,
         addedAt: Date.now(),
+        // Stamp the Vite dev-server pid so a gateway that boots later can
+        // probe `process.kill(pid, 0)` and skip manifests whose owning process
+        // is already dead (e.g. a Vite session killed without a clean
+        // `httpServer.close`, leaving an orphan `<id>.json`). See tesseron#53.
+        pid: process.pid,
         transport: { kind: 'ws', url: inst.wsUrl },
       },
       null,
@@ -65,7 +94,7 @@ async function writeManifest(inst: PendingInstance): Promise<void> {
 }
 
 async function deleteManifest(instanceId: string): Promise<void> {
-  const file = join(INSTANCES_DIR, `${instanceId}.json`);
+  const file = join(getInstancesDir(), `${instanceId}.json`);
   if (existsSync(file)) {
     await unlink(file).catch(() => {});
   }
@@ -123,7 +152,7 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
             };
             instances.set(instanceId, entry);
 
-            writeManifest(entry).catch((err: Error) =>
+            writeInstanceManifest(entry).catch((err: Error) =>
               process.stderr.write(
                 `[tesseron] failed to write instance manifest: ${err.message}\n`,
               ),

--- a/packages/vite/test/manifest.test.ts
+++ b/packages/vite/test/manifest.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Coverage for the Vite plugin's instance-manifest writer. Avoids booting a
+ * full Vite dev server — the writer is exported as `writeInstanceManifest`
+ * specifically so the manifest contract can be locked without one.
+ *
+ * Asserts the two pieces of the contract introduced for tesseron#53:
+ *  - the v2 manifest carries `pid: process.pid` so a sibling gateway can
+ *    tombstone the file when the Vite dev server crashes;
+ *  - the manifest path is resolved lazily (after `prepareSandbox()` mutates
+ *    `HOME`/`USERPROFILE`) so test sandboxes don't pollute the real
+ *    `~/.tesseron/instances/`.
+ */
+
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { writeInstanceManifest } from '../src/index.js';
+
+let sandbox: string;
+let previousEnv: { HOME: string | undefined; USERPROFILE: string | undefined };
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'tesseron-vite-test-'));
+  previousEnv = {
+    HOME: process.env['HOME'],
+    USERPROFILE: process.env['USERPROFILE'],
+  };
+  // Sandbox the home dir AFTER the module has loaded — the plugin must
+  // resolve `homedir()` at call time, not at import time, for this to
+  // redirect. Regression-guards the lazy `getInstancesDir()` switch.
+  process.env['HOME'] = sandbox;
+  process.env['USERPROFILE'] = sandbox;
+});
+
+afterAll(() => {
+  for (const [k, v] of Object.entries(previousEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('writeInstanceManifest', () => {
+  it('writes a v2 manifest stamped with the current process pid', async () => {
+    const instanceId = 'inst-test-1';
+    await writeInstanceManifest({
+      instanceId,
+      appName: 'pid-stamp-test',
+      wsUrl: 'ws://localhost:5173/@tesseron/ws/inst-test-1',
+    });
+
+    const path = join(sandbox, '.tesseron', 'instances', `${instanceId}.json`);
+    const parsed = JSON.parse(readFileSync(path, 'utf-8')) as Record<string, unknown>;
+
+    expect(parsed['version']).toBe(2);
+    expect(parsed['instanceId']).toBe(instanceId);
+    expect(parsed['appName']).toBe('pid-stamp-test');
+    expect(parsed['pid']).toBe(process.pid);
+    expect(parsed['transport']).toEqual({
+      kind: 'ws',
+      url: 'ws://localhost:5173/@tesseron/ws/inst-test-1',
+    });
+    expect(typeof parsed['addedAt']).toBe('number');
+  });
+
+  it('honours HOME/USERPROFILE redirection set after import (lazy resolution)', async () => {
+    // Same suite-level sandbox; this test exists explicitly to fail loudly
+    // if the writer ever regresses to a module-level `INSTANCES_DIR =
+    // join(homedir(), …)` constant — that would write to the real home
+    // dir and the assertion below would never see the file.
+    const instanceId = 'inst-test-lazy';
+    await writeInstanceManifest({
+      instanceId,
+      appName: 'lazy-test',
+      wsUrl: 'ws://localhost:5173/@tesseron/ws/inst-test-lazy',
+    });
+    const path = join(sandbox, '.tesseron', 'instances', `${instanceId}.json`);
+    expect(() => readFileSync(path, 'utf-8')).not.toThrow();
+  });
+});

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19300,10 +19300,24 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
   dialers;
   discoveryWatchers = [];
   discoveryInterval;
+  /**
+   * Manifest paths already attempted to tombstone (via `unlink`). Keeps the
+   * 2 s discovery poll from re-logging "tombstoning stale instance manifest"
+   * for a file the OS won't let us delete (EACCES, EBUSY on Windows). Still
+   * re-tries the unlink on every tick — the file might genuinely become
+   * deletable later — but suppresses the repeated stderr line.
+   */
+  tombstonedManifests = /* @__PURE__ */ new Set();
   /** Closes all sessions, outbound connections, and discovery watchers. */
   async stop() {
     this.stopped = true;
+    const pendingClaimRemovals = [];
     for (const session of this.sessions.values()) {
+      if (!session.claimed) {
+        pendingClaimRemovals.push(
+          awaitThenRemoveClaimRecord(session.claimRecordWritten, session.claimCode)
+        );
+      }
       session.transport.close("Gateway shutting down");
     }
     this.sessions.clear();
@@ -19325,6 +19339,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       dialed.close("Gateway shutting down");
     }
     this.connected.clear();
+    await Promise.allSettled(pendingClaimRemovals);
   }
   /** Installs the handler invoked for `sampling/request`. Pass `undefined` to clear. */
   setSamplingHandler(handler) {
@@ -19407,6 +19422,28 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
             const content = await (0, import_promises.readFile)((0, import_node_path.join)(instancesDir, file2), "utf-8");
             const data = JSON.parse(content);
             if (data.version !== 2 || !data.transport) continue;
+            if (data.pid !== void 0 && !isPidAlive(data.pid)) {
+              const path = (0, import_node_path.join)(instancesDir, file2);
+              const alreadyLogged = this.tombstonedManifests.has(path);
+              try {
+                await (0, import_promises.unlink)(path);
+                if (!alreadyLogged) {
+                  logToStderr(
+                    `[tesseron] tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`
+                  );
+                }
+                this.tombstonedManifests.delete(path);
+              } catch (unlinkErr) {
+                if (!alreadyLogged) {
+                  const reason = unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr);
+                  logToStderr(
+                    `[tesseron] could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} \u2014 remove the file manually if it persists`
+                  );
+                  this.tombstonedManifests.add(path);
+                }
+              }
+              continue;
+            }
             const id = data.instanceId ?? instanceId;
             this.connectToApp(id, data.transport).catch((err) => {
               logToStderr(`[tesseron] could not connect to instance ${id}: ${err.message}`);
@@ -19502,6 +19539,37 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     return Array.from(this.sessions.values()).filter((s) => !s.claimed);
   }
   /**
+   * Look up the cross-gateway breadcrumb for `code` in `~/.tesseron/claims/`.
+   * Used by the MCP `tesseron__claim_session` handler when its own
+   * `claimSession` returns null: instead of the previous flat "no pending
+   * session" error, the tool can report "this code was minted by gateway pid
+   * N at HH:MM:SS — switch to that Claude session and try again". On the
+   * `stale` outcome only — never on `foreign` or `unknown` — the breadcrumb
+   * file is unlinked as a side-effect so future probes don't keep reporting
+   * the same dead pid. See tesseron#53.
+   */
+  async describeForeignClaim(code) {
+    const record2 = await readClaimRecord(code);
+    if (!record2) return { kind: "unknown" };
+    if (!isPidAlive(record2.gatewayPid)) {
+      void removeClaimRecord(code);
+      return {
+        kind: "stale",
+        gatewayPid: record2.gatewayPid,
+        mintedAt: record2.mintedAt,
+        appId: record2.appId,
+        appName: record2.appName
+      };
+    }
+    return {
+      kind: "foreign",
+      gatewayPid: record2.gatewayPid,
+      mintedAt: record2.mintedAt,
+      appId: record2.appId,
+      appName: record2.appName
+    };
+  }
+  /**
    * Attempts to claim a pending session by its claim code. Returns the claimed
    * session, or `null` if the code is unknown or already consumed. Emits
    * `sessions-changed` on success and a `tesseron/claimed` notification to the
@@ -19515,6 +19583,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     session.claimed = true;
     session.claimedAt = Date.now();
     this.pendingClaims.delete(claimCode.toUpperCase());
+    void awaitThenRemoveClaimRecord(session.claimRecordWritten, claimCode);
     const clientName = this.agentCapabilities.clientName;
     session.dispatcher.notify("tesseron/claimed", {
       agent: {
@@ -19681,6 +19750,9 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           evictTimer
         });
       }
+      if (!session.claimed) {
+        void awaitThenRemoveClaimRecord(session.claimRecordWritten, session.claimCode);
+      }
       this.sessions.delete(session.id);
       this.pendingClaims.delete(session.claimCode);
       for (const [invocationId, inv] of this.activeInvocations.entries()) {
@@ -19726,6 +19798,15 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       };
       this.sessions.set(sessionId, session);
       this.pendingClaims.set(claimCode, sessionId);
+      session.claimRecordWritten = writeClaimRecord({
+        version: 1,
+        code: claimCode,
+        sessionId,
+        appId: helloParams.app.id,
+        appName: helloParams.app.name,
+        gatewayPid: process.pid,
+        mintedAt: Date.now()
+      });
       logToStderr(
         `[tesseron] new session "${helloParams.app.name}" (${sessionId}) \u2014 claim code: ${claimCode}`
       );
@@ -19919,6 +20000,64 @@ function parseProtocolVersion(version2) {
   const major = Number.parseInt(parts[0] ?? "0", 10);
   const minor = Number.parseInt(parts[1] ?? "0", 10);
   return [Number.isFinite(major) ? major : 0, Number.isFinite(minor) ? minor : 0];
+}
+function isPidAlive(pid) {
+  if (typeof pid !== "number" || !Number.isFinite(pid) || pid <= 0) return true;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    const code = err.code;
+    if (code === "ESRCH") return false;
+    return true;
+  }
+}
+function claimsDir() {
+  return (0, import_node_path.join)((0, import_node_os.homedir)(), ".tesseron", "claims");
+}
+function claimFilePath(code) {
+  return (0, import_node_path.join)(claimsDir(), `${code.toUpperCase()}.json`);
+}
+async function writeClaimRecord(record2) {
+  const path = claimFilePath(record2.code);
+  try {
+    await (0, import_promises.mkdir)(claimsDir(), { recursive: true });
+    await (0, import_promises.writeFile)(path, JSON.stringify(record2, null, 2));
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    logToStderr(`[tesseron] failed to write claim record at ${path}: ${reason}`);
+  }
+}
+async function removeClaimRecord(code) {
+  try {
+    await (0, import_promises.unlink)(claimFilePath(code));
+  } catch (err) {
+    const errno = err.code;
+    if (errno === "ENOENT") return;
+    const reason = err instanceof Error ? err.message : String(err);
+    logToStderr(`[tesseron] failed to remove claim record at ${claimFilePath(code)}: ${reason}`);
+  }
+}
+async function awaitThenRemoveClaimRecord(writePromise, code) {
+  if (writePromise) {
+    try {
+      await writePromise;
+    } catch {
+    }
+  }
+  await removeClaimRecord(code);
+}
+async function readClaimRecord(code) {
+  try {
+    const raw = await (0, import_promises.readFile)(claimFilePath(code), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (parsed.version !== 1 || typeof parsed.code !== "string" || typeof parsed.sessionId !== "string" || typeof parsed.appId !== "string" || typeof parsed.appName !== "string" || typeof parsed.gatewayPid !== "number" || typeof parsed.mintedAt !== "number") {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
 }
 
 // ../../node_modules/.pnpm/zod@4.3.6/node_modules/zod/v3/helpers/util.js
@@ -25996,13 +26135,31 @@ var McpAgentBridge = class {
       return errorResult(message, error2 instanceof TesseronError ? error2 : void 0);
     }
   }
-  handleClaim(args) {
+  async handleClaim(args) {
     const code = typeof args["code"] === "string" ? args["code"] : "";
     if (!code) {
       return errorResult('Missing "code" argument. Provide the 6-character claim code.');
     }
     const session = this.gateway.claimSession(code);
     if (!session) {
+      let foreign;
+      try {
+        foreign = await this.gateway.describeForeignClaim(code);
+      } catch {
+        foreign = { kind: "unknown" };
+      }
+      if (foreign.kind === "foreign") {
+        const minted = new Date(foreign.mintedAt).toISOString();
+        return errorResult(
+          `Claim code "${code.toUpperCase()}" belongs to a different Tesseron gateway (pid ${foreign.gatewayPid}, app "${foreign.appName}", minted ${minted}). Switch to the Claude session that opened this connection and run tesseron__claim_session there. Each running Claude session has its own gateway; only the one that minted the code can redeem it. See tesseron#53.`
+        );
+      }
+      if (foreign.kind === "stale") {
+        const minted = new Date(foreign.mintedAt).toISOString();
+        return errorResult(
+          `Claim code "${code.toUpperCase()}" was minted at ${minted} by gateway pid ${foreign.gatewayPid}, which is no longer running. Have the web app reconnect to mint a fresh code, then claim that one.`
+        );
+      }
       return errorResult(
         `No pending session found for code "${code}". Has the web app connected, and is the code current?`
       );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -406,6 +406,9 @@ importers:
       vite:
         specifier: ^5.4.0
         version: 5.4.21(@types/node@22.19.17)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/vue:
     dependencies:


### PR DESCRIPTION
## Summary

Closes the two concerns from tesseron#53 that #54 (single-owner binding) and #55 (`tesseron/claimed`) left unfixed:

- **(2) Stale instance manifests.** `@tesseron/server` (WS + UDS) and `@tesseron/vite` now stamp `pid: process.pid` on every `~/.tesseron/instances/<id>.json` they write. The gateway probes `process.kill(pid, 0)` before dialing and unlinks manifests whose owning process is gone, so a Vite dev server killed without `httpServer.close` doesn't leave a corpse the gateway re-dials every poll tick. `InstanceManifest` in `@tesseron/core` gains an optional `pid?: number`; older SDKs without `pid` stay trusted (no regression for in-flight upgrades).

- **(3 lite) Cross-gateway claim ownership.** When the gateway mints a claim code it now drops a breadcrumb at `~/.tesseron/claims/<CODE>.json` with `{ sessionId, appId, appName, gatewayPid, mintedAt }`. A sibling gateway that receives `tesseron__claim_session` for a code it doesn't own locally reads the breadcrumb and reports `Claim code XYZ-12 belongs to a different Tesseron gateway (pid 12345, app "My App", minted 2026-04-26T15:16:09Z). Switch to the Claude session that opened this connection...` instead of the previous opaque `No pending session found`. Stale breadcrumbs (dead `gatewayPid`) report a stale-claim error and tombstone the file. Removed atomically on successful claim, on unclaimed close, and on `gateway.stop()`.

This is the lighter ownership-surfacing variant suggested in the issue thread: it does not transfer claim ownership across processes (the deterministic per-process model from #54 stays), but it ends the "guess which Claude window owns this code" UX problem on multi-session machines. A full cross-gateway rendezvous (concern 3 proper) remains future work.

`TesseronGateway` exposes a new `describeForeignClaim(code)` method (returns `{ kind: 'foreign' | 'stale' | 'unknown', ... }`) and an `isPidAlive(pid)` helper for embedders building their own claim UIs.

## Files

- `packages/core/src/transport-spec.ts` — `InstanceManifest.pid?: number`.
- `packages/server/src/transport.ts`, `packages/server/src/uds-transport.ts`, `packages/vite/src/index.ts` — stamp `pid: process.pid`.
- `packages/mcp/src/gateway.ts` — claim-record write/remove; stale-manifest tombstoning in `checkDir`; `describeForeignClaim` + `isPidAlive` exports; cleanup in `claimSession`, transport-close, and `stop()`.
- `packages/mcp/src/mcp-bridge.ts` — `handleClaim` consults `describeForeignClaim` on miss.
- `packages/mcp/test/discovery-and-claim-record.test.ts` — 8 new tests (see below).
- `docs/src/content/docs/protocol/transport.md`, `protocol/handshake.mdx`, `sdk/typescript/mcp.md` — manifest schema, multi-gateway section, gateway API.
- `plugin/server/index.cjs` — rebuilt via `pnpm --filter @tesseron/mcp build:plugin`.
- `.changeset/fix-mcp-stale-manifest-and-claim-record.md` — `@tesseron/mcp`, `@tesseron/core`, `@tesseron/server`, `@tesseron/vite` patch.

## Test plan

- [x] `pnpm -r typecheck` — clean across all packages and examples.
- [x] `pnpm -r test` — all 143 tests pass (`@tesseron/core` 30, `@tesseron/docs-mcp` 21, `@tesseron/react` 17, `@tesseron/mcp` 75 incl. 8 new, 1 existing skip).
- [x] `pnpm -r build` — clean.
- [x] `pnpm --filter @tesseron/mcp build:plugin` rebuilds the plugin bundle; the rebuilt `plugin/server/index.cjs` contains the new `describeForeignClaim` / `writeClaimRecord` / `tombstoning` strings.
- [x] `biome check` clean on all changed files.
- [ ] Manual repro of the two-Claude-sessions scenario from the issue: with two MCP gateways alive, claim from the wrong one and verify the new error names the owning pid.

### New test cases

- `@tesseron/server` manifest writer round-trips `pid: process.pid` to disk.
- Gateway tombstones a v2 manifest whose `pid` is dead and never dials its transport.
- Gateway leaves manifests without `pid` alone (back-compat).
- `tesseron/hello` writes the claim breadcrumb with the right shape; successful claim removes it.
- Unclaimed session close removes the breadcrumb.
- `tesseron__claim_session` on a code owned by a sibling gateway returns a `foreign` error naming the pid + app.
- `tesseron__claim_session` on a code whose `gatewayPid` is dead returns a `stale` error and tombstones the breadcrumb.
- `tesseron__claim_session` for a code with no breadcrumb returns the original `No pending session` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
