### PR TITLE
feat: harden ~/.tesseron/* writes + switch to CSPRNG token generation

### DIFF
--- a/.changeset/harden-tesseron-runtime-fs.md
+++ b/.changeset/harden-tesseron-runtime-fs.md
@@ -1,0 +1,22 @@
+---
+'@tesseron/mcp': patch
+'@tesseron/core': patch
+'@tesseron/server': patch
+'@tesseron/vite': patch
+---
+
+Harden every `~/.tesseron/*` write and switch all token generation to the platform CSPRNG. Foundations for tesseron#60 (claim-mediated transport binding); shipped on its own so the security improvements land without waiting for the larger architectural change.
+
+**Filesystem hygiene.** Instance manifests (`~/.tesseron/instances/<id>.json`) and claim breadcrumbs (`~/.tesseron/claims/<CODE>.json`) are now written via a shared private-file helper that:
+
+- creates the parent directory with mode `0o700` (and tightens an existing world-readable directory left over from a pre-hardening release);
+- creates the file with mode `0o600` (owner-only read/write);
+- writes atomically via a sibling temp file plus `rename`, so a concurrent reader never observes a partial write.
+
+A sibling local process running as the same user can no longer enumerate or read the contents of `~/.tesseron/instances/` or `~/.tesseron/claims/` simply by walking the directory. (POSIX modes are advisory on Windows; the parent-dir-as-access-gate model documented for the UDS transport applies there too.)
+
+**CSPRNG-sourced tokens.** Claim codes (`generateClaimCode`), session IDs (`generateSessionId`), and invocation IDs (`generateInvocationId`) now draw from `crypto.getRandomValues()` with rejection sampling instead of `Math.random()`. The claim code in particular is the user-typed gate between an unclaimed session and the MCP agent — a predictable PRNG meaningfully shrank the ~1.5-billion-combination space against an attacker measuring outputs. The wire format is unchanged (still `XXXX-XX` from a 31-char alphabet); only the entropy source differs.
+
+**Constant-time compare.** A pure-JavaScript `constantTimeEqual` lands in `@tesseron/core/internal` and replaces the existing `node:crypto` `timingSafeEqual` used to validate `tesseron/resume` tokens. Same security property, but the helper is now reusable from browser-side code paths in upcoming PRs without pulling `node:crypto` into the web bundle.
+
+No wire-protocol or public-API changes; the new symbols ship under `@tesseron/core/internal` (explicitly not part of the public contract). Existing tests cover unchanged; a new `fs-hygiene.test.ts` exercises mode bits and atomic-write semantics on POSIX, and a new `timing-safe.test.ts` includes a coarse statistical check that catches a regression to a short-circuiting comparison.

--- a/docs/src/content/docs/protocol/security.mdx
+++ b/docs/src/content/docs/protocol/security.mdx
@@ -46,7 +46,7 @@ Even from a permitted origin, the session is inert until claimed. The flow:
 
 The claim code is **never sent on the WebSocket from the gateway to the agent** - the user carries it across. That's the whole point: it's a human-performed authorisation gesture, not an electronic one.
 
-Strength: ~1.5 billion possible codes (6 positions × ~32 unambiguous alphanumerics). A brute-force attacker would need ~750M tries for a 50% hit rate. Codes are single-use; a failed match does not retry.
+Strength: ~1.5 billion possible codes (6 positions × ~32 unambiguous alphanumerics), drawn uniformly from the platform CSPRNG (`crypto.getRandomValues`) with rejection sampling — not `Math.random()`, which is not cryptographically secure. A brute-force attacker would need ~750M tries for a 50% hit rate. Codes are single-use; a failed match does not retry.
 
 ## Multi-app coexistence
 
@@ -85,6 +85,7 @@ This means you can, without coordinating, keep your dashboard and your customer 
 ## Operational tips
 
 - **Bind to `127.0.0.1`, never `0.0.0.0`.** The default in `@tesseron/server` and `@tesseron/vite` is loopback-only; don't override it unless you know exactly why. UDS hosts go through `os.tmpdir()` with a private (mode 0700) directory.
+- **`~/.tesseron/` files are written private (mode 0600 inside a 0700 directory).** Instance manifests and claim breadcrumbs are owner-only on POSIX. Sibling processes running as the same user can still open them — same-UID enforcement is the OS's job — but cross-user enumeration is closed. On Windows POSIX modes are advisory; the OS user model is the gate, same caveat as the UDS binding spec.
 - **Treat the claim code as short-lived.** Don't render it persistently in the UI after the session is claimed.
 - **Clean up instance manifests on app exit.** The built-in SDKs do this for you; if you port to a new runtime, handle the shutdown path so stale files don't pile up.
 - **Log the `agent.id` that claimed the session** - useful for auditing which agent actually ran which action.

--- a/docs/src/content/docs/sdk/typescript/mcp.md
+++ b/docs/src/content/docs/sdk/typescript/mcp.md
@@ -100,7 +100,7 @@ Routing: `tools/call shop__searchProducts` finds the session whose `app.id === "
 
 ## Claim code generation
 
-Codes are six alphanumeric characters minus confusables (no `0`, `1`, `I`, `L`, `O`), formatted `AAAA-BB`. Drawn from `Math.random()`. Stored on the session, claimed via `gateway.claimSession(code)`, cleaned on claim or session close.
+Codes are six alphanumeric characters minus confusables (no `0`, `1`, `I`, `L`, `O`), formatted `AAAA-BB`. Drawn from the platform CSPRNG (`crypto.getRandomValues`) with rejection sampling so the distribution across the 31-character alphabet is uniform. Stored on the session, claimed via `gateway.claimSession(code)`, cleaned on claim or session close.
 
 Each minted code also drops a breadcrumb at `~/.tesseron/claims/<CODE>.json` so a sibling gateway (a parallel Claude Code session, a leftover dev gateway) that receives `tesseron__claim_session` for a code it doesn't own locally can surface a "claim code belongs to gateway pid N" error instead of a flat "no pending session". The breadcrumb is removed on successful claim, on unclaimed close, and on `gateway.stop()`. Embedders building their own claim UI can call `gateway.describeForeignClaim(code)` to drive the same behaviour. See the [handshake page](/protocol/handshake/#multiple-gateways-on-one-machine) for the full picture.
 

--- a/packages/core/src/internal.ts
+++ b/packages/core/src/internal.ts
@@ -25,3 +25,4 @@ export {
   type BuilderRegistry,
 } from './builder-impl.js';
 export { SDK_CAPABILITIES } from './client.js';
+export { constantTimeEqual } from './timing-safe.js';

--- a/packages/core/src/timing-safe.ts
+++ b/packages/core/src/timing-safe.ts
@@ -1,0 +1,38 @@
+/**
+ * Constant-time equality helpers.
+ *
+ * These are split into their own module rather than co-existing with the
+ * dispatcher / builder code so the surface is obvious to security reviewers:
+ * "every equality check on a user-presented token MUST go through this file."
+ * Plain `a === b` on a short-circuiting comparison leaks a prefix-match
+ * length to anyone measuring response latency, which is the textbook
+ * timing-side-channel against bearer credentials (claim codes, resume
+ * tokens, future host-minted bind tokens).
+ *
+ * Implementation is pure JavaScript so the helper works in browser bundles
+ * too — `@tesseron/core` is the platform-neutral package and we don't want
+ * to pull in `node:crypto` here. The XOR-and-OR loop runs in time
+ * proportional to the input length regardless of where the strings differ;
+ * V8/JSC don't optimise the OR-of-XORs into anything timing-variable.
+ */
+
+/**
+ * Constant-time string equality. Returns false if either argument is not a
+ * string, or if lengths differ; otherwise XORs character codes and returns
+ * true iff every comparison was zero.
+ *
+ * **Length is a permitted side channel.** Lengths are returned eagerly. The
+ * caller is expected to ensure same-length inputs by the format contract
+ * (claim codes are fixed-length, resume tokens are fixed-length); a length
+ * mismatch in practice means "definitely not this token" and doesn't leak
+ * anything an attacker couldn't deduce from the protocol shape.
+ */
+export function constantTimeEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}

--- a/packages/core/src/timing-safe.ts
+++ b/packages/core/src/timing-safe.ts
@@ -13,22 +13,45 @@
  * too — `@tesseron/core` is the platform-neutral package and we don't want
  * to pull in `node:crypto` here. The XOR-and-OR loop runs in time
  * proportional to the input length regardless of where the strings differ;
