### PR TITLE
feat(mcp): forward discovery/dial outcomes through MCP sendLoggingMessage

### DIFF
--- a/.changeset/feat-mcp-dial-outcomes-logging.md
+++ b/.changeset/feat-mcp-dial-outcomes-logging.md
@@ -1,0 +1,7 @@
+---
+'@tesseron/mcp': patch
+---
+
+Discovery and dial outcomes (connect success, connect failure, stale-manifest tombstone) now reach the connected MCP client via `notifications/message` (`logger: "tesseron.discovery"`). A developer running Claude Code sees these inline rather than having to grep `~/.claude/` for the gateway's stderr stream. Stderr still receives the same lines for grep-ability — the new channel is additive.
+
+Closes the last open thread on tesseron#53 — concern (4) called for "plumbing dial outcomes through the MCP `sendLoggingMessage` channel"; this PR ships exactly that. The bridge now declares the `logging` server capability (which a previous version omitted, silently no-op'ing all `sendLoggingMessage` calls). `TesseronGateway` exposes a `'gateway-log'` event and a `GatewayLogEvent` type so embedders that don't use the bundled `McpAgentBridge` can wire the same forwarding into their own MCP server.

--- a/docs/src/content/docs/sdk/typescript/mcp.md
+++ b/docs/src/content/docs/sdk/typescript/mcp.md
@@ -62,6 +62,8 @@ For one minor version (1.1.x), the gateway also reads the legacy v1 directory `~
 
 When the app process dies, the channel closes and the gateway drops the session. The app is also expected to delete its own manifest on graceful shutdown.
 
+Discovery and dial outcomes (connect successes, connect failures, stale-manifest tombstones, foreign-claim probe results) are forwarded to the connected MCP client via `notifications/message` (`logger: "tesseron.discovery"`), so a developer running Claude Code sees them inline rather than having to grep `~/.claude/`. Set the level on the client side via `logging/setLevel` to filter. Stderr still receives the same lines for grep-ability.
+
 Shipping support for a new runtime is three steps:
 
 1. Bind whichever [transport binding](/protocol/transport/) fits the runtime (WS, UDS, …).

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -125,6 +125,29 @@ export interface AgentCapabilityInfo {
   clientName?: string;
 }
 
+/**
+ * Operational event the gateway emits as `'gateway-log'` so an MCP bridge can
+ * forward it to the connected agent via `notifications/message` (MCP
+ * `sendLoggingMessage`). Solves the "user has to grep ~/.claude/" problem
+ * called out as concern (4) in tesseron#53 — without this, dial successes /
+ * failures / tombstone outcomes are stderr-only, invisible to the developer
+ * unless they hunt down the gateway's log stream by hand.
+ *
+ * Currently only the discovery / dial path emits these; other categories may
+ * be added later (the `category` discriminator exists so consumers can filter).
+ */
+export interface GatewayLogEvent {
+  level: 'debug' | 'info' | 'warning' | 'error';
+  /** Coarse-grained category; today only `'discovery'` is emitted. */
+  category: 'discovery';
+  /** Human-readable message; the same string written to stderr. */
+  message: string;
+  /** Instance the event is about, when the call site has one. */
+  instanceId?: string;
+  /** Structured payload merged into the MCP logging notification's `data`. */
+  meta?: Record<string, unknown>;
+}
+
 // Defaults used before a bridge has announced its client's real capabilities. Optimistic so
 // standalone gateways (no bridge yet) still advertise streaming/subscriptions which they own
 // directly; sampling/elicitation default to false and are flipped true only when a bridge
@@ -205,6 +228,19 @@ export class TesseronGateway extends EventEmitter {
     for (const dialer of builtIns) {
       this.dialers.set(dialer.kind, dialer);
     }
+  }
+
+  /**
+   * Write a discovery / dial-outcome event to stderr (kept for grep-ability)
+   * and emit it as `'gateway-log'` so any attached MCP bridge can forward it
+   * to the connected agent via `notifications/message`. Used by the discovery
+   * loop and the dial paths so a developer sees connect successes, failures,
+   * and stale-manifest tombstones inline in their MCP client. See
+   * tesseron#53 concern (4).
+   */
+  private emitDiscoveryLog(event: Omit<GatewayLogEvent, 'category'>): void {
+    logToStderr(`[tesseron] ${event.message}`);
+    this.emit('gateway-log', { ...event, category: 'discovery' } satisfies GatewayLogEvent);
   }
 
   /** Closes all sessions, outbound connections, and discovery watchers. */
@@ -312,7 +348,12 @@ export class TesseronGateway extends EventEmitter {
       this.connected.delete(instanceId);
       throw err;
     }
-    logToStderr(`[tesseron] connected to app instance ${instanceId} (${describeSpec(spec)})`);
+    this.emitDiscoveryLog({
+      level: 'info',
+      message: `connected to app instance ${instanceId} (${describeSpec(spec)})`,
+      instanceId,
+      meta: { transport: spec.kind },
+    });
   }
 
   /**
@@ -357,9 +398,12 @@ export class TesseronGateway extends EventEmitter {
               try {
                 await unlink(path);
                 if (!alreadyLogged) {
-                  logToStderr(
-                    `[tesseron] tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`,
-                  );
+                  this.emitDiscoveryLog({
+                    level: 'info',
+                    message: `tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`,
+                    instanceId,
+                    meta: { pid: data.pid, path },
+                  });
                 }
                 this.tombstonedManifests.delete(path);
               } catch (unlinkErr) {
@@ -369,9 +413,12 @@ export class TesseronGateway extends EventEmitter {
                 // unlink in case the lock clears.
                 if (!alreadyLogged) {
                   const reason = unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr);
-                  logToStderr(
-                    `[tesseron] could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} — remove the file manually if it persists`,
-                  );
+                  this.emitDiscoveryLog({
+                    level: 'warning',
+                    message: `could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} — remove the file manually if it persists`,
+                    instanceId,
+                    meta: { pid: data.pid, path, reason },
+                  });
                   this.tombstonedManifests.add(path);
                 }
               }
@@ -379,7 +426,12 @@ export class TesseronGateway extends EventEmitter {
             }
             const id = data.instanceId ?? instanceId;
             this.connectToApp(id, data.transport).catch((err: Error) => {
-              logToStderr(`[tesseron] could not connect to instance ${id}: ${err.message}`);
+              this.emitDiscoveryLog({
+                level: 'warning',
+                message: `could not connect to instance ${id}: ${err.message}`,
+                instanceId: id,
+                meta: { reason: err.message },
+              });
             });
           } catch {
             // malformed file or race with deletion — skip
@@ -406,7 +458,12 @@ export class TesseronGateway extends EventEmitter {
             if (typeof data.wsUrl !== 'string') continue;
             const id = data.tabId ?? tabId;
             this.connectToApp(id, { kind: 'ws', url: data.wsUrl }).catch((err: Error) => {
-              logToStderr(`[tesseron] could not connect to legacy tab ${id}: ${err.message}`);
+              this.emitDiscoveryLog({
+                level: 'warning',
+                message: `could not connect to legacy tab ${id}: ${err.message}`,
+                instanceId: id,
+                meta: { reason: err.message, legacy: true },
+              });
             });
           } catch {
             // malformed file or race with deletion — skip

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -19,7 +19,12 @@ import {
   type TesseronStructuredError,
 } from '@tesseron/core';
 import { assertValidElicitSchema } from '@tesseron/core/internal';
-import type { ForeignClaim, ResourceSubscription, TesseronGateway } from './gateway.js';
+import type {
+  ForeignClaim,
+  GatewayLogEvent,
+  ResourceSubscription,
+  TesseronGateway,
+} from './gateway.js';
 import type { Session } from './session.js';
 
 const META_TOOL_CLAIM_SESSION = 'tesseron__claim_session';
@@ -164,6 +169,12 @@ export class McpAgentBridge {
       capabilities: {
         tools: { listChanged: true },
         resources: { listChanged: true, subscribe: true },
+        // Advertise logging so the SDK doesn't silently no-op
+        // sendLoggingMessage. Used both by the per-action log forwarder
+        // (tools/call -> SDK `log` notification) and by the discovery
+        // event bridge that forwards dial outcomes to the agent so a
+        // developer doesn't have to grep stderr (tesseron#53 concern 4).
+        logging: {},
       },
     });
 
@@ -222,6 +233,27 @@ export class McpAgentBridge {
     this.gateway.on('sessions-changed', () => {
       void this.notifyToolsChanged();
       void this.notifyResourcesChanged();
+    });
+
+    // Forward dial / discovery events to the connected MCP client so a
+    // developer sees connect successes, failures, and stale-manifest
+    // tombstones inline in their MCP client instead of having to grep
+    // ~/.claude/. Pre-`connect()` events are dropped (no agent to tell
+    // yet) and any forward failure is silent — these are advisory, never
+    // load-bearing. See tesseron#53 concern (4).
+    this.gateway.on('gateway-log', (event: GatewayLogEvent) => {
+      if (!this.connected) return;
+      void this.server
+        .sendLoggingMessage({
+          level: event.level === 'warning' ? 'warning' : event.level,
+          logger: `tesseron.${event.category}`,
+          data: {
+            message: event.message,
+            ...(event.instanceId !== undefined ? { instanceId: event.instanceId } : {}),
+            ...(event.meta ?? {}),
+          },
+        })
+        .catch(() => {});
     });
   }
 

--- a/packages/mcp/test/discovery-and-claim-record.test.ts
+++ b/packages/mcp/test/discovery-and-claim-record.test.ts
@@ -22,7 +22,10 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  CallToolResultSchema,
+  LoggingMessageNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
 import { ServerTesseronClient } from '@tesseron/server';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { isPidAlive } from '../src/gateway.js';
@@ -270,6 +273,75 @@ describe('claim record breadcrumb in ~/.tesseron/claims/', () => {
     expect(result.text).toContain('No pending session found');
     expect(result.text).not.toContain('different Tesseron gateway');
     expect(result.text).not.toContain('no longer running');
+  });
+});
+
+describe('gateway dial outcomes are forwarded as MCP logging notifications', () => {
+  it('forwards dial-success and tombstone events to the connected MCP client', async () => {
+    // Standalone bridge wired to a Client so we can capture
+    // notifications/message frames. Uses its own gateway so the parent
+    // suite's bridge isn't stealing events.
+    const localGateway = new TesseronGateway();
+    const localBridge = new McpAgentBridge({ gateway: localGateway });
+    const [agentSide, gatewaySide] = InMemoryTransport.createLinkedPair();
+    await localBridge.connect(gatewaySide);
+    const localClient = new Client({ name: 'log-capture', version: '0.0.0' });
+    const messages: Array<{ logger?: string; data: Record<string, unknown> }> = [];
+    localClient.setNotificationHandler(LoggingMessageNotificationSchema, (note) => {
+      const params = note.params as { logger?: string; data: Record<string, unknown> };
+      messages.push({ logger: params.logger, data: params.data });
+    });
+    await localClient.connect(agentSide);
+
+    // Drop a stale-pid manifest into the sandbox; the discovery loop
+    // tombstones it on the next tick and emits a discovery log event.
+    const dir = join(sandbox.dir, '.tesseron', 'instances');
+    await mkdir(dir, { recursive: true });
+    const dead = deadPid();
+    await writeFile(
+      join(dir, 'inst-log-test.json'),
+      JSON.stringify({
+        version: 2,
+        instanceId: 'inst-log-test',
+        appName: 'log capture',
+        addedAt: Date.now(),
+        pid: dead,
+        transport: { kind: 'ws', url: 'ws://127.0.0.1:1/log-test' },
+      }),
+    );
+    const stop = localGateway.watchInstances();
+    await new Promise((r) => setTimeout(r, 250));
+
+    const tombstone = messages.find(
+      (m) =>
+        m.logger === 'tesseron.discovery' &&
+        typeof m.data['message'] === 'string' &&
+        m.data['message'].includes('tombstoned stale instance manifest inst-log-test'),
+    );
+    expect(tombstone, 'expected an MCP logging notification for the tombstone').toBeDefined();
+    expect(tombstone?.data['instanceId']).toBe('inst-log-test');
+    expect(tombstone?.data['pid']).toBe(dead);
+
+    // Now do a real successful dial via a live SDK and confirm we see the
+    // 'connected to app instance' event come through too.
+    const sdk = new ServerTesseronClient();
+    sdk.app({ id: 'log_dial', name: 'log dial', origin: 'http://localhost' });
+    sdk.action('noop').handler(() => 'ok');
+    await dialSdk(localGateway, sandbox, () => sdk.connect());
+
+    const connected = messages.find(
+      (m) =>
+        m.logger === 'tesseron.discovery' &&
+        typeof m.data['message'] === 'string' &&
+        m.data['message'].includes('connected to app instance'),
+    );
+    expect(connected, 'expected an MCP logging notification for the dial-success').toBeDefined();
+    expect(connected?.data['transport']).toBe('ws');
+
+    stop();
+    await sdk.disconnect().catch(() => {});
+    await localClient.close().catch(() => {});
+    await localGateway.stop();
   });
 });
 

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19308,6 +19308,18 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
    * deletable later — but suppresses the repeated stderr line.
    */
   tombstonedManifests = /* @__PURE__ */ new Set();
+  /**
+   * Write a discovery / dial-outcome event to stderr (kept for grep-ability)
+   * and emit it as `'gateway-log'` so any attached MCP bridge can forward it
+   * to the connected agent via `notifications/message`. Used by the discovery
+   * loop and the dial paths so a developer sees connect successes, failures,
+   * and stale-manifest tombstones inline in their MCP client. See
+   * tesseron#53 concern (4).
+   */
+  emitDiscoveryLog(event) {
+    logToStderr(`[tesseron] ${event.message}`);
+    this.emit("gateway-log", { ...event, category: "discovery" });
+  }
   /** Closes all sessions, outbound connections, and discovery watchers. */
   async stop() {
     this.stopped = true;
@@ -19393,7 +19405,12 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       this.connected.delete(instanceId);
       throw err;
     }
-    logToStderr(`[tesseron] connected to app instance ${instanceId} (${describeSpec(spec)})`);
+    this.emitDiscoveryLog({
+      level: "info",
+      message: `connected to app instance ${instanceId} (${describeSpec(spec)})`,
+      instanceId,
+      meta: { transport: spec.kind }
+    });
   }
   /**
    * Watches `~/.tesseron/instances/` for v2 manifests written by SDK-side
@@ -19428,17 +19445,23 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
               try {
                 await (0, import_promises.unlink)(path);
                 if (!alreadyLogged) {
-                  logToStderr(
-                    `[tesseron] tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`
-                  );
+                  this.emitDiscoveryLog({
+                    level: "info",
+                    message: `tombstoned stale instance manifest ${instanceId} (pid ${data.pid} no longer running)`,
+                    instanceId,
+                    meta: { pid: data.pid, path }
+                  });
                 }
                 this.tombstonedManifests.delete(path);
               } catch (unlinkErr) {
                 if (!alreadyLogged) {
                   const reason = unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr);
-                  logToStderr(
-                    `[tesseron] could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} \u2014 remove the file manually if it persists`
-                  );
+                  this.emitDiscoveryLog({
+                    level: "warning",
+                    message: `could not tombstone stale manifest ${path} (pid ${data.pid} dead): ${reason} \u2014 remove the file manually if it persists`,
+                    instanceId,
+                    meta: { pid: data.pid, path, reason }
+                  });
                   this.tombstonedManifests.add(path);
                 }
               }
@@ -19446,7 +19469,12 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
             }
             const id = data.instanceId ?? instanceId;
             this.connectToApp(id, data.transport).catch((err) => {
-              logToStderr(`[tesseron] could not connect to instance ${id}: ${err.message}`);
+              this.emitDiscoveryLog({
+                level: "warning",
+                message: `could not connect to instance ${id}: ${err.message}`,
+                instanceId: id,
+                meta: { reason: err.message }
+              });
             });
           } catch {
           }
@@ -19468,7 +19496,12 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
             if (typeof data.wsUrl !== "string") continue;
             const id = data.tabId ?? tabId;
             this.connectToApp(id, { kind: "ws", url: data.wsUrl }).catch((err) => {
-              logToStderr(`[tesseron] could not connect to legacy tab ${id}: ${err.message}`);
+              this.emitDiscoveryLog({
+                level: "warning",
+                message: `could not connect to legacy tab ${id}: ${err.message}`,
+                instanceId: id,
+                meta: { reason: err.message, legacy: true }
+              });
             });
           } catch {
           }
@@ -25775,7 +25808,13 @@ var McpAgentBridge = class {
     this.server = new Server(serverInfo, {
       capabilities: {
         tools: { listChanged: true },
-        resources: { listChanged: true, subscribe: true }
+        resources: { listChanged: true, subscribe: true },
+        // Advertise logging so the SDK doesn't silently no-op
+        // sendLoggingMessage. Used both by the per-action log forwarder
+        // (tools/call -> SDK `log` notification) and by the discovery
+        // event bridge that forwards dial outcomes to the agent so a
+        // developer doesn't have to grep stderr (tesseron#53 concern 4).
+        logging: {}
       }
     });
     this.registerToolHandlers();
@@ -25821,6 +25860,19 @@ var McpAgentBridge = class {
     this.gateway.on("sessions-changed", () => {
       void this.notifyToolsChanged();
       void this.notifyResourcesChanged();
+    });
+    this.gateway.on("gateway-log", (event) => {
+      if (!this.connected) return;
+      void this.server.sendLoggingMessage({
+        level: event.level === "warning" ? "warning" : event.level,
+        logger: `tesseron.${event.category}`,
+        data: {
+          message: event.message,
+          ...event.instanceId !== void 0 ? { instanceId: event.instanceId } : {},
+          ...event.meta ?? {}
+        }
+      }).catch(() => {
+      });
     });
   }
   /**


### PR DESCRIPTION
## Summary

Closes the final open thread on tesseron#53 — concern (4) asked for "plumbing dial outcomes through the MCP `sendLoggingMessage` channel so a developer sees them in their MCP client without having to grep `~/.claude/`". This PR ships that.

The MCP server constructor now declares the `logging` capability — which the prior version omitted, silently no-op'ing every `sendLoggingMessage` call (including the per-action `log` forwarder that's been broken since day one). With the capability declared, dial outcomes propagate from the gateway to the connected agent as `notifications/message` with `logger: "tesseron.discovery"`:

| Outcome | Level |
|---|---|
| successful dial | info |
| dial failure | warning |
| tombstoned stale file | info |
| tombstone-unlink failure | warning |

Stderr still receives the same lines for grep-ability — the new channel is additive, not a replacement.

`TesseronGateway` gains a `'gateway-log'` EventEmitter event and a public `GatewayLogEvent` type so embedders that wire their own MCP server (rather than using the bundled `McpAgentBridge`) can forward the same events into their server's logging notification path.

## Files

- `packages/mcp/src/gateway.ts` — `GatewayLogEvent` type; `emitDiscoveryLog` helper that does both `logToStderr` and `this.emit('gateway-log', ...)`; replaced 4 dial-related stderr calls.
- `packages/mcp/src/mcp-bridge.ts` — declared `logging` capability in `Server` constructor; subscribed to `'gateway-log'` and forwarded via `sendLoggingMessage`.
- `packages/mcp/test/discovery-and-claim-record.test.ts` — 1 new test wiring a Client, capturing `notifications/message`, asserting both tombstone and dial-success outcomes are forwarded with the right metadata.
- `docs/src/content/docs/sdk/typescript/mcp.md` — notes the new logging channel.
- `plugin/server/index.cjs` — rebuilt via `pnpm --filter @tesseron/mcp build:plugin`.
- `.changeset/feat-mcp-dial-outcomes-logging.md` — `@tesseron/mcp` patch.

## Test plan

- [x] `pnpm -r typecheck` clean.
- [x] `pnpm -r test` — all 146 tests pass (78 in mcp incl. 1 new).
- [x] `pnpm exec biome check` clean on changed files.
- [x] `pnpm --filter @tesseron/mcp build:plugin` rebuilds bundle; new `tesseron.discovery` / `'gateway-log'` strings present in `plugin/server/index.cjs`.
- [ ] Manual: run a Claude Code session, kill a Vite dev server, observe the tombstone notification appear in Claude Code's logging UI rather than only in the gateway stderr.

## What's next for #53

After this lands, all five concerns originally diagnosed in #53 are addressed:

- (1) single-owner binding — shipped in #54
- (2) manifest TTL / pid tombstoning — shipped in #58
- (3) cross-gateway claim ownership (lite variant) — shipped in #58
- (3) full UDS rendezvous — explicitly future work per the issue's prioritization
- (4) MCP `sendLoggingMessage` plumbing — **this PR**
- (5) `tesseron/claimed` notification — shipped in #55

Closes #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