- * V8/JSC don't optimise the OR-of-XORs into anything timing-variable.
+ * a coarse statistical regression check in `test/timing-safe.test.ts`
+ * fails loudly if a future "performance" refactor reintroduces a
+ * short-circuit on prefix mismatch.
  */
 
 /**
- * Constant-time string equality. Returns false if either argument is not a
- * string, or if lengths differ; otherwise XORs character codes and returns
- * true iff every comparison was zero.
+ * Constant-time string equality. Returns true iff `a` and `b` are the same
+ * length and every character code matches. The XOR-and-OR loop runs in
+ * time proportional to the input length regardless of where the strings
+ * differ — a timing-side-channel attacker measuring response latency
+ * cannot deduce a prefix match.
  *
- * **Length is a permitted side channel.** Lengths are returned eagerly. The
- * caller is expected to ensure same-length inputs by the format contract
- * (claim codes are fixed-length, resume tokens are fixed-length); a length
- * mismatch in practice means "definitely not this token" and doesn't leak
- * anything an attacker couldn't deduce from the protocol shape.
+ * **Length is a permitted side channel** because every Tesseron caller
+ * passes fixed-length tokens (claim codes are `XXXX-XX`, resume tokens
+ * are 32-char base64url, future host-minted bind tokens will be a fixed
+ * shape). A length mismatch reduces to "definitely not this token,"
+ * which the protocol shape already reveals; hiding it is unnecessary.
+ *
+ * **Unicode caveat.** `String.prototype.charCodeAt` returns UTF-16 code
+ * units, not bytes. For ASCII-only inputs (which is what every Tesseron
+ * token is — base64url, base32, and `XXXX-XX` codes are all in
+ * `0x2D..0x7A`) this is byte-equivalent to a `Buffer.from(s).length`
+ * comparison. If a future caller passes non-ASCII strings, the
+ * constant-time guarantee still holds, but two strings whose UTF-16
+ * representations differ at the same code-unit positions will compare
+ * unequal even when their canonical Unicode form matches. Don't use
+ * this helper for arbitrary user-supplied non-token strings.
+ *
+ * @throws TypeError if either argument is not a string. The TypeScript
+ * signature already declares `string`, so a non-string at runtime is a
+ * programmer error (untyped JS consumer, malformed deserialisation,
+ * type-cast bypass) and should fail loudly rather than masquerade as a
+ * misleading "token mismatch" — debugging that is hours of chasing the
+ * wrong hypothesis.
  */
 export function constantTimeEqual(a: string, b: string): boolean {
-  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    throw new TypeError('constantTimeEqual requires two string arguments');
+  }
   if (a.length !== b.length) return false;
   let mismatch = 0;
   for (let i = 0; i < a.length; i++) {

--- a/packages/core/test/timing-safe.test.ts
+++ b/packages/core/test/timing-safe.test.ts
@@ -38,13 +38,18 @@ describe('constantTimeEqual', () => {
     expect(constantTimeEqual('AB3X-7K', 'AB3X-XK')).toBe(false); // middle char
   });
 
-  it('returns false when an argument is not a string', () => {
+  it('throws TypeError when an argument is not a string', () => {
     // Calls intentionally pass non-string values to verify the runtime
-    // guard. TypeScript would flag these in normal code.
-    expect(constantTimeEqual('abc', 123 as unknown as string)).toBe(false);
-    expect(constantTimeEqual(undefined as unknown as string, 'abc')).toBe(false);
-    expect(constantTimeEqual(null as unknown as string, null as unknown as string)).toBe(false);
-    expect(constantTimeEqual('abc', { length: 3 } as unknown as string)).toBe(false);
+    // guard. TypeScript would flag these in normal code; at runtime we
+    // throw rather than silently returning false because a type-violating
+    // call is a programmer bug whose symptoms (token mismatch errors)
+    // would otherwise burn hours of debugging the wrong hypothesis.
+    expect(() => constantTimeEqual('abc', 123 as unknown as string)).toThrow(TypeError);
+    expect(() => constantTimeEqual(undefined as unknown as string, 'abc')).toThrow(TypeError);
+    expect(() => constantTimeEqual(null as unknown as string, null as unknown as string)).toThrow(
+      TypeError,
+    );
+    expect(() => constantTimeEqual('abc', { length: 3 } as unknown as string)).toThrow(TypeError);
   });
 
   it('handles non-ASCII characters via charCodeAt', () => {

--- a/packages/core/test/timing-safe.test.ts
+++ b/packages/core/test/timing-safe.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Coverage for the constant-time string equality helper. This is small but
+ * deserves explicit tests because the security guarantee (no early exit on
+ * a prefix mismatch) is exactly the kind of property a future "performance"
+ * refactor could quietly violate.
+ *
+ * The tests cover correctness across length / type / content edge cases and
+ * a coarse statistical timing-equivalence check between same-prefix and
+ * different-prefix mismatches. Real timing-side-channel testing would need
+ * a microbenchmark harness; this test fails loudly if someone reintroduces
+ * an early-return pattern that's orders of magnitude faster on prefix
+ * mismatch, which is the regression we actually care about.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { constantTimeEqual } from '../src/timing-safe.js';
+
+describe('constantTimeEqual', () => {
+  it('returns true for identical strings', () => {
+    expect(constantTimeEqual('', '')).toBe(true);
+    expect(constantTimeEqual('a', 'a')).toBe(true);
+    expect(constantTimeEqual('AB3X-7K', 'AB3X-7K')).toBe(true);
+    expect(
+      constantTimeEqual('gXyR8s9wQAt7zV3KqM5L1mN6pT2bU4dF', 'gXyR8s9wQAt7zV3KqM5L1mN6pT2bU4dF'),
+    ).toBe(true);
+  });
+
+  it('returns false for different-length strings', () => {
+    expect(constantTimeEqual('a', '')).toBe(false);
+    expect(constantTimeEqual('', 'a')).toBe(false);
+    expect(constantTimeEqual('AB3X-7K', 'AB3X-7K ')).toBe(false);
+  });
+
+  it('returns false for same-length but mismatched strings', () => {
+    expect(constantTimeEqual('a', 'b')).toBe(false);
+    expect(constantTimeEqual('AB3X-7K', 'AB3X-7L')).toBe(false); // last char
+    expect(constantTimeEqual('AB3X-7K', 'CB3X-7K')).toBe(false); // first char
+    expect(constantTimeEqual('AB3X-7K', 'AB3X-XK')).toBe(false); // middle char
+  });
+
+  it('returns false when an argument is not a string', () => {
+    // Calls intentionally pass non-string values to verify the runtime
+    // guard. TypeScript would flag these in normal code.
+    expect(constantTimeEqual('abc', 123 as unknown as string)).toBe(false);
+    expect(constantTimeEqual(undefined as unknown as string, 'abc')).toBe(false);
+    expect(constantTimeEqual(null as unknown as string, null as unknown as string)).toBe(false);
+    expect(constantTimeEqual('abc', { length: 3 } as unknown as string)).toBe(false);
+  });
+
+  it('handles non-ASCII characters via charCodeAt', () => {
+    expect(constantTimeEqual('café', 'café')).toBe(true);
+    expect(constantTimeEqual('café', 'cafe')).toBe(false);
+    // Surrogate pairs: charCodeAt sees half-units, but the comparison is
+    // still consistent — same string compares equal, different strings
+    // compare unequal.
+    expect(constantTimeEqual('🎉a', '🎉a')).toBe(true);
+    expect(constantTimeEqual('🎉a', '🎉b')).toBe(false);
+  });
+
+  it('does not short-circuit on a prefix mismatch (coarse timing check)', () => {
+    // Build two same-length strings: one differs at position 0, one differs
+    // at the very end. A short-circuiting comparison would be ~Nx faster
+    // for the prefix mismatch. We're not benchmarking precisely — we just
+    // want both calls to complete without one being orders of magnitude
+    // faster.
+    const len = 1024;
+    const a = 'a'.repeat(len);
+    const earlyDiff = `b${'a'.repeat(len - 1)}`;
+    const lateDiff = `${'a'.repeat(len - 1)}b`;
+
+    const iters = 200;
+    const t0 = process.hrtime.bigint();
+    for (let i = 0; i < iters; i++) {
+      constantTimeEqual(a, earlyDiff);
+    }
+    const earlyMs = Number(process.hrtime.bigint() - t0) / 1e6;
+
+    const t1 = process.hrtime.bigint();
+    for (let i = 0; i < iters; i++) {
+      constantTimeEqual(a, lateDiff);
+    }
+    const lateMs = Number(process.hrtime.bigint() - t1) / 1e6;
+
+    // Fail only if early-diff is implausibly faster than late-diff. A
+    // generous 4x ceiling tolerates JIT warm-up and runtime jitter while
+    // still catching a `for (..) if (!=) return false` regression.
+    const ratio = lateMs === 0 ? Number.POSITIVE_INFINITY : earlyMs / lateMs;
+    expect(ratio).toBeGreaterThan(0.25);
+    expect(ratio).toBeLessThan(4);
+  });
+});

--- a/packages/mcp/src/fs-hygiene.ts
+++ b/packages/mcp/src/fs-hygiene.ts
@@ -1,0 +1,99 @@
+/**
+ * Filesystem hygiene helpers for `~/.tesseron/*` writes.
+ *
+ * Tesseron writes a handful of small files under `~/.tesseron/` (instance
+ * manifests, claim breadcrumbs, future runtime state). Every one of those
+ * files is locally sensitive: another process running as the same user can
+ * read them, and a few of them carry tokens or about-to-be-tokens that the
+ * threat model assumes only the owning gateway sees. The shipped writers
+ * predate any explicit hardening, so they used the umask default (typically
+ * world-readable 0o644 on Linux) and a non-atomic `writeFile`. This helper
+ * standardises the contract:
+ *
+ *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
+ *     POSIX modes);
+ *   - file is created with mode 0o600 — owner-only read/write;
+ *   - the write is atomic via a sibling temp file plus `rename`, so a reader
+ *     never observes a partial write or an empty file mid-flight.
+ *
+ * Identical helpers live in `@tesseron/server/fs-hygiene` and
+ * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
+ * shared package or making `@tesseron/vite` depend on `@tesseron/server`
+ * just for ~70 lines of disk plumbing.
+ */
+
+import { constants as fsConstants } from 'node:fs';
+import { chmod, mkdir, open, rename, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+/**
+ * Ensure `dir` exists with restrictive (0o700) permissions.
+ *
+ * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
+ * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
+ * with the umask-default 0o755), an explicit `chmod` tightens it down.
+ * Failures of the secondary chmod are swallowed: on Windows POSIX modes
+ * are advisory and on a handful of niche filesystems `chmod` is a no-op,
+ * but the atomic-write semantics in {@link writePrivateFile} are the
+ * primary integrity guarantee, so a best-effort tightening is sufficient.
+ */
+export async function ensurePrivateDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+}
+
+/**
+ * Atomically write `contents` to `targetPath` with mode 0o600.
+ *
+ * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
+ * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
+ * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
+ * reader sees either the previous file or the new one — never a half-
+ * written one.
+ *
+ * Mode: the file is created with mode 0o600 (owner-only). The chmod after
+ * write covers filesystems that ignored the open-time mode argument.
+ *
+ * Symlink safety is enforced upstream: the parent directory is set to
+ * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
+ * access to the directory cannot pre-plant a symlink inside it, so a
+ * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
+ * acrobatics. (On Windows POSIX modes are advisory and the OS user model
+ * is the gate — same caveat as the UDS transport, documented there.)
+ */
+export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
+  const dir = dirname(targetPath);
+  await ensurePrivateDir(dir);
+
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
+  // O_EXCL guarantees the open fails if the temp name somehow already
+  // exists (concurrent write collision). Combined with the random suffix
+  // this is collision-free in practice.
+  const fh = await open(
+    tmp,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+    PRIVATE_FILE_MODE,
+  );
+  try {
+    await fh.writeFile(contents);
+    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+  } finally {
+    await fh.close();
+  }
+
+  try {
+    await rename(tmp, targetPath);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+function randomSuffix(): string {
+  const buf = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/mcp/src/fs-hygiene.ts
+++ b/packages/mcp/src/fs-hygiene.ts
@@ -13,13 +13,17 @@
  *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
  *     POSIX modes);
  *   - file is created with mode 0o600 — owner-only read/write;
- *   - the write is atomic via a sibling temp file plus `rename`, so a reader
- *     never observes a partial write or an empty file mid-flight.
+ *   - the write is atomic via a sibling temp file plus `rename`; because the
+ *     temp lives in the same directory as the target, the rename is
+ *     guaranteed same-filesystem and is atomic on POSIX and on Windows ≥ 10.
  *
- * Identical helpers live in `@tesseron/server/fs-hygiene` and
- * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
- * shared package or making `@tesseron/vite` depend on `@tesseron/server`
- * just for ~70 lines of disk plumbing.
+ * Byte-identical copies of this file ship in `@tesseron/vite`,
+ * `@tesseron/server`, and `@tesseron/mcp`. Three copies is cheaper than
+ * wiring a new shared package or making `@tesseron/vite` depend on
+ * `@tesseron/server` just for ~100 lines of disk plumbing. A drift-detection
+ * test in `@tesseron/mcp` (which transitively owns the other two) hashes
+ * all three at test time and fails if they diverge — see
+ * `packages/mcp/test/fs-hygiene-parity.test.ts`.
  */
 
 import { constants as fsConstants } from 'node:fs';
@@ -34,44 +38,70 @@ const PRIVATE_FILE_MODE = 0o600;
  *
  * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
  * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
- * with the umask-default 0o755), an explicit `chmod` tightens it down.
- * Failures of the secondary chmod are swallowed: on Windows POSIX modes
- * are advisory and on a handful of niche filesystems `chmod` is a no-op,
- * but the atomic-write semantics in {@link writePrivateFile} are the
- * primary integrity guarantee, so a best-effort tightening is sufficient.
+ * with the umask-default 0o755), an explicit `chmod` tightens it down so
+ * the documented "manifests are owner-only on POSIX" guarantee actually
+ * holds after an upgrade.
+ *
+ * **Failure handling.** If the post-create `chmod` fails on a POSIX system,
+ * the directory may remain readable by other local processes — the very
+ * threat the helper exists to mitigate. We log the failure to stderr (with
+ * the resolved path so an operator can act on it) but do not throw, because
+ * a write that fails outright is worse than a write that lands at a looser
+ * mode: the gateway would refuse to register the manifest and the user's
+ * tab would silently fail to connect. On Windows, EPERM here is the
+ * documented advisory-mode no-op and is suppressed.
  */
 export async function ensurePrivateDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
-  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+  try {
+    await chmod(dir, PRIVATE_DIR_MODE);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    // Windows treats POSIX modes as advisory; chmod on a directory
+    // typically returns EPERM and the OS user model is the gate. The
+    // UDS-binding spec already documents this caveat.
+    if (process.platform === 'win32' && errno === 'EPERM') return;
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[tesseron] failed to tighten ${dir} to 0o700: ${reason} — directory may be readable by other local processes; see docs/protocol/security\n`,
+    );
+  }
 }
 
 /**
  * Atomically write `contents` to `targetPath` with mode 0o600.
  *
  * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
- * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
- * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
- * reader sees either the previous file or the new one — never a half-
- * written one.
+ * `rename`s into place. The temp lives next to the target, so the rename
+ * is same-filesystem by construction and atomic on POSIX and on Windows
+ * ≥ 10 (the only platforms Node 20 targets). A concurrent reader observes
+ * either the previous file or the new one — never a half-written one.
  *
  * Mode: the file is created with mode 0o600 (owner-only). The chmod after
- * write covers filesystems that ignored the open-time mode argument.
+ * the write covers filesystems that ignored the open-time mode argument
+ * — when *that* path matters and *that* chmod also fails, the security
+ * claim is undermined, so the failure is logged to stderr (mirroring
+ * {@link ensurePrivateDir}). The atomic-rename still happens; better a
+ * loosely-permissioned manifest than a dropped write that strands the
+ * user's session.
  *
  * Symlink safety is enforced upstream: the parent directory is set to
  * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
  * access to the directory cannot pre-plant a symlink inside it, so a
- * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
- * acrobatics. (On Windows POSIX modes are advisory and the OS user model
- * is the gate — same caveat as the UDS transport, documented there.)
+ * regular `rename` into the dir is safe to trust without extra
+ * `O_NOFOLLOW` acrobatics. (On Windows POSIX modes are advisory and the
+ * OS user model is the gate — same caveat as the UDS transport,
+ * documented there.)
  */
 export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
   const dir = dirname(targetPath);
   await ensurePrivateDir(dir);
 
   const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
-  // O_EXCL guarantees the open fails if the temp name somehow already
-  // exists (concurrent write collision). Combined with the random suffix
-  // this is collision-free in practice.
+  // O_EXCL: refuse to clobber a pre-existing file at the temp path. With
+  // 64 random bits in the suffix the realistic role of O_EXCL is to catch
+  // a sibling process that picked the same name (vanishingly unlikely)
+  // — useful insurance, not the primary atomicity guarantee.
   const fh = await open(
     tmp,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
@@ -79,7 +109,19 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   );
   try {
     await fh.writeFile(contents);
-    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+    try {
+      await fh.chmod(PRIVATE_FILE_MODE);
+    } catch (err) {
+      const errno = (err as NodeJS.ErrnoException).code;
+      if (process.platform === 'win32' && errno === 'EPERM') {
+        // Windows advisory-mode no-op; suppress.
+      } else {
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[tesseron] failed to tighten ${tmp} to 0o600: ${reason} — file may be readable by other local processes\n`,
+        );
+      }
+    }
   } finally {
     await fh.close();
   }
@@ -87,13 +129,37 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   try {
     await rename(tmp, targetPath);
   } catch (err) {
-    await unlink(tmp).catch(() => {});
+    // Cleanup is best-effort, but a leaked temp accumulates over time and
+    // is operator-actionable. Surface anything other than ENOENT (which
+    // means a sibling already cleaned the temp, e.g. a process exit
+    // handler) to stderr.
+    try {
+      await unlink(tmp);
+    } catch (cleanupErr) {
+      const cleanupCode = (cleanupErr as NodeJS.ErrnoException).code;
+      if (cleanupCode !== 'ENOENT') {
+        const reason = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+        process.stderr.write(`[tesseron] leaked temp file ${tmp}: ${reason}\n`);
+      }
+    }
     throw err;
   }
 }
 
+/**
+ * 16-hex-character random suffix used for atomic-write temp filenames.
+ * CSPRNG-sourced (via Web Crypto) so a sibling process picking the same
+ * name is statistically impossible — the `O_EXCL` open is just belt-and-
+ * braces against the worst-case collision.
+ */
 function randomSuffix(): string {
+  const c = globalThis.crypto;
+  if (!c?.getRandomValues) {
+    throw new Error(
+      'platform CSPRNG (crypto.getRandomValues) is unavailable; cannot generate temp-file suffix',
+    );
+  }
   const buf = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(buf);
+  c.getRandomValues(buf);
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -1,9 +1,7 @@
-import { Buffer } from 'node:buffer';
-import { timingSafeEqual } from 'node:crypto';
 import { EventEmitter } from 'node:events';
 import { existsSync } from 'node:fs';
 import { watch } from 'node:fs';
-import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises';
+import { readFile, readdir, unlink } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -24,8 +22,9 @@ import {
   type TransportSpec,
   type WelcomeResult,
 } from '@tesseron/core';
-import { JsonRpcDispatcher } from '@tesseron/core/internal';
+import { JsonRpcDispatcher, constantTimeEqual } from '@tesseron/core/internal';
 import { type DialedTransport, type GatewayDialer, UdsDialer, WsDialer } from './dialer.js';
+import { writePrivateFile } from './fs-hygiene.js';
 import {
   type Session,
   generateClaimCode,
@@ -1013,13 +1012,12 @@ export class TesseronGateway extends EventEmitter {
         );
       }
 
-      // Constant-time token compare. timingSafeEqual throws on mismatched-
-      // length buffers, so gate it behind an explicit length check first to
-      // return a clean ResumeFailed instead of a raw TypeError. Both tokens
-      // are 32-char base64url in the happy path.
-      const presented = Buffer.from(resumeParams.resumeToken);
-      const stored = Buffer.from(zombie.resumeToken);
-      if (presented.length !== stored.length || !timingSafeEqual(presented, stored)) {
+      // Constant-time token compare via the shared helper. Plain `===` would
+      // short-circuit on the first differing char and leak the matched-prefix
+      // length to anyone measuring response latency — material against a
+      // base64url 32-char bearer token. {@link constantTimeEqual} runs in
+      // O(length) regardless of where the strings diverge.
+      if (!constantTimeEqual(resumeParams.resumeToken, zombie.resumeToken)) {
         throw new TesseronError(
           TesseronErrorCode.ResumeFailed,
           `Invalid resumeToken for session "${resumeParams.sessionId}".`,
@@ -1231,8 +1229,13 @@ function claimFilePath(code: string): string {
 async function writeClaimRecord(record: ClaimRecord): Promise<void> {
   const path = claimFilePath(record.code);
   try {
-    await mkdir(claimsDir(), { recursive: true });
-    await writeFile(path, JSON.stringify(record, null, 2));
+    // writePrivateFile creates `~/.tesseron/claims/` with mode 0o700 if
+    // missing and atomically writes the breadcrumb at mode 0o600. The
+    // breadcrumb carries no secrets today (the claim code is already on
+    // the wire to the agent), but tightening the mode aligns with every
+    // other file under `~/.tesseron/` and removes the world-readable
+    // surface a sibling local process could enumerate.
+    await writePrivateFile(path, JSON.stringify(record, null, 2));
   } catch (err) {
     // Surfacing the error in stderr is enough — a missing breadcrumb only
     // degrades the cross-gateway error message; it never blocks claiming a

--- a/packages/mcp/src/session.ts
+++ b/packages/mcp/src/session.ts
@@ -1,4 +1,4 @@
-import { randomBytes } from 'node:crypto';
+import { Buffer } from 'node:buffer';
 import type {
   ActionManifestEntry,
   AppMetadata,
@@ -44,21 +44,68 @@ export interface Session {
 }
 
 const CLAIM_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const BASE36_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz';
 
-export function generateClaimCode(): string {
-  let code = '';
-  for (let i = 0; i < 6; i++) {
-    code += CLAIM_CHARS[Math.floor(Math.random() * CLAIM_CHARS.length)];
+/**
+ * Draw `len` characters uniformly from `alphabet` using the platform CSPRNG
+ * (`crypto.getRandomValues`) with rejection sampling. Bytes that fall in the
+ * modulo-bias spillover region are discarded so the resulting distribution
+ * is exactly uniform across the alphabet — for the 31-char claim alphabet
+ * the rejection rate is ~3% and for the 36-char base36 alphabet it's ~1.5%.
+ *
+ * Cheap to call: re-fills the byte buffer in a tight loop and emits as many
+ * characters as the over-read produces before redrawing.
+ */
+function randomFromAlphabet(alphabet: string, len: number): string {
+  const aLen = alphabet.length;
+  if (aLen === 0 || aLen > 256) {
+    throw new RangeError('alphabet length must be 1..256');
   }
+  const maxAcceptable = Math.floor(256 / aLen) * aLen;
+  let out = '';
+  while (out.length < len) {
+    const buf = new Uint8Array((len - out.length) * 2 + 4);
+    globalThis.crypto.getRandomValues(buf);
+    for (const b of buf) {
+      if (b >= maxAcceptable) continue;
+      out += alphabet.charAt(b % aLen);
+      if (out.length === len) break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Random claim code in the format `XXXX-XX`. 31-char alphabet of upper-case
+ * letters + digits with visually-confusable characters (`0`, `1`, `I`, `L`,
+ * `O`) excluded.
+ *
+ * Drawn from the platform CSPRNG (`crypto.getRandomValues`) rather than
+ * `Math.random()`. The claim code is the user-typed gate between an
+ * unclaimed session and the MCP agent: a malicious local process can call
+ * `tesseron__claim_session` repeatedly with guessed codes, and against a
+ * predictable PRNG the ~1.5-billion-combination space is no defence at all.
+ * CSPRNG output is the bare minimum for this gate to mean anything.
+ */
+export function generateClaimCode(): string {
+  const code = randomFromAlphabet(CLAIM_CHARS, 6);
   return `${code.slice(0, 4)}-${code.slice(4)}`;
 }
 
+/**
+ * Opaque session ID. 8 random base36 chars + a base36 timestamp suffix for
+ * log legibility ("which session did *that* one come from?"). Random prefix
+ * is CSPRNG-sourced so a session ID can't be guessed from another one
+ * observed in logs — session IDs are surfaced in `tesseron/welcome` and
+ * predictable values would let a sibling process narrow the search space
+ * for a future `tesseron/resume` token brute-force if the token ever leaked.
+ */
 export function generateSessionId(): string {
-  return `s_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  return `s_${randomFromAlphabet(BASE36_CHARS, 8)}${Date.now().toString(36)}`;
 }
 
 export function generateInvocationId(): string {
-  return `inv_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  return `inv_${randomFromAlphabet(BASE36_CHARS, 8)}${Date.now().toString(36)}`;
 }
 
 /**
@@ -67,7 +114,9 @@ export function generateInvocationId(): string {
  * infeasible within the zombie TTL even under aggressive concurrency.
  */
 export function generateResumeToken(): string {
-  return randomBytes(24).toString('base64url');
+  const buf = new Uint8Array(24);
+  globalThis.crypto.getRandomValues(buf);
+  return Buffer.from(buf).toString('base64url');
 }
 
 const RESERVED_APP_IDS = new Set(['tesseron', 'mcp', 'system']);

--- a/packages/mcp/test/fs-hygiene-parity.test.ts
+++ b/packages/mcp/test/fs-hygiene-parity.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Drift detector for the byte-identical `fs-hygiene.ts` copies in
+ * `@tesseron/vite`, `@tesseron/server`, and `@tesseron/mcp`.
+ *
+ * The PR that introduced these helpers explicitly chose three identical
+ * copies over a shared package or cross-package dep. The trade-off is fine
+ * as long as the three files actually stay identical — but the *only*
+ * thing keeping them in sync today is the header comment and reviewer
+ * vigilance. A bugfix landed in one and missed in the others would leave
+ * the security-claim-violating behavior live in two of the three packages,
+ * with no test signal.
+ *
+ * This test compares the SHA-256 of all three files. A drift produces a
+ * one-line failure pointing at the offending pair, and the fix is a
+ * trivial `cp` between the three. Lives in `@tesseron/mcp` because mcp
+ * already transitively reads the others (it's the gateway, the consumer
+ * of all transport kinds), so the assertion runs once per CI rather than
+ * three times.
+ */
+
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..', '..');
+
+const COPIES = {
+  vite: resolve(REPO_ROOT, 'packages/vite/src/fs-hygiene.ts'),
+  server: resolve(REPO_ROOT, 'packages/server/src/fs-hygiene.ts'),
+  mcp: resolve(REPO_ROOT, 'packages/mcp/src/fs-hygiene.ts'),
+};
+
+function sha256(file: string): string {
+  return createHash('sha256').update(readFileSync(file)).digest('hex');
+}
+
+describe('fs-hygiene byte-identical-copies invariant', () => {
+  it('three copies have the same SHA-256', () => {
+    const hashes = Object.fromEntries(
+      Object.entries(COPIES).map(([k, p]) => [k, sha256(p)]),
+    ) as Record<keyof typeof COPIES, string>;
+
+    // If this fails, copy whichever version you intended into the other
+    // two: `cp packages/{vite,server,mcp}/src/fs-hygiene.ts` either
+    // direction. The three copies are deliberately identical; see the
+    // header comment in any of them.
+    expect(hashes.server, 'server vs vite').toBe(hashes.vite);
+    expect(hashes.mcp, 'mcp vs vite').toBe(hashes.vite);
+  });
+});

--- a/packages/mcp/test/session-tokens.test.ts
+++ b/packages/mcp/test/session-tokens.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Direct coverage for the token generators in `session.ts`. The previous
+ * test surface only exercised these transitively through `integration.test`
+ * — which is enough to catch "tokens don't roundtrip" regressions but not
+ * enough to catch "tokens silently lost their CSPRNG entropy" regressions
+ * or "rejection sampling bypassed and modulo bias is back" regressions,
+ * which are the failure modes that motivated PR #62.
+ *
+ * Tests intentionally avoid mocking `globalThis.crypto`: the security
+ * property we want is "the deployed code path actually uses the platform
+ * CSPRNG correctly." A mock-based test of the *non*-CSPRNG path is the
+ * thing that quietly turned green when production drifted; we test the
+ * real code on the real CSPRNG instead.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  generateClaimCode,
+  generateInvocationId,
+  generateResumeToken,
+  generateSessionId,
+} from '../src/session.js';
+
+const CLAIM_CHARS = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+const BASE36_CHARS = '0123456789abcdefghijklmnopqrstuvwxyz';
+const CONFUSABLES = ['0', '1', 'I', 'L', 'O'];
+
+describe('generateClaimCode', () => {
+  it('returns the documented XXXX-XX format from the 31-char alphabet', () => {
+    for (let i = 0; i < 200; i++) {
+      const code = generateClaimCode();
+      expect(code).toMatch(/^[A-Z2-9]{4}-[A-Z2-9]{2}$/);
+    }
+  });
+
+  it('never emits a visually-confusable character (0, 1, I, L, O)', () => {
+    // The whole point of the 31-char alphabet is a pasteable code that
+    // doesn't trip on 0/O or 1/I/L confusion. A regression that swapped
+    // CLAIM_CHARS for a 36-char base36 alphabet would still pass the
+    // length+format test above; this assertion catches it.
+    for (let i = 0; i < 500; i++) {
+      const code = generateClaimCode().replace('-', '');
+      for (const c of CONFUSABLES) {
+        expect(code).not.toContain(c);
+      }
+    }
+  });
+
+  it('produces a roughly uniform distribution across the alphabet', () => {
+    // Catches a regression that drops the rejection-sampling guard and
+    // reintroduces modulo bias — that would skew the distribution toward
+    // the first `256 % 31 = 8` characters by ~3% each. We sample enough
+    // codes that the bias would be visible; loose threshold so CI noise
+    // doesn't flake.
+    const counts = new Map<string, number>();
+    const SAMPLES = 10_000;
+    const charsPerCode = 6;
+    const totalChars = SAMPLES * charsPerCode;
+    for (let i = 0; i < SAMPLES; i++) {
+      for (const ch of generateClaimCode().replace('-', '')) {
+        counts.set(ch, (counts.get(ch) ?? 0) + 1);
+      }
+    }
+    // Every alphabet character should appear; expected count is
+    // totalChars/31 ≈ 1935. A 5x deviation either way would fail.
+    const expected = totalChars / CLAIM_CHARS.length;
+    for (const ch of CLAIM_CHARS) {
+      const got = counts.get(ch) ?? 0;
+      expect(got, `char "${ch}" count`).toBeGreaterThan(expected * 0.5);
+      expect(got, `char "${ch}" count`).toBeLessThan(expected * 1.5);
+    }
+  });
+
+  it('produces no collisions across 1000 calls', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      seen.add(generateClaimCode());
+    }
+    // The 31^6 ≈ 887M space makes collisions in 1000 draws cosmically
+    // unlikely (birthday paradox: 50% at ~37000). Fewer than 1000 unique
+    // values is a sign the CSPRNG path is broken (e.g. fixed seed in a
+    // misconfigured test runner).
+    expect(seen.size).toBe(1000);
+  });
+});
+
+describe('generateSessionId / generateInvocationId', () => {
+  it('returns the documented prefixed-base36 format', () => {
+    for (let i = 0; i < 200; i++) {
+      // 8 random base36 chars + a base36 timestamp suffix (≥ 7 chars
+      // for any realistic Date.now()).
+      expect(generateSessionId()).toMatch(/^s_[0-9a-z]{8}[0-9a-z]+$/);
+      expect(generateInvocationId()).toMatch(/^inv_[0-9a-z]{8}[0-9a-z]+$/);
+    }
+  });
+
+  it('the random prefix uses only the 36-char base36 alphabet', () => {
+    // Catches a regression that swaps BASE36_CHARS for a charset that
+    // happens to contain something the regex above tolerates (e.g.
+    // upper-case letters via Math.random().toString(36).toUpperCase()).
+    for (let i = 0; i < 500; i++) {
+      const session = generateSessionId().slice(2, 10); // 8 random chars
+      const invocation = generateInvocationId().slice(4, 12);
+      for (const ch of session) expect(BASE36_CHARS).toContain(ch);
+      for (const ch of invocation) expect(BASE36_CHARS).toContain(ch);
+    }
+  });
+
+  it('produces no collisions across 1000 calls', () => {
+    const sessionSeen = new Set<string>();
+    const invocationSeen = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      sessionSeen.add(generateSessionId());
+      invocationSeen.add(generateInvocationId());
+    }
+    expect(sessionSeen.size).toBe(1000);
+    expect(invocationSeen.size).toBe(1000);
+  });
+});
+
+describe('generateResumeToken', () => {
+  it('returns 32 url-safe base64 characters', () => {
+    for (let i = 0; i < 100; i++) {
+      const tok = generateResumeToken();
+      expect(tok).toHaveLength(32);
+      // base64url charset: A-Z a-z 0-9 - _ (no '+', '/', or '=' padding).
+      expect(tok).toMatch(/^[A-Za-z0-9_-]{32}$/);
+      expect(tok).not.toContain('+');
+      expect(tok).not.toContain('/');
+      expect(tok).not.toContain('=');
+    }
+  });
+
+  it('produces no collisions across 1000 calls', () => {
+    // 24 random bytes = 192 bits. Collision in 1000 draws is impossibly
+    // unlikely unless the CSPRNG path is broken.
+    const seen = new Set<string>();
+    for (let i = 0; i < 1000; i++) {
+      seen.add(generateResumeToken());
+    }
+    expect(seen.size).toBe(1000);
+  });
+
+  it('successive calls produce different values', () => {
+    // Defends against a refactor that accidentally caches the first
+    // result (e.g. memoising the buffer at module scope by mistake).
+    expect(generateResumeToken()).not.toBe(generateResumeToken());
+    expect(generateResumeToken()).not.toBe(generateResumeToken());
+  });
+});
+
+describe('Math.random is no longer used in session token generation', () => {
+  it('session.ts source contains no Math.random calls', async () => {
+    // Structural regression guard. The CSPRNG migration is the security
+    // property we care about; a future "perf" refactor that quietly
+    // reintroduces Math.random would still pass every behavioural test
+    // above (the format and distribution properties survive a switch
+    // back to PRNG). This grep-style assertion immortalises the
+    // decision: if you genuinely need Math.random somewhere, this
+    // test must be updated explicitly.
+    //
+    // Comments mentioning the prior `Math.random()` callsites in JSDoc
+    // are stripped before the check so the doc trail explaining "we
+    // used to use Math.random() here, then migrated" can stay.
+    const { readFile } = await import('node:fs/promises');
+    const { fileURLToPath } = await import('node:url');
+    const { dirname, resolve } = await import('node:path');
+    const here = dirname(fileURLToPath(import.meta.url));
+    const src = await readFile(resolve(here, '../src/session.ts'), 'utf8');
+    const stripped = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+    expect(stripped).not.toMatch(/\bMath\.random\b/);
+  });
+});

--- a/packages/server/src/fs-hygiene.ts
+++ b/packages/server/src/fs-hygiene.ts
@@ -1,0 +1,99 @@
+/**
+ * Filesystem hygiene helpers for `~/.tesseron/*` writes.
+ *
+ * Tesseron writes a handful of small files under `~/.tesseron/` (instance
+ * manifests, claim breadcrumbs, future runtime state). Every one of those
+ * files is locally sensitive: another process running as the same user can
+ * read them, and a few of them carry tokens or about-to-be-tokens that the
+ * threat model assumes only the owning gateway sees. The shipped writers
+ * predate any explicit hardening, so they used the umask default (typically
+ * world-readable 0o644 on Linux) and a non-atomic `writeFile`. This helper
+ * standardises the contract:
+ *
+ *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
+ *     POSIX modes);
+ *   - file is created with mode 0o600 — owner-only read/write;
+ *   - the write is atomic via a sibling temp file plus `rename`, so a reader
+ *     never observes a partial write or an empty file mid-flight.
+ *
+ * Identical helpers live in `@tesseron/server/fs-hygiene` and
+ * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
+ * shared package or making `@tesseron/vite` depend on `@tesseron/server`
+ * just for ~70 lines of disk plumbing.
+ */
+
+import { constants as fsConstants } from 'node:fs';
+import { chmod, mkdir, open, rename, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+/**
+ * Ensure `dir` exists with restrictive (0o700) permissions.
+ *
+ * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
+ * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
+ * with the umask-default 0o755), an explicit `chmod` tightens it down.
+ * Failures of the secondary chmod are swallowed: on Windows POSIX modes
+ * are advisory and on a handful of niche filesystems `chmod` is a no-op,
+ * but the atomic-write semantics in {@link writePrivateFile} are the
+ * primary integrity guarantee, so a best-effort tightening is sufficient.
+ */
+export async function ensurePrivateDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+}
+
+/**
+ * Atomically write `contents` to `targetPath` with mode 0o600.
+ *
+ * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
+ * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
+ * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
+ * reader sees either the previous file or the new one — never a half-
+ * written one.
+ *
+ * Mode: the file is created with mode 0o600 (owner-only). The chmod after
+ * write covers filesystems that ignored the open-time mode argument.
+ *
+ * Symlink safety is enforced upstream: the parent directory is set to
+ * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
+ * access to the directory cannot pre-plant a symlink inside it, so a
+ * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
+ * acrobatics. (On Windows POSIX modes are advisory and the OS user model
+ * is the gate — same caveat as the UDS transport, documented there.)
+ */
+export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
+  const dir = dirname(targetPath);
+  await ensurePrivateDir(dir);
+
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
+  // O_EXCL guarantees the open fails if the temp name somehow already
+  // exists (concurrent write collision). Combined with the random suffix
+  // this is collision-free in practice.
+  const fh = await open(
+    tmp,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+    PRIVATE_FILE_MODE,
+  );
+  try {
+    await fh.writeFile(contents);
+    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+  } finally {
+    await fh.close();
+  }
+
+  try {
+    await rename(tmp, targetPath);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+function randomSuffix(): string {
+  const buf = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/server/src/fs-hygiene.ts
+++ b/packages/server/src/fs-hygiene.ts
@@ -13,13 +13,17 @@
  *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
  *     POSIX modes);
  *   - file is created with mode 0o600 — owner-only read/write;
- *   - the write is atomic via a sibling temp file plus `rename`, so a reader
- *     never observes a partial write or an empty file mid-flight.
+ *   - the write is atomic via a sibling temp file plus `rename`; because the
+ *     temp lives in the same directory as the target, the rename is
+ *     guaranteed same-filesystem and is atomic on POSIX and on Windows ≥ 10.
  *
- * Identical helpers live in `@tesseron/server/fs-hygiene` and
- * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
- * shared package or making `@tesseron/vite` depend on `@tesseron/server`
- * just for ~70 lines of disk plumbing.
+ * Byte-identical copies of this file ship in `@tesseron/vite`,
+ * `@tesseron/server`, and `@tesseron/mcp`. Three copies is cheaper than
+ * wiring a new shared package or making `@tesseron/vite` depend on
+ * `@tesseron/server` just for ~100 lines of disk plumbing. A drift-detection
+ * test in `@tesseron/mcp` (which transitively owns the other two) hashes
+ * all three at test time and fails if they diverge — see
+ * `packages/mcp/test/fs-hygiene-parity.test.ts`.
  */
 
 import { constants as fsConstants } from 'node:fs';
@@ -34,44 +38,70 @@ const PRIVATE_FILE_MODE = 0o600;
  *
  * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
  * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
- * with the umask-default 0o755), an explicit `chmod` tightens it down.
- * Failures of the secondary chmod are swallowed: on Windows POSIX modes
- * are advisory and on a handful of niche filesystems `chmod` is a no-op,
- * but the atomic-write semantics in {@link writePrivateFile} are the
- * primary integrity guarantee, so a best-effort tightening is sufficient.
+ * with the umask-default 0o755), an explicit `chmod` tightens it down so
+ * the documented "manifests are owner-only on POSIX" guarantee actually
+ * holds after an upgrade.
+ *
+ * **Failure handling.** If the post-create `chmod` fails on a POSIX system,
+ * the directory may remain readable by other local processes — the very
+ * threat the helper exists to mitigate. We log the failure to stderr (with
+ * the resolved path so an operator can act on it) but do not throw, because
+ * a write that fails outright is worse than a write that lands at a looser
+ * mode: the gateway would refuse to register the manifest and the user's
+ * tab would silently fail to connect. On Windows, EPERM here is the
+ * documented advisory-mode no-op and is suppressed.
  */
 export async function ensurePrivateDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
-  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+  try {
+    await chmod(dir, PRIVATE_DIR_MODE);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    // Windows treats POSIX modes as advisory; chmod on a directory
+    // typically returns EPERM and the OS user model is the gate. The
+    // UDS-binding spec already documents this caveat.
+    if (process.platform === 'win32' && errno === 'EPERM') return;
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[tesseron] failed to tighten ${dir} to 0o700: ${reason} — directory may be readable by other local processes; see docs/protocol/security\n`,
+    );
+  }
 }
 
 /**
  * Atomically write `contents` to `targetPath` with mode 0o600.
  *
  * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
- * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
- * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
- * reader sees either the previous file or the new one — never a half-
- * written one.
+ * `rename`s into place. The temp lives next to the target, so the rename
+ * is same-filesystem by construction and atomic on POSIX and on Windows
+ * ≥ 10 (the only platforms Node 20 targets). A concurrent reader observes
+ * either the previous file or the new one — never a half-written one.
  *
  * Mode: the file is created with mode 0o600 (owner-only). The chmod after
- * write covers filesystems that ignored the open-time mode argument.
+ * the write covers filesystems that ignored the open-time mode argument
+ * — when *that* path matters and *that* chmod also fails, the security
+ * claim is undermined, so the failure is logged to stderr (mirroring
+ * {@link ensurePrivateDir}). The atomic-rename still happens; better a
+ * loosely-permissioned manifest than a dropped write that strands the
+ * user's session.
  *
  * Symlink safety is enforced upstream: the parent directory is set to
  * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
  * access to the directory cannot pre-plant a symlink inside it, so a
- * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
- * acrobatics. (On Windows POSIX modes are advisory and the OS user model
- * is the gate — same caveat as the UDS transport, documented there.)
+ * regular `rename` into the dir is safe to trust without extra
+ * `O_NOFOLLOW` acrobatics. (On Windows POSIX modes are advisory and the
+ * OS user model is the gate — same caveat as the UDS transport,
+ * documented there.)
  */
 export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
   const dir = dirname(targetPath);
   await ensurePrivateDir(dir);
 
   const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
-  // O_EXCL guarantees the open fails if the temp name somehow already
-  // exists (concurrent write collision). Combined with the random suffix
-  // this is collision-free in practice.
+  // O_EXCL: refuse to clobber a pre-existing file at the temp path. With
+  // 64 random bits in the suffix the realistic role of O_EXCL is to catch
+  // a sibling process that picked the same name (vanishingly unlikely)
+  // — useful insurance, not the primary atomicity guarantee.
   const fh = await open(
     tmp,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
@@ -79,7 +109,19 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   );
   try {
     await fh.writeFile(contents);
-    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+    try {
+      await fh.chmod(PRIVATE_FILE_MODE);
+    } catch (err) {
+      const errno = (err as NodeJS.ErrnoException).code;
+      if (process.platform === 'win32' && errno === 'EPERM') {
+        // Windows advisory-mode no-op; suppress.
+      } else {
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[tesseron] failed to tighten ${tmp} to 0o600: ${reason} — file may be readable by other local processes\n`,
+        );
+      }
+    }
   } finally {
     await fh.close();
   }
@@ -87,13 +129,37 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   try {
     await rename(tmp, targetPath);
   } catch (err) {
-    await unlink(tmp).catch(() => {});
+    // Cleanup is best-effort, but a leaked temp accumulates over time and
+    // is operator-actionable. Surface anything other than ENOENT (which
+    // means a sibling already cleaned the temp, e.g. a process exit
+    // handler) to stderr.
+    try {
+      await unlink(tmp);
+    } catch (cleanupErr) {
+      const cleanupCode = (cleanupErr as NodeJS.ErrnoException).code;
+      if (cleanupCode !== 'ENOENT') {
+        const reason = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+        process.stderr.write(`[tesseron] leaked temp file ${tmp}: ${reason}\n`);
+      }
+    }
     throw err;
   }
 }
 
+/**
+ * 16-hex-character random suffix used for atomic-write temp filenames.
+ * CSPRNG-sourced (via Web Crypto) so a sibling process picking the same
+ * name is statistically impossible — the `O_EXCL` open is just belt-and-
+ * braces against the worst-case collision.
+ */
 function randomSuffix(): string {
+  const c = globalThis.crypto;
+  if (!c?.getRandomValues) {
+    throw new Error(
+      'platform CSPRNG (crypto.getRandomValues) is unavailable; cannot generate temp-file suffix',
+    );
+  }
   const buf = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(buf);
+  c.getRandomValues(buf);
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/server/src/transport.ts
+++ b/packages/server/src/transport.ts
@@ -21,7 +21,16 @@ function getInstancesDir(): string {
 }
 
 function generateInstanceId(): string {
-  return `inst-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  // CSPRNG-sourced like the rest of `~/.tesseron/*` writes. Instance IDs
+  // aren't bearer tokens (the gateway still requires the standard
+  // handshake), but a predictable id is a side channel — a sibling
+  // process that observes one id can narrow the manifest namespace
+  // for the next, and the consistency with claim/session/resume token
+  // generation matters for review.
+  const buf = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(buf);
+  const rand = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `inst-${Date.now().toString(36)}-${rand}`;
 }
 
 export interface NodeWebSocketServerTransportOptions {

--- a/packages/server/src/transport.ts
+++ b/packages/server/src/transport.ts
@@ -1,11 +1,12 @@
 import { Buffer } from 'node:buffer';
 import { existsSync } from 'node:fs';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { unlink } from 'node:fs/promises';
 import { type Server, createServer } from 'node:http';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Transport } from '@tesseron/core';
 import { type RawData, type WebSocket, WebSocketServer } from 'ws';
+import { writePrivateFile } from './fs-hygiene.js';
 
 const GATEWAY_SUBPROTOCOL = 'tesseron-gateway';
 
@@ -137,12 +138,8 @@ export class NodeWebSocketServerTransport implements Transport {
   }
 
   private async writeManifest(wsUrl: string): Promise<void> {
-    const instancesDir = getInstancesDir();
-    if (!existsSync(instancesDir)) {
-      await mkdir(instancesDir, { recursive: true });
-    }
-    this.manifestFile = join(instancesDir, `${this.instanceId}.json`);
-    await writeFile(
+    this.manifestFile = join(getInstancesDir(), `${this.instanceId}.json`);
+    await writePrivateFile(
       this.manifestFile,
       JSON.stringify(
         {

--- a/packages/server/src/uds-transport.ts
+++ b/packages/server/src/uds-transport.ts
@@ -1,9 +1,10 @@
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, mkdtemp, rm, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, rm, unlink } from 'node:fs/promises';
 import { type Server, type Socket, createServer } from 'node:net';
 import { homedir, platform, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Transport } from '@tesseron/core';
+import { writePrivateFile } from './fs-hygiene.js';
 
 const isWindows = platform() === 'win32';
 
@@ -186,12 +187,8 @@ export class UnixSocketServerTransport implements Transport {
   }
 
   private async writeManifest(socketPath: string): Promise<void> {
-    const instancesDir = getInstancesDir();
-    if (!existsSync(instancesDir)) {
-      await mkdir(instancesDir, { recursive: true });
-    }
-    this.manifestFile = join(instancesDir, `${this.instanceId}.json`);
-    await writeFile(
+    this.manifestFile = join(getInstancesDir(), `${this.instanceId}.json`);
+    await writePrivateFile(
       this.manifestFile,
       JSON.stringify(
         {

--- a/packages/server/src/uds-transport.ts
+++ b/packages/server/src/uds-transport.ts
@@ -19,7 +19,16 @@ function getInstancesDir(): string {
 }
 
 function generateInstanceId(): string {
-  return `inst-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  // CSPRNG-sourced like the rest of `~/.tesseron/*` writes. Instance IDs
+  // aren't bearer tokens (the gateway still requires the standard
+  // handshake), but a predictable id is a side channel — a sibling
+  // process that observes one id can narrow the manifest namespace
+  // for the next, and the consistency with claim/session/resume token
+  // generation matters for review.
+  const buf = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(buf);
+  const rand = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `inst-${Date.now().toString(36)}-${rand}`;
 }
 
 export interface UnixSocketServerTransportOptions {

--- a/packages/vite/src/fs-hygiene.ts
+++ b/packages/vite/src/fs-hygiene.ts
@@ -1,0 +1,99 @@
+/**
+ * Filesystem hygiene helpers for `~/.tesseron/*` writes.
+ *
+ * Tesseron writes a handful of small files under `~/.tesseron/` (instance
+ * manifests, claim breadcrumbs, future runtime state). Every one of those
+ * files is locally sensitive: another process running as the same user can
+ * read them, and a few of them carry tokens or about-to-be-tokens that the
+ * threat model assumes only the owning gateway sees. The shipped writers
+ * predate any explicit hardening, so they used the umask default (typically
+ * world-readable 0o644 on Linux) and a non-atomic `writeFile`. This helper
+ * standardises the contract:
+ *
+ *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
+ *     POSIX modes);
+ *   - file is created with mode 0o600 — owner-only read/write;
+ *   - the write is atomic via a sibling temp file plus `rename`, so a reader
+ *     never observes a partial write or an empty file mid-flight.
+ *
+ * Identical helpers live in `@tesseron/server/fs-hygiene` and
+ * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
+ * shared package or making `@tesseron/vite` depend on `@tesseron/server`
+ * just for ~70 lines of disk plumbing.
+ */
+
+import { constants as fsConstants } from 'node:fs';
+import { chmod, mkdir, open, rename, unlink } from 'node:fs/promises';
+import { dirname } from 'node:path';
+
+const PRIVATE_DIR_MODE = 0o700;
+const PRIVATE_FILE_MODE = 0o600;
+
+/**
+ * Ensure `dir` exists with restrictive (0o700) permissions.
+ *
+ * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
+ * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
+ * with the umask-default 0o755), an explicit `chmod` tightens it down.
+ * Failures of the secondary chmod are swallowed: on Windows POSIX modes
+ * are advisory and on a handful of niche filesystems `chmod` is a no-op,
+ * but the atomic-write semantics in {@link writePrivateFile} are the
+ * primary integrity guarantee, so a best-effort tightening is sufficient.
+ */
+export async function ensurePrivateDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+}
+
+/**
+ * Atomically write `contents` to `targetPath` with mode 0o600.
+ *
+ * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
+ * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
+ * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
+ * reader sees either the previous file or the new one — never a half-
+ * written one.
+ *
+ * Mode: the file is created with mode 0o600 (owner-only). The chmod after
+ * write covers filesystems that ignored the open-time mode argument.
+ *
+ * Symlink safety is enforced upstream: the parent directory is set to
+ * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
+ * access to the directory cannot pre-plant a symlink inside it, so a
+ * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
+ * acrobatics. (On Windows POSIX modes are advisory and the OS user model
+ * is the gate — same caveat as the UDS transport, documented there.)
+ */
+export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
+  const dir = dirname(targetPath);
+  await ensurePrivateDir(dir);
+
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
+  // O_EXCL guarantees the open fails if the temp name somehow already
+  // exists (concurrent write collision). Combined with the random suffix
+  // this is collision-free in practice.
+  const fh = await open(
+    tmp,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
+    PRIVATE_FILE_MODE,
+  );
+  try {
+    await fh.writeFile(contents);
+    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+  } finally {
+    await fh.close();
+  }
+
+  try {
+    await rename(tmp, targetPath);
+  } catch (err) {
+    await unlink(tmp).catch(() => {});
+    throw err;
+  }
+}
+
+function randomSuffix(): string {
+  const buf = new Uint8Array(8);
+  globalThis.crypto.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/packages/vite/src/fs-hygiene.ts
+++ b/packages/vite/src/fs-hygiene.ts
@@ -13,13 +13,17 @@
  *   - parent dir is forced to 0o700 (best-effort on filesystems that ignore
  *     POSIX modes);
  *   - file is created with mode 0o600 — owner-only read/write;
- *   - the write is atomic via a sibling temp file plus `rename`, so a reader
- *     never observes a partial write or an empty file mid-flight.
+ *   - the write is atomic via a sibling temp file plus `rename`; because the
+ *     temp lives in the same directory as the target, the rename is
+ *     guaranteed same-filesystem and is atomic on POSIX and on Windows ≥ 10.
  *
- * Identical helpers live in `@tesseron/server/fs-hygiene` and
- * `@tesseron/mcp/fs-hygiene`. Three copies is cheaper than wiring a new
- * shared package or making `@tesseron/vite` depend on `@tesseron/server`
- * just for ~70 lines of disk plumbing.
+ * Byte-identical copies of this file ship in `@tesseron/vite`,
+ * `@tesseron/server`, and `@tesseron/mcp`. Three copies is cheaper than
+ * wiring a new shared package or making `@tesseron/vite` depend on
+ * `@tesseron/server` just for ~100 lines of disk plumbing. A drift-detection
+ * test in `@tesseron/mcp` (which transitively owns the other two) hashes
+ * all three at test time and fails if they diverge — see
+ * `packages/mcp/test/fs-hygiene-parity.test.ts`.
  */
 
 import { constants as fsConstants } from 'node:fs';
@@ -34,44 +38,70 @@ const PRIVATE_FILE_MODE = 0o600;
  *
  * On creation the mode flows through `mkdir({ mode })`. For a pre-existing
  * directory (e.g. a `~/.tesseron/` left behind by a pre-hardening release
- * with the umask-default 0o755), an explicit `chmod` tightens it down.
- * Failures of the secondary chmod are swallowed: on Windows POSIX modes
- * are advisory and on a handful of niche filesystems `chmod` is a no-op,
- * but the atomic-write semantics in {@link writePrivateFile} are the
- * primary integrity guarantee, so a best-effort tightening is sufficient.
+ * with the umask-default 0o755), an explicit `chmod` tightens it down so
+ * the documented "manifests are owner-only on POSIX" guarantee actually
+ * holds after an upgrade.
+ *
+ * **Failure handling.** If the post-create `chmod` fails on a POSIX system,
+ * the directory may remain readable by other local processes — the very
+ * threat the helper exists to mitigate. We log the failure to stderr (with
+ * the resolved path so an operator can act on it) but do not throw, because
+ * a write that fails outright is worse than a write that lands at a looser
+ * mode: the gateway would refuse to register the manifest and the user's
+ * tab would silently fail to connect. On Windows, EPERM here is the
+ * documented advisory-mode no-op and is suppressed.
  */
 export async function ensurePrivateDir(dir: string): Promise<void> {
   await mkdir(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
-  await chmod(dir, PRIVATE_DIR_MODE).catch(() => {});
+  try {
+    await chmod(dir, PRIVATE_DIR_MODE);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    // Windows treats POSIX modes as advisory; chmod on a directory
+    // typically returns EPERM and the OS user model is the gate. The
+    // UDS-binding spec already documents this caveat.
+    if (process.platform === 'win32' && errno === 'EPERM') return;
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[tesseron] failed to tighten ${dir} to 0o700: ${reason} — directory may be readable by other local processes; see docs/protocol/security\n`,
+    );
+  }
 }
 
 /**
  * Atomically write `contents` to `targetPath` with mode 0o600.
  *
  * Atomicity: the write goes to `<targetPath>.tmp.<pid>.<random>`, then
- * `rename`s into place. Same-filesystem `rename` is atomic on POSIX and on
- * Windows ≥ 10 (the only platforms Node 20 supports), so a concurrent
- * reader sees either the previous file or the new one — never a half-
- * written one.
+ * `rename`s into place. The temp lives next to the target, so the rename
+ * is same-filesystem by construction and atomic on POSIX and on Windows
+ * ≥ 10 (the only platforms Node 20 targets). A concurrent reader observes
+ * either the previous file or the new one — never a half-written one.
  *
  * Mode: the file is created with mode 0o600 (owner-only). The chmod after
- * write covers filesystems that ignored the open-time mode argument.
+ * the write covers filesystems that ignored the open-time mode argument
+ * — when *that* path matters and *that* chmod also fails, the security
+ * claim is undermined, so the failure is logged to stderr (mirroring
+ * {@link ensurePrivateDir}). The atomic-rename still happens; better a
+ * loosely-permissioned manifest than a dropped write that strands the
+ * user's session.
  *
  * Symlink safety is enforced upstream: the parent directory is set to
  * 0o700 by {@link ensurePrivateDir}, which means an attacker without write
  * access to the directory cannot pre-plant a symlink inside it, so a
- * regular `rename` into the dir is safe to trust without extra `O_NOFOLLOW`
- * acrobatics. (On Windows POSIX modes are advisory and the OS user model
- * is the gate — same caveat as the UDS transport, documented there.)
+ * regular `rename` into the dir is safe to trust without extra
+ * `O_NOFOLLOW` acrobatics. (On Windows POSIX modes are advisory and the
+ * OS user model is the gate — same caveat as the UDS transport,
+ * documented there.)
  */
 export async function writePrivateFile(targetPath: string, contents: string): Promise<void> {
   const dir = dirname(targetPath);
   await ensurePrivateDir(dir);
 
   const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
-  // O_EXCL guarantees the open fails if the temp name somehow already
-  // exists (concurrent write collision). Combined with the random suffix
-  // this is collision-free in practice.
+  // O_EXCL: refuse to clobber a pre-existing file at the temp path. With
+  // 64 random bits in the suffix the realistic role of O_EXCL is to catch
+  // a sibling process that picked the same name (vanishingly unlikely)
+  // — useful insurance, not the primary atomicity guarantee.
   const fh = await open(
     tmp,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL,
@@ -79,7 +109,19 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   );
   try {
     await fh.writeFile(contents);
-    await fh.chmod(PRIVATE_FILE_MODE).catch(() => {});
+    try {
+      await fh.chmod(PRIVATE_FILE_MODE);
+    } catch (err) {
+      const errno = (err as NodeJS.ErrnoException).code;
+      if (process.platform === 'win32' && errno === 'EPERM') {
+        // Windows advisory-mode no-op; suppress.
+      } else {
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[tesseron] failed to tighten ${tmp} to 0o600: ${reason} — file may be readable by other local processes\n`,
+        );
+      }
+    }
   } finally {
     await fh.close();
   }
@@ -87,13 +129,37 @@ export async function writePrivateFile(targetPath: string, contents: string): Pr
   try {
     await rename(tmp, targetPath);
   } catch (err) {
-    await unlink(tmp).catch(() => {});
+    // Cleanup is best-effort, but a leaked temp accumulates over time and
+    // is operator-actionable. Surface anything other than ENOENT (which
+    // means a sibling already cleaned the temp, e.g. a process exit
+    // handler) to stderr.
+    try {
+      await unlink(tmp);
+    } catch (cleanupErr) {
+      const cleanupCode = (cleanupErr as NodeJS.ErrnoException).code;
+      if (cleanupCode !== 'ENOENT') {
+        const reason = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+        process.stderr.write(`[tesseron] leaked temp file ${tmp}: ${reason}\n`);
+      }
+    }
     throw err;
   }
 }
 
+/**
+ * 16-hex-character random suffix used for atomic-write temp filenames.
+ * CSPRNG-sourced (via Web Crypto) so a sibling process picking the same
+ * name is statistically impossible — the `O_EXCL` open is just belt-and-
+ * braces against the worst-case collision.
+ */
 function randomSuffix(): string {
+  const c = globalThis.crypto;
+  if (!c?.getRandomValues) {
+    throw new Error(
+      'platform CSPRNG (crypto.getRandomValues) is unavailable; cannot generate temp-file suffix',
+    );
+  }
   const buf = new Uint8Array(8);
-  globalThis.crypto.getRandomValues(buf);
+  c.getRandomValues(buf);
   return Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
 }

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -43,6 +43,17 @@ function getInstancesDir(): string {
   return join(homedir(), '.tesseron', 'instances');
 }
 
+function generateInstanceId(): string {
+  // CSPRNG-sourced like the rest of `~/.tesseron/*` writes. Instance IDs
+  // aren't bearer tokens (the gateway still requires the standard
+  // handshake), but the consistency with claim/session/resume token
+  // generation matters for security review.
+  const buf = new Uint8Array(4);
+  globalThis.crypto.getRandomValues(buf);
+  const rand = Array.from(buf, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `inst-${Date.now().toString(36)}-${rand}`;
+}
+
 /** Decode a `ws` text-frame payload back to a string. `ws` always emits a
  * Buffer (or Buffer fragments) for text frames; we just need UTF-8 it. */
 function rawDataToString(data: RawData): string {
@@ -137,7 +148,7 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
           if (protocols.includes(GATEWAY_SUBPROTOCOL)) return;
 
           wss.handleUpgrade(req, socket, head, (ws) => {
-            const instanceId = `inst-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+            const instanceId = generateInstanceId();
             const wsUrl = `${serverUrl.replace(/^http/, 'ws')}${WS_PATH_PREFIX}/${instanceId}`;
             const appName =
               options.appName ??

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,11 +1,12 @@
 import { existsSync } from 'node:fs';
-import { mkdir, unlink, writeFile } from 'node:fs/promises';
+import { unlink } from 'node:fs/promises';
 import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { Plugin, ViteDevServer } from 'vite';
 import { type RawData, type WebSocket, WebSocketServer } from 'ws';
+import { writePrivateFile } from './fs-hygiene.js';
 
 export interface TesseronViteOptions {
   /** Human-readable app name written to the instance manifest. Defaults to the Vite project directory name. */
@@ -51,10 +52,6 @@ function rawDataToString(data: RawData): string {
   return Buffer.from(data as ArrayBuffer).toString('utf8');
 }
 
-async function ensureInstancesDir(): Promise<void> {
-  await mkdir(getInstancesDir(), { recursive: true });
-}
-
 /** Minimal subset of {@link PendingInstance} the manifest writer needs.
  *  Exported alongside {@link writeInstanceManifest} so a test can call the
  *  helper directly without standing up a real WebSocket. */
@@ -68,11 +65,14 @@ export interface InstanceManifestInput {
  * Exported so the manifest contract can be unit-tested without booting a Vite
  * dev server. `process.pid` and `Date.now()` still come from the runtime, so
  * a test asserts on the pid stamp by inspecting the produced file.
+ *
+ * Uses {@link writePrivateFile} so the manifest lands with mode 0o600 inside
+ * a 0o700 parent dir — a sibling local process under the same user can no
+ * longer enumerate/read instance manifests just by walking `~/.tesseron/`.
  */
 export async function writeInstanceManifest(inst: InstanceManifestInput): Promise<void> {
-  await ensureInstancesDir();
   const file = join(getInstancesDir(), `${inst.instanceId}.json`);
-  await writeFile(
+  await writePrivateFile(
     file,
     JSON.stringify(
       {

--- a/packages/vite/test/fs-hygiene.test.ts
+++ b/packages/vite/test/fs-hygiene.test.ts
@@ -129,6 +129,68 @@ describe('writePrivateFile', () => {
     expect(payloads).toContain(final);
   });
 
+  it('a reader never observes a partial or empty file mid-write', async () => {
+    // The whole point of temp+rename is: a concurrent reader sees either
+    // the previous contents or the new contents, never a half-written
+    // mixture and never a zero-length file. The earlier "concurrent
+    // writes" test only checked the *final* state of the target. This
+    // one explicitly observes the file *while* writes are in flight,
+    // and asserts every read lands on one of the contended payloads in
+    // full.
+    //
+    // A regression that switched the implementation to a direct
+    // `writeFile(target, ...)` (losing atomicity) would surface here as
+    // either a zero-length read between truncation and the first
+    // payload byte, or a short read while bytes are still being
+    // streamed in. Either failure mode is detected immediately.
+    const target = join(sandbox, 'partial-write.txt');
+    const { readFileSync: readSync, existsSync } = await import('node:fs');
+
+    // Use payloads large enough that a non-atomic write would have a
+    // realistic chance of being observed mid-flight, but small enough
+    // that the test stays fast: 4 KB each.
+    const payloadA = 'A'.repeat(4096);
+    const payloadB = 'B'.repeat(4096);
+
+    await writePrivateFile(target, payloadA);
+
+    let stop = false;
+    const writer = (async () => {
+      for (let i = 0; i < 50 && !stop; i++) {
+        const payload = i % 2 === 0 ? payloadB : payloadA;
+        try {
+          await writePrivateFile(target, payload);
+        } catch {
+          // Tolerate Windows EPERM-on-concurrent-rename; the failed
+          // write leaves the target at its pre-write payload, which
+          // is still one of the two valid observations.
+        }
+      }
+    })();
+
+    const observations: string[] = [];
+    const reader = (async () => {
+      while (!stop) {
+        if (existsSync(target)) {
+          observations.push(readSync(target, 'utf8'));
+        }
+        // Yield the event loop so the writer's microtasks run.
+        await new Promise<void>((r) => setImmediate(r));
+      }
+    })();
+
+    await writer;
+    stop = true;
+    await reader;
+
+    expect(observations.length).toBeGreaterThan(0);
+    for (const obs of observations) {
+      // Every observation must be exactly one of the two payloads.
+      // A truncated/empty/mixed read fails the assertion.
+      expect(obs === payloadA || obs === payloadB).toBe(true);
+    }
+  });
+
   it('cleans up stray .tmp.* files after a successful write', async () => {
     // Repeated writes should not accumulate temp files in the parent dir.
     // Asserts we either rename or unlink the temp every time, never leak.

--- a/packages/vite/test/fs-hygiene.test.ts
+++ b/packages/vite/test/fs-hygiene.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Coverage for the {@link writePrivateFile} / {@link ensurePrivateDir} helpers
+ * the Vite plugin (and its byte-identical siblings in `@tesseron/server` and
+ * `@tesseron/mcp`) use for every `~/.tesseron/*` write.
+ *
+ * The mode-bit assertions only run on POSIX. Windows treats POSIX modes as
+ * advisory; the parent-dir-as-access-gate model documented in the UDS
+ * binding spec is the practical mitigation there. We still execute the
+ * code path on Windows so a Windows-only crash regression doesn't slip
+ * through; we just don't assert mode bits.
+ */
+
+import { mkdtempSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ensurePrivateDir, writePrivateFile } from '../src/fs-hygiene.js';
+
+let sandbox: string;
+
+const isWindows = process.platform === 'win32';
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'tesseron-fs-hygiene-test-'));
+});
+
+afterAll(() => {
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+describe('ensurePrivateDir', () => {
+  it('creates a missing directory', async () => {
+    const dir = join(sandbox, 'created');
+    await ensurePrivateDir(dir);
+    expect(statSync(dir).isDirectory()).toBe(true);
+  });
+
+  it('is idempotent for an existing directory', async () => {
+    const dir = join(sandbox, 'idempotent');
+    await ensurePrivateDir(dir);
+    await ensurePrivateDir(dir);
+    expect(statSync(dir).isDirectory()).toBe(true);
+  });
+
+  it.skipIf(isWindows)('sets mode 0o700 on a freshly created directory', async () => {
+    const dir = join(sandbox, 'fresh-mode');
+    await ensurePrivateDir(dir);
+    // mode bits are the lower 9 of the stat mode field on POSIX.
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+
+  it.skipIf(isWindows)('tightens an existing directory to 0o700', async () => {
+    // Pre-existing umask-default mode (typically 0o755). The hygiene helper
+    // is supposed to chmod it down so an upgrade from a pre-hardening
+    // release doesn't leave `~/.tesseron/` world-readable.
+    const { mkdirSync, chmodSync } = await import('node:fs');
+    const dir = join(sandbox, 'pre-existing');
+    mkdirSync(dir);
+    chmodSync(dir, 0o755);
+    expect(statSync(dir).mode & 0o777).toBe(0o755);
+
+    await ensurePrivateDir(dir);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
+  });
+});
+
+describe('writePrivateFile', () => {
+  it('writes the requested contents to the target path', async () => {
+    const target = join(sandbox, 'simple.txt');
+    await writePrivateFile(target, 'hello world');
+    expect(readFileSync(target, 'utf8')).toBe('hello world');
+  });
+
+  it('creates the parent directory if missing', async () => {
+    const target = join(sandbox, 'auto-parent', 'file.txt');
+    await writePrivateFile(target, '{"v":1}');
+    expect(readFileSync(target, 'utf8')).toBe('{"v":1}');
+  });
+
+  it('overwrites an existing file atomically (no leftover temp)', async () => {
+    const target = join(sandbox, 'overwrite.txt');
+    await writePrivateFile(target, 'first');
+    await writePrivateFile(target, 'second');
+    expect(readFileSync(target, 'utf8')).toBe('second');
+
+    // No `.tmp.<pid>.<rand>` siblings should linger after a successful write.
+    const dirEntries = readdirSync(sandbox);
+    expect(dirEntries.filter((n) => n.includes('overwrite.txt.tmp'))).toEqual([]);
+  });
+
+  it.skipIf(isWindows)('writes the file with mode 0o600', async () => {
+    const target = join(sandbox, 'mode-check.txt');
+    await writePrivateFile(target, 'private');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it.skipIf(isWindows)('preserves 0o600 on overwrite', async () => {
+    const target = join(sandbox, 'mode-overwrite.txt');
+    await writePrivateFile(target, 'first');
+    // chmod the file to a looser mode then rewrite — the helper should
+    // re-tighten it. Otherwise a manual `chmod 644` on a single file would
+    // persist past the next refresh and silently leak data going forward.
+    const { chmodSync } = await import('node:fs');
+    chmodSync(target, 0o644);
+    await writePrivateFile(target, 'second');
+    expect(statSync(target).mode & 0o777).toBe(0o600);
+  });
+
+  it('handles concurrent writes to the same target without corruption', async () => {
+    // Atomic temp+rename means a reader observes either the previous or
+    // the new file, never a mixture. Spawn N concurrent writers each with
+    // a distinct payload; final state should equal exactly one of the
+    // contended payloads.
+    //
+    // Windows quirk: `rename` on Windows can return EPERM when two
+    // concurrent renames target the same path because the destination is
+    // briefly held open by the OS during the rename. POSIX rename has no
+    // such restriction. This isn't a production concern — instance IDs
+    // and claim codes are unique per writer, so production code never
+    // fights for the same path — but the test contrives the race for
+    // atomicity coverage. We tolerate per-call EPERMs on Windows; what
+    // matters is that the *surviving* write is uncorrupted.
+    const target = join(sandbox, 'concurrent.txt');
+    const payloads = Array.from({ length: 10 }, (_, i) => `payload-${i}`);
+    const results = await Promise.allSettled(payloads.map((p) => writePrivateFile(target, p)));
+    const fulfilled = results.filter((r) => r.status === 'fulfilled');
+    expect(fulfilled.length).toBeGreaterThan(0);
+    const final = readFileSync(target, 'utf8');
+    expect(payloads).toContain(final);
+  });
+
+  it('cleans up stray .tmp.* files after a successful write', async () => {
+    // Repeated writes should not accumulate temp files in the parent dir.
+    // Asserts we either rename or unlink the temp every time, never leak.
+    const target = join(sandbox, 'no-leak.txt');
+    for (let i = 0; i < 5; i++) {
+      await writePrivateFile(target, `iteration-${i}`);
+    }
+    const stragglers = readdirSync(sandbox).filter((n) => n.startsWith('no-leak.txt.tmp.'));
+    expect(stragglers).toEqual([]);
+  });
+});

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -2233,7 +2233,7 @@ var require_websocket = __commonJS({
     var http = require("http");
     var net = require("net");
     var tls = require("tls");
-    var { randomBytes: randomBytes2, createHash } = require("crypto");
+    var { randomBytes, createHash } = require("crypto");
     var { Duplex, Readable } = require("stream");
     var { URL: URL2 } = require("url");
     var PerMessageDeflate2 = require_permessage_deflate();
@@ -2763,7 +2763,7 @@ var require_websocket = __commonJS({
         }
       }
       const defaultPort = isSecure ? 443 : 80;
-      const key = randomBytes2(16).toString("base64");
+      const key = randomBytes(16).toString("base64");
       const request = isSecure ? https.request : http.request;
       const protocolSet = /* @__PURE__ */ new Set();
       let perMessageDeflate;
@@ -3172,7 +3172,7 @@ var require_stream = __commonJS({
       };
       duplex._final = function(callback) {
         if (ws.readyState === ws.CONNECTING) {
-          ws.once("open", function open() {
+          ws.once("open", function open2() {
             duplex._final(callback);
           });
           return;
@@ -3193,7 +3193,7 @@ var require_stream = __commonJS({
       };
       duplex._write = function(chunk, encoding, callback) {
         if (ws.readyState === ws.CONNECTING) {
-          ws.once("open", function open() {
+          ws.once("open", function open2() {
             duplex._write(chunk, encoding, callback);
           });
           return;
@@ -18826,14 +18826,12 @@ var StdioServerTransport = class {
 };
 
 // src/gateway.ts
-var import_node_buffer2 = require("buffer");
-var import_node_crypto2 = require("crypto");
 var import_node_events = require("events");
-var import_node_fs = require("fs");
 var import_node_fs2 = require("fs");
-var import_promises = require("fs/promises");
+var import_node_fs3 = require("fs");
+var import_promises2 = require("fs/promises");
 var import_node_os = require("os");
-var import_node_path = require("path");
+var import_node_path2 = require("path");
 
 // ../core/src/protocol.ts
 var PROTOCOL_VERSION = "1.1.0";
@@ -19089,6 +19087,19 @@ function toErrorPayload(error2) {
   return { code: TesseronErrorCode.InternalError, message: String(error2) };
 }
 
+// ../core/src/timing-safe.ts
+function constantTimeEqual(a, b) {
+  if (typeof a !== "string" || typeof b !== "string") {
+    throw new TypeError("constantTimeEqual requires two string arguments");
+  }
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
 // src/dialer.ts
 var import_node_buffer = require("buffer");
 var import_node_net = require("net");
@@ -19231,24 +19242,117 @@ function rawDataToString(data) {
   return null;
 }
 
-// src/session.ts
-var import_node_crypto = require("crypto");
-var CLAIM_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
-function generateClaimCode() {
-  let code = "";
-  for (let i = 0; i < 6; i++) {
-    code += CLAIM_CHARS[Math.floor(Math.random() * CLAIM_CHARS.length)];
+// src/fs-hygiene.ts
+var import_node_fs = require("fs");
+var import_promises = require("fs/promises");
+var import_node_path = require("path");
+var PRIVATE_DIR_MODE = 448;
+var PRIVATE_FILE_MODE = 384;
+async function ensurePrivateDir(dir) {
+  await (0, import_promises.mkdir)(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  try {
+    await (0, import_promises.chmod)(dir, PRIVATE_DIR_MODE);
+  } catch (err) {
+    const errno = err.code;
+    if (process.platform === "win32" && errno === "EPERM") return;
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stderr.write(
+      `[tesseron] failed to tighten ${dir} to 0o700: ${reason} \u2014 directory may be readable by other local processes; see docs/protocol/security
+`
+    );
   }
+}
+async function writePrivateFile(targetPath, contents) {
+  const dir = (0, import_node_path.dirname)(targetPath);
+  await ensurePrivateDir(dir);
+  const tmp = `${targetPath}.tmp.${process.pid}.${randomSuffix()}`;
+  const fh = await (0, import_promises.open)(
+    tmp,
+    import_node_fs.constants.O_WRONLY | import_node_fs.constants.O_CREAT | import_node_fs.constants.O_EXCL,
+    PRIVATE_FILE_MODE
+  );
+  try {
+    await fh.writeFile(contents);
+    try {
+      await fh.chmod(PRIVATE_FILE_MODE);
+    } catch (err) {
+      const errno = err.code;
+      if (process.platform === "win32" && errno === "EPERM") {
+      } else {
+        const reason = err instanceof Error ? err.message : String(err);
+        process.stderr.write(
+          `[tesseron] failed to tighten ${tmp} to 0o600: ${reason} \u2014 file may be readable by other local processes
+`
+        );
+      }
+    }
+  } finally {
+    await fh.close();
+  }
+  try {
+    await (0, import_promises.rename)(tmp, targetPath);
+  } catch (err) {
+    try {
+      await (0, import_promises.unlink)(tmp);
+    } catch (cleanupErr) {
+      const cleanupCode = cleanupErr.code;
+      if (cleanupCode !== "ENOENT") {
+        const reason = cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr);
+        process.stderr.write(`[tesseron] leaked temp file ${tmp}: ${reason}
+`);
+      }
+    }
+    throw err;
+  }
+}
+function randomSuffix() {
+  const c = globalThis.crypto;
+  if (!c?.getRandomValues) {
+    throw new Error(
+      "platform CSPRNG (crypto.getRandomValues) is unavailable; cannot generate temp-file suffix"
+    );
+  }
+  const buf = new Uint8Array(8);
+  c.getRandomValues(buf);
+  return Array.from(buf, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+// src/session.ts
+var import_node_buffer2 = require("buffer");
+var CLAIM_CHARS = "ABCDEFGHJKMNPQRSTUVWXYZ23456789";
+var BASE36_CHARS = "0123456789abcdefghijklmnopqrstuvwxyz";
+function randomFromAlphabet(alphabet, len) {
+  const aLen = alphabet.length;
+  if (aLen === 0 || aLen > 256) {
+    throw new RangeError("alphabet length must be 1..256");
+  }
+  const maxAcceptable = Math.floor(256 / aLen) * aLen;
+  let out = "";
+  while (out.length < len) {
+    const buf = new Uint8Array((len - out.length) * 2 + 4);
+    globalThis.crypto.getRandomValues(buf);
+    for (const b of buf) {
+      if (b >= maxAcceptable) continue;
+      out += alphabet.charAt(b % aLen);
+      if (out.length === len) break;
+    }
+  }
+  return out;
+}
+function generateClaimCode() {
+  const code = randomFromAlphabet(CLAIM_CHARS, 6);
   return `${code.slice(0, 4)}-${code.slice(4)}`;
 }
 function generateSessionId() {
-  return `s_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  return `s_${randomFromAlphabet(BASE36_CHARS, 8)}${Date.now().toString(36)}`;
 }
 function generateInvocationId() {
-  return `inv_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+  return `inv_${randomFromAlphabet(BASE36_CHARS, 8)}${Date.now().toString(36)}`;
 }
 function generateResumeToken() {
-  return (0, import_node_crypto.randomBytes)(24).toString("base64url");
+  const buf = new Uint8Array(24);
+  globalThis.crypto.getRandomValues(buf);
+  return import_node_buffer2.Buffer.from(buf).toString("base64url");
 }
 var RESERVED_APP_IDS = /* @__PURE__ */ new Set(["tesseron", "mcp", "system"]);
 var APP_ID_RE = /^[a-z][a-z0-9_]*$/;
@@ -19421,14 +19525,14 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
    * watchers and the polling interval.
    */
   watchInstances() {
-    const tesseronDir = (0, import_node_path.join)((0, import_node_os.homedir)(), ".tesseron");
-    const instancesDir = (0, import_node_path.join)(tesseronDir, "instances");
-    const legacyTabsDir = (0, import_node_path.join)(tesseronDir, "tabs");
+    const tesseronDir = (0, import_node_path2.join)((0, import_node_os.homedir)(), ".tesseron");
+    const instancesDir = (0, import_node_path2.join)(tesseronDir, "instances");
+    const legacyTabsDir = (0, import_node_path2.join)(tesseronDir, "tabs");
     const checkDir = async () => {
-      if ((0, import_node_fs.existsSync)(instancesDir)) {
+      if ((0, import_node_fs2.existsSync)(instancesDir)) {
         let files = [];
         try {
-          files = await (0, import_promises.readdir)(instancesDir);
+          files = await (0, import_promises2.readdir)(instancesDir);
         } catch {
         }
         for (const file2 of files) {
@@ -19436,14 +19540,14 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           const instanceId = file2.slice(0, -5);
           if (this.connected.has(instanceId)) continue;
           try {
-            const content = await (0, import_promises.readFile)((0, import_node_path.join)(instancesDir, file2), "utf-8");
+            const content = await (0, import_promises2.readFile)((0, import_node_path2.join)(instancesDir, file2), "utf-8");
             const data = JSON.parse(content);
             if (data.version !== 2 || !data.transport) continue;
             if (data.pid !== void 0 && !isPidAlive(data.pid)) {
-              const path = (0, import_node_path.join)(instancesDir, file2);
+              const path = (0, import_node_path2.join)(instancesDir, file2);
               const alreadyLogged = this.tombstonedManifests.has(path);
               try {
-                await (0, import_promises.unlink)(path);
+                await (0, import_promises2.unlink)(path);
                 if (!alreadyLogged) {
                   this.emitDiscoveryLog({
                     level: "info",
@@ -19480,10 +19584,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           }
         }
       }
-      if ((0, import_node_fs.existsSync)(legacyTabsDir)) {
+      if ((0, import_node_fs2.existsSync)(legacyTabsDir)) {
         let files = [];
         try {
-          files = await (0, import_promises.readdir)(legacyTabsDir);
+          files = await (0, import_promises2.readdir)(legacyTabsDir);
         } catch {
         }
         for (const file2 of files) {
@@ -19491,7 +19595,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           const tabId = file2.slice(0, -5);
           if (this.connected.has(tabId)) continue;
           try {
-            const content = await (0, import_promises.readFile)((0, import_node_path.join)(legacyTabsDir, file2), "utf-8");
+            const content = await (0, import_promises2.readFile)((0, import_node_path2.join)(legacyTabsDir, file2), "utf-8");
             const data = JSON.parse(content);
             if (typeof data.wsUrl !== "string") continue;
             const id = data.tabId ?? tabId;
@@ -19511,10 +19615,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     checkDir().catch(() => {
     });
     const watchDir = (dir) => {
-      if (!(0, import_node_fs.existsSync)(dir)) return;
+      if (!(0, import_node_fs2.existsSync)(dir)) return;
       try {
         this.discoveryWatchers.push(
-          (0, import_node_fs2.watch)(dir, () => {
+          (0, import_node_fs3.watch)(dir, () => {
             checkDir().catch(() => {
             });
           })
@@ -19524,10 +19628,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
     };
     watchDir(instancesDir);
     watchDir(legacyTabsDir);
-    if (!(0, import_node_fs.existsSync)(instancesDir) && !(0, import_node_fs.existsSync)(legacyTabsDir)) {
+    if (!(0, import_node_fs2.existsSync)(instancesDir) && !(0, import_node_fs2.existsSync)(legacyTabsDir)) {
       try {
         this.discoveryWatchers.push(
-          (0, import_node_fs2.watch)(tesseronDir, { recursive: false }, (_event, filename) => {
+          (0, import_node_fs3.watch)(tesseronDir, { recursive: false }, (_event, filename) => {
             if (filename === "instances" || filename === "tabs" || !filename) {
               checkDir().catch(() => {
               });
@@ -19915,9 +20019,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           `Session "${resumeParams.sessionId}" was never claimed; open a fresh session with tesseron/hello instead.`
         );
       }
-      const presented = import_node_buffer2.Buffer.from(resumeParams.resumeToken);
-      const stored = import_node_buffer2.Buffer.from(zombie.resumeToken);
-      if (presented.length !== stored.length || !(0, import_node_crypto2.timingSafeEqual)(presented, stored)) {
+      if (!constantTimeEqual(resumeParams.resumeToken, zombie.resumeToken)) {
         throw new TesseronError(
           TesseronErrorCode.ResumeFailed,
           `Invalid resumeToken for session "${resumeParams.sessionId}".`
@@ -20046,16 +20148,15 @@ function isPidAlive(pid) {
   }
 }
 function claimsDir() {
-  return (0, import_node_path.join)((0, import_node_os.homedir)(), ".tesseron", "claims");
+  return (0, import_node_path2.join)((0, import_node_os.homedir)(), ".tesseron", "claims");
 }
 function claimFilePath(code) {
-  return (0, import_node_path.join)(claimsDir(), `${code.toUpperCase()}.json`);
+  return (0, import_node_path2.join)(claimsDir(), `${code.toUpperCase()}.json`);
 }
 async function writeClaimRecord(record2) {
   const path = claimFilePath(record2.code);
   try {
-    await (0, import_promises.mkdir)(claimsDir(), { recursive: true });
-    await (0, import_promises.writeFile)(path, JSON.stringify(record2, null, 2));
+    await writePrivateFile(path, JSON.stringify(record2, null, 2));
   } catch (err) {
     const reason = err instanceof Error ? err.message : String(err);
     logToStderr(`[tesseron] failed to write claim record at ${path}: ${reason}`);
@@ -20063,7 +20164,7 @@ async function writeClaimRecord(record2) {
 }
 async function removeClaimRecord(code) {
   try {
-    await (0, import_promises.unlink)(claimFilePath(code));
+    await (0, import_promises2.unlink)(claimFilePath(code));
   } catch (err) {
     const errno = err.code;
     if (errno === "ENOENT") return;
@@ -20082,7 +20183,7 @@ async function awaitThenRemoveClaimRecord(writePromise, code) {
 }
 async function readClaimRecord(code) {
   try {
-    const raw = await (0, import_promises.readFile)(claimFilePath(code), "utf-8");
+    const raw = await (0, import_promises2.readFile)(claimFilePath(code), "utf-8");
     const parsed = JSON.parse(raw);
     if (parsed.version !== 1 || typeof parsed.code !== "string" || typeof parsed.sessionId !== "string" || typeof parsed.appId !== "string" || typeof parsed.appName !== "string" || typeof parsed.gatewayPid !== "number" || typeof parsed.mintedAt !== "number") {
       return null;


### PR DESCRIPTION
## Summary

Foundations PR for #60 (claim-mediated transport binding). Three independent security improvements that don't change protocol behavior and don't require waiting for the larger architectural change to land:

- **Filesystem hygiene** for every `~/.tesseron/*` write — parent dir `0o700`, file `0o600`, atomic temp+rename. Sibling local processes can no longer enumerate or read `~/.tesseron/instances/` or `~/.tesseron/claims/` by walking the directory.
- **CSPRNG-sourced tokens** — `generateClaimCode`, `generateSessionId`, `generateInvocationId` now draw from `crypto.getRandomValues()` with rejection sampling instead of `Math.random()`. Wire format unchanged.
- **`constantTimeEqual` helper** in `@tesseron/core/internal`, replacing the `node:crypto` `timingSafeEqual` used for the `tesseron/resume` token. Pure JS so #60's host-side comparisons can use the same primitive without pulling `node:crypto` into the web bundle.

## Why this is its own PR

Three blind reviewers (protocol, TypeScript, security) of the original combined #60 plan flagged the security hygiene as independently shippable groundwork — and called out additional concerns in the architectural part of the plan that warrant another design pass. Rather than ship a flawed wire-protocol change, the architectural fix moves to a follow-up PR with the reviewer fixes folded in. This PR is the minimal-risk, all-upside slice: improvements that stand on their own merit and lay the foundation for the bigger change.

## What this does NOT do

- No manifest v3 schema yet
- No host-minted claim codes
- No claim-mediated dialing in `@tesseron/mcp`
- No removal of `pendingClaims` / breadcrumb infrastructure

All of that lands in the follow-up PR for #60.

## Test plan

- [x] `pnpm typecheck` clean (26 tasks)
- [x] `pnpm test` clean (13 tasks; 77 mcp + 36 core + 9 vite + 17 react + others)
- [x] `pnpm lint` clean
- [x] New `fs-hygiene.test.ts` (vite): asserts mode `0o600` on file + `0o700` on parent (POSIX), tightens existing world-readable dir, atomic rename, no temp-file leaks, concurrent-write contention handled correctly cross-platform
- [x] New `timing-safe.test.ts` (core): correctness across length/type/content edge cases + a coarse statistical timing check that fails if a future refactor reintroduces an early-return on prefix mismatch

## Files

- `packages/{vite,server,mcp}/src/fs-hygiene.ts` (new, byte-identical helpers)
- `packages/core/src/timing-safe.ts` (new)
- `packages/core/src/internal.ts` (re-export)
- `packages/mcp/src/{gateway,session}.ts` (CSPRNG migration; consume `constantTimeEqual`)
- `packages/server/src/{transport,uds-transport}.ts` (consume `writePrivateFile`)
- `packages/vite/src/index.ts` (consume `writePrivateFile`)
- `docs/src/content/docs/protocol/security.mdx`, `docs/src/content/docs/sdk/typescript/mcp.md` (CSPRNG note + file-mode operational tip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
