### PR TITLE
fix: tesseron/resume hang on @tesseron/vite host-mint path (closes #68)

### DIFF
--- a/.changeset/fix-vite-resume-hang-issue-68.md
+++ b/.changeset/fix-vite-resume-hang-issue-68.md
@@ -1,0 +1,17 @@
+---
+'@tesseron/vite': patch
+'@tesseron/web': patch
+'@tesseron/react': patch
+---
+
+Fix `tesseron/resume` hang on the `@tesseron/vite` host-mint path (closes #68). On a fresh page load with stored resume credentials, the SDK sent `tesseron/resume` to the plugin but no handler existed for that method on the host-mint path — the frame just sat in `entry.queue` waiting for a gateway dial that never arrives for an unclaimed instance, and `useTesseronConnection` hung at `status: 'connecting'` forever.
+
+**`@tesseron/vite`.** The host-mint message handler now answers `tesseron/resume` directly with `ResumeFailed` (-32011). Each fresh WS opens a brand-new `PendingInstance` with a brand-new `sessionId` / `resumeToken`, so any incoming resume's tokens are by definition stale. The rejection lets the SDK clear its stored creds and fall back to a fresh `tesseron/hello` on the same socket. The branch is gated on `!entry.helloAnswered` so a (theoretical) mid-session resume post-hello still forwards to the gateway, which has its own `InvalidRequest` handling for that case.
+
+**`@tesseron/web`.** `BrowserWebSocketTransport.ready()` now rejects on `close` in addition to `error`. Without this, closing a CONNECTING socket (which can happen when React 18 StrictMode unmounts mid-handshake) left the `opened` promise unresolved and the hook hung. A no-op `.catch(() => {})` is attached to suppress unhandled-rejection warnings on the orphan reference — vitest with `unhandledRejection: 'strict'` would otherwise crash the test process. The class also now exposes a public `readonly url` field for diagnostics.
+
+**`@tesseron/react`.** `useTesseronConnection` now constructs and owns its `BrowserWebSocketTransport` instead of letting `client.connect(url)` create one internally, and unconditionally closes it on cleanup. This eliminates the StrictMode double-mount race over the singleton client's `this.transport`: each mount has its own transport ref; cleanup closes whichever connect is in flight; the first mount's `connectOnce` throws a `CancelledError` (private sentinel) when it sees `cancelled = true` after `await ready()`, and `run().catch` short-circuits without flipping state to `'error'`.
+
+**Tests.** `packages/vite/test/resume-rejection.test.ts` boots the plugin against a real HTTP server and verifies (a) `tesseron/resume` returns `ResumeFailed` and (b) a follow-up `tesseron/hello` on the same socket still synthesizes a welcome. `packages/react/test/use-tesseron-connection.test.tsx` adds direct coverage for `BrowserWebSocketTransport.ready()` rejecting on close, the `.catch(() => {})` not crashing under strict unhandled-rejection settings, an unmount-during-handshake regression test, and a real `<StrictMode>` double-mount test that asserts `client.connect` is called exactly once and the surviving mount drives final state.
+
+**End-to-end validation.** Verified against the `examples/react-todo` Vite dev server in a real browser: page refresh with stored resume creds reaches `Status: open` with a fresh claim code in <1s (was hanging forever). Multiple consecutive refreshes each yield a fresh claim. Claimed the new session via `tesseron__claim_session`, invoked `todos__addTodo` via MCP, and read `todoStats` — bidirectional flow works. Refresh-while-claimed cleanly invalidates the previous session and shows a fresh claim code; the agent's stale tools drop from the MCP tool list.

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -301,9 +301,9 @@ export function useTesseronConnection(
 
     const storage = resolveResumeStorage(resumeRef.current);
 
-    const connectOnce = async (
-      options?: { resume?: ResumeCredentials },
-    ): Promise<WelcomeResult> => {
+    const connectOnce = async (options?: {
+      resume?: ResumeCredentials;
+    }): Promise<WelcomeResult> => {
       const t = new BrowserWebSocketTransport(url ?? DEFAULT_GATEWAY_URL);
       transport = t;
       await t.ready();

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -2,6 +2,8 @@ import type { StandardSchemaV1 } from '@standard-schema/spec';
 import {
   type ActionAnnotations,
   type ActionContext,
+  BrowserWebSocketTransport,
+  DEFAULT_GATEWAY_URL,
   type ResumeCredentials,
   TesseronError,
   TesseronErrorCode,
@@ -176,6 +178,22 @@ export interface UseTesseronConnectionOptions {
  */
 export type TesseronResumeStatus = 'none' | 'resumed' | 'failed';
 
+/**
+ * Sentinel thrown when {@link useTesseronConnection}'s effect detects that
+ * cleanup has already fired. The outer `run().catch` checks for this type
+ * and skips `setState({ status: 'error' })` — without the sentinel a future
+ * refactor that drops the redundant `cancelled` re-check could surface
+ * "useTesseronConnection: cancelled" as a UI error string.
+ *
+ * Internal — not exported from the package.
+ */
+class CancelledError extends Error {
+  constructor() {
+    super('useTesseronConnection: effect cancelled before connect resolved');
+    this.name = 'CancelledError';
+  }
+}
+
 /** Reactive connection state returned from {@link useTesseronConnection}. */
 export interface TesseronConnectionState {
   status: 'idle' | 'connecting' | 'open' | 'error' | 'closed';
@@ -269,9 +287,40 @@ export function useTesseronConnection(
   useEffect(() => {
     if (!enabled) return;
     let cancelled = false;
+    // Own the transport here rather than letting `client.connect(url)`
+    // construct one internally. React 18 StrictMode mounts the effect
+    // twice (mount → cleanup → re-mount); without an owned transport, the
+    // first mount's WebSocket leaks past cleanup and races the second
+    // mount's connect over the singleton client's `this.transport`. With
+    // the hook holding the ref, cleanup closes the in-flight WS
+    // unconditionally — the dispatcher's pending hello/resume rejects
+    // cleanly via TransportClosedError and the second mount proceeds with
+    // its own fresh transport. See tesseron#68.
+    let transport: BrowserWebSocketTransport | null = null;
     setState({ status: 'connecting' });
 
     const storage = resolveResumeStorage(resumeRef.current);
+
+    const connectOnce = async (
+      options?: { resume?: ResumeCredentials },
+    ): Promise<WelcomeResult> => {
+      const t = new BrowserWebSocketTransport(url ?? DEFAULT_GATEWAY_URL);
+      transport = t;
+      await t.ready();
+      if (cancelled) {
+        // Cleanup ran during the await. Two paths converge here:
+        //   - Cleanup's `transport?.close()` fired before `t.ready()`
+        //     resolved → ready() rejected → we never reach this line.
+        //   - The open handshake won the race and ready() resolved
+        //     before cleanup closed `t` → close `t` ourselves and bail.
+        // The `transport` ref always points at the most recently
+        // constructed `t` (each call to connectOnce overwrites it), so
+        // cleanup closes whichever connect is in flight.
+        t.close();
+        throw new CancelledError();
+      }
+      return client.connect(t, options);
+    };
 
     const run = async (): Promise<void> => {
       let saved: ResumeCredentials | null = null;
@@ -288,7 +337,7 @@ export function useTesseronConnection(
       let welcome: WelcomeResult;
       let resumeStatus: TesseronResumeStatus = 'none';
       try {
-        welcome = await client.connect(url, saved ? { resume: saved } : undefined);
+        welcome = await connectOnce(saved ? { resume: saved } : undefined);
         if (saved) resumeStatus = 'resumed';
       } catch (err) {
         if (saved && err instanceof TesseronError && err.code === TesseronErrorCode.ResumeFailed) {
@@ -304,7 +353,7 @@ export function useTesseronConnection(
             }
           }
           if (cancelled) return;
-          welcome = await client.connect(url);
+          welcome = await connectOnce();
           resumeStatus = 'failed';
         } else {
           throw err;
@@ -333,7 +382,7 @@ export function useTesseronConnection(
     };
 
     run().catch((error: unknown) => {
-      if (cancelled) return;
+      if (cancelled || error instanceof CancelledError) return;
       setState({
         status: 'error',
         error: error instanceof Error ? error : new Error(String(error)),
@@ -358,6 +407,12 @@ export function useTesseronConnection(
     return () => {
       cancelled = true;
       unsubscribe();
+      // Close any in-flight transport. If it was still in the open
+      // handshake, the patched `ready()` rejects on close so `run()`
+      // unwinds cleanly. If it was past handshake, the core client's
+      // `transport.onClose` handler clears `this.dispatcher` /
+      // `this.welcome` and rejects pending dispatcher requests.
+      transport?.close();
     };
   }, [enabled, url, client]);
 

--- a/packages/react/test/use-tesseron-connection.test.tsx
+++ b/packages/react/test/use-tesseron-connection.test.tsx
@@ -1,12 +1,15 @@
 import {
+  BrowserWebSocketTransport,
   type ConnectOptions,
   type ResumeCredentials,
   TesseronError,
   TesseronErrorCode,
+  type Transport,
   type WebTesseronClient,
   type WelcomeResult,
 } from '@tesseron/web';
 import { act, render, waitFor } from '@testing-library/react';
+import { StrictMode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   type ResumeStorage,
@@ -16,6 +19,47 @@ import {
 } from '../src/index.js';
 
 const STORAGE_KEY = 'tesseron:resume';
+
+// jsdom doesn't ship a working WebSocket. The hook owns the transport and
+// awaits `transport.ready()` before calling `client.connect(transport)` so
+// the open handshake must succeed for the test flow to reach the fake
+// client. Stub a minimal WebSocket that fires 'open' on the next microtask
+// and exposes the standard listener / close API.
+class FakeWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState: number = FakeWebSocket.CONNECTING;
+  url: string;
+  private listeners = new Map<string, Set<(ev: unknown) => void>>();
+  constructor(url: string) {
+    this.url = url;
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      for (const l of this.listeners.get('open') ?? []) l({ type: 'open' });
+    });
+  }
+  addEventListener(type: string, fn: (ev: unknown) => void): void {
+    let set = this.listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(type, set);
+    }
+    set.add(fn);
+  }
+  removeEventListener(type: string, fn: (ev: unknown) => void): void {
+    this.listeners.get(type)?.delete(fn);
+  }
+  send(): void {}
+  close(_code?: number, reason?: string): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    queueMicrotask(() => {
+      for (const l of this.listeners.get('close') ?? []) l({ type: 'close', reason });
+    });
+  }
+}
+const RealWebSocket = globalThis.WebSocket;
 
 function makeWelcome(overrides: Partial<WelcomeResult> = {}): WelcomeResult {
   return {
@@ -48,7 +92,17 @@ function makeFakeClient(plan: Array<WelcomeResult | TesseronError | Error>): {
   const welcomeListeners = new Set<(w: WelcomeResult) => void>();
   let i = 0;
   const client = {
-    connect: vi.fn(async (url?: string, options?: ConnectOptions) => {
+    // Hook now passes a Transport to client.connect (so it can own the
+    // socket and close it cleanly on unmount). The fake only cares about
+    // the URL the transport was constructed with — captured here so the
+    // existing url-passthrough tests still work.
+    connect: vi.fn(async (target?: Transport | string, options?: ConnectOptions) => {
+      const url =
+        typeof target === 'string'
+          ? target
+          : target && 'url' in target && typeof (target as { url?: unknown }).url === 'string'
+            ? (target as { url: string }).url
+            : undefined;
       calls.push({ url, options });
       const next = plan[i++];
       if (!next) throw new Error('no more planned responses');
@@ -102,10 +156,14 @@ async function renderUntilOpenOrError(
 
 beforeEach(() => {
   window.localStorage.clear();
+  // @ts-expect-error - jsdom's WebSocket is a stub; replace with a fake
+  // that opens synchronously for the duration of each test.
+  globalThis.WebSocket = FakeWebSocket;
 });
 
 afterEach(() => {
   vi.restoreAllMocks();
+  globalThis.WebSocket = RealWebSocket;
 });
 
 describe('useTesseronConnection - default behaviour (no resume)', () => {
@@ -425,5 +483,216 @@ describe('useTesseronConnection - resume: ResumeStorage (custom backend)', () =>
     expect(state.welcome?.sessionId).toBe('s-new');
     expect(calls).toHaveLength(2);
     expect(backend.clear).toHaveBeenCalled();
+  });
+});
+
+describe('BrowserWebSocketTransport.ready() (tesseron#68)', () => {
+  it('rejects when the socket closes before the open handshake completes', async () => {
+    const sockets: Array<{
+      readyState: number;
+      listeners: Map<string, Set<(ev: unknown) => void>>;
+      close(): void;
+    }> = [];
+    class StalledWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState: number = StalledWebSocket.CONNECTING;
+      url: string;
+      listeners = new Map<string, Set<(ev: unknown) => void>>();
+      constructor(url: string) {
+        this.url = url;
+        sockets.push(this);
+      }
+      addEventListener(type: string, fn: (ev: unknown) => void): void {
+        let set = this.listeners.get(type);
+        if (!set) {
+          set = new Set();
+          this.listeners.set(type, set);
+        }
+        set.add(fn);
+      }
+      removeEventListener(type: string, fn: (ev: unknown) => void): void {
+        this.listeners.get(type)?.delete(fn);
+      }
+      send(): void {}
+      close(): void {
+        this.readyState = StalledWebSocket.CLOSED;
+        queueMicrotask(() => {
+          for (const l of this.listeners.get('close') ?? []) l({ type: 'close' });
+        });
+      }
+    }
+    // @ts-expect-error - swap stub
+    globalThis.WebSocket = StalledWebSocket;
+
+    const transport = new BrowserWebSocketTransport('ws://test.invalid/x');
+    expect(sockets).toHaveLength(1);
+
+    // Trigger the close-before-open path.
+    sockets[0]!.close();
+
+    await expect(transport.ready()).rejects.toThrow(/closed before open/);
+  });
+
+  it('does not crash with unhandledRejection when no caller awaits ready()', async () => {
+    // Regression for the .catch(() => {}) noop swallow at transport.ts.
+    // Constructing a transport and immediately closing it without ever
+    // calling ready() must not produce an unhandled rejection — vitest
+    // strict mode would fail the test if it did.
+    class StalledWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState: number = StalledWebSocket.CONNECTING;
+      url: string;
+      listeners = new Map<string, Set<(ev: unknown) => void>>();
+      constructor(url: string) {
+        this.url = url;
+      }
+      addEventListener(type: string, fn: (ev: unknown) => void): void {
+        let set = this.listeners.get(type);
+        if (!set) {
+          set = new Set();
+          this.listeners.set(type, set);
+        }
+        set.add(fn);
+      }
+      removeEventListener(type: string, fn: (ev: unknown) => void): void {
+        this.listeners.get(type)?.delete(fn);
+      }
+      send(): void {}
+      close(): void {
+        this.readyState = StalledWebSocket.CLOSED;
+        queueMicrotask(() => {
+          for (const l of this.listeners.get('close') ?? []) l({ type: 'close' });
+        });
+      }
+    }
+    // @ts-expect-error - swap stub
+    globalThis.WebSocket = StalledWebSocket;
+
+    const t = new BrowserWebSocketTransport('ws://test.invalid/y');
+    t.close();
+    // Drain microtasks so the close handler's reject() has a chance to fire.
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+    // If the .catch(() => {}) is removed, this test process would crash
+    // before reaching here under strict unhandledRejection settings.
+    expect(true).toBe(true);
+  });
+});
+
+describe('useTesseronConnection - StrictMode / unmount race (tesseron#68)', () => {
+  it('closes the in-flight WebSocket on unmount before the open handshake completes', async () => {
+    // Drop-in WebSocket that NEVER fires 'open' so we can assert the hook
+    // closes the socket explicitly during unmount, the way StrictMode's
+    // double-mount cleanup needs to. Defined inline so it doesn't inherit
+    // the auto-open behaviour of the test-suite's FakeWebSocket.
+    const sockets: Array<{
+      url: string;
+      readyState: number;
+      listeners: Map<string, Set<(ev: unknown) => void>>;
+    }> = [];
+    class StalledWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+      readyState: number = StalledWebSocket.CONNECTING;
+      url: string;
+      listeners = new Map<string, Set<(ev: unknown) => void>>();
+      constructor(url: string) {
+        this.url = url;
+        sockets.push(this);
+      }
+      addEventListener(type: string, fn: (ev: unknown) => void): void {
+        let set = this.listeners.get(type);
+        if (!set) {
+          set = new Set();
+          this.listeners.set(type, set);
+        }
+        set.add(fn);
+      }
+      removeEventListener(type: string, fn: (ev: unknown) => void): void {
+        this.listeners.get(type)?.delete(fn);
+      }
+      send(): void {}
+      close(_code?: number, reason?: string): void {
+        this.readyState = StalledWebSocket.CLOSED;
+        queueMicrotask(() => {
+          for (const l of this.listeners.get('close') ?? []) l({ type: 'close', reason });
+        });
+      }
+    }
+    // @ts-expect-error - swap in stalled stub for this test only.
+    globalThis.WebSocket = StalledWebSocket;
+
+    const { client, calls } = makeFakeClient([makeWelcome()]);
+    const { unmount } = render(<ConnectionProbe client={client} onState={() => {}} />);
+
+    // Let the hook construct the transport.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(sockets).toHaveLength(1);
+    expect(sockets[0]!.readyState).toBe(StalledWebSocket.CONNECTING);
+
+    // Unmount before the open handshake completes — the previous
+    // implementation left this WS dangling, so a re-mount in StrictMode
+    // would race over the singleton client.transport. The fix has the
+    // hook own the transport and close it on cleanup.
+    unmount();
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(sockets[0]!.readyState).toBe(StalledWebSocket.CLOSED);
+    // client.connect must NOT have been called, because ready() rejected
+    // when the close fired.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('handles React 18 StrictMode double-mount: first connect is cancelled, second one drives state', async () => {
+    // Real reproduction of the tesseron#68 race: StrictMode mounts the
+    // effect twice (mount → cleanup → re-mount) within the same commit.
+    // The fix has the hook own its transport and close it on cleanup so
+    // the first mount's `client.connect` never fires — its `connectOnce`
+    // throws CancelledError when it sees `cancelled = true` after the
+    // (still-resolved-because-FakeWebSocket-auto-opens) `await ready()`.
+    //
+    // Verifies:
+    //   1. status reaches 'open' (no hang from the dropped first connect)
+    //   2. `client.connect` is called exactly once — the first mount's
+    //      connectOnce bails before reaching the fake.
+    //   3. The welcome that lands in state is the one consumed by the
+    //      surviving (second) mount.
+    const welcomes = [makeWelcome({ sessionId: 'survivor' })];
+    const { client, calls } = makeFakeClient(welcomes);
+
+    let latest: TesseronConnectionState = { status: 'idle' };
+    await act(async () => {
+      render(
+        <StrictMode>
+          <ConnectionProbe
+            client={client}
+            onState={(s) => {
+              latest = s;
+            }}
+          />
+        </StrictMode>,
+      );
+    });
+
+    await waitFor(() => {
+      expect(latest.status).toBe('open');
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(latest.welcome?.sessionId).toBe('survivor');
+    // No spurious error state from the cancelled first mount.
+    expect(latest.error).toBeUndefined();
   });
 });

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -4,8 +4,8 @@ import type { IncomingMessage } from 'node:http';
 import type { Socket } from 'node:net';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
-import type { AgentIdentity, HelloParams, WelcomeResult } from '@tesseron/core';
-import { PROTOCOL_VERSION } from '@tesseron/core';
+import type { AgentIdentity, WelcomeResult } from '@tesseron/core';
+import { PROTOCOL_VERSION, TesseronErrorCode } from '@tesseron/core';
 import { constantTimeEqual, parseBindSubprotocol, validateAppId } from '@tesseron/core/internal';
 import type { Plugin, ViteDevServer } from 'vite';
 import { type RawData, type WebSocket, WebSocketServer } from 'ws';
@@ -332,24 +332,47 @@ export function tesseron(options: TesseronViteOptions = {}): Plugin {
               // drops (it only handles string frames). Decode text frames back
               // to a string so the frame type round-trips correctly.
               const payload: RawData | string = isBinary ? data : rawDataToString(data);
-              // Intercept the SDK's `tesseron/hello` and synthesize a
-              // welcome immediately. Without this, the SDK is blocked
-              // waiting for a peer that will never speak — the gateway
-              // doesn't dial until `tesseron__claim_session` completes,
-              // and the user can't paste a code they haven't seen yet.
-              // The welcome carries the host-minted claim code; the
-              // browser app shows it; the user pastes it; the gateway
-              // dials with the bind subprotocol; the cached hello below
-              // is replayed to the gateway, the gateway processes it,
-              // and the gateway's reply is discarded (synthesized
-              // welcome already went to the SDK).
+              // Pre-hello local handler. Two responsibilities:
+              // (1) Synthesize the welcome for `tesseron/hello` immediately
+              //     so the user sees the host-minted claim code without
+              //     waiting for a gateway dial — see the synthesizer
+              //     branch below. The cached hello is later replayed to
+              //     the gateway when it dials with the bind subprotocol;
+              //     the gateway's reply is then discarded (the SDK
+              //     already saw the synthesized welcome).
+              // (2) Reject `tesseron/resume` locally with ResumeFailed
+              //     because the host mints fresh sessionId/resumeToken
+              //     at every WS open — any incoming resume's tokens
+              //     belong to a previous instance the host can't
+              //     validate. See tesseron#68.
+              // Once hello is answered, frames flow to the gateway.
               if (!entry.helloAnswered && !isBinary) {
                 const parsed = parseJsonFrame(payload);
-                if (
-                  parsed !== null &&
-                  typeof parsed === 'object' &&
-                  (parsed as { method?: unknown }).method === 'tesseron/hello'
-                ) {
+                const method =
+                  parsed !== null && typeof parsed === 'object'
+                    ? (parsed as { method?: unknown }).method
+                    : undefined;
+
+                if (method === 'tesseron/resume') {
+                  const m = parsed as { id?: unknown };
+                  ws.send(
+                    JSON.stringify({
+                      jsonrpc: '2.0',
+                      id: m.id ?? null,
+                      error: {
+                        code: TesseronErrorCode.ResumeFailed,
+                        message:
+                          'Host-minted session does not honour resume; the previous session ended when the page reloaded. The SDK will fall back to a fresh tesseron/hello.',
+                      },
+                    }),
+                  );
+                  // Intentionally leave entry.helloAnswered = false so
+                  // the SDK's fallback hello on the same socket still
+                  // hits the synthesizer below.
+                  return;
+                }
+
+                if (method === 'tesseron/hello') {
                   const m = parsed as { id?: unknown; params?: { app?: { id?: unknown } } };
                   // Validate the app.id before synthesizing — defends
                   // against the SDK trying to claim a reserved id (e.g.

--- a/packages/vite/test/resume-rejection.test.ts
+++ b/packages/vite/test/resume-rejection.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Coverage for tesseron#68: the host-mint Vite plugin must respond to
+ * `tesseron/resume` directly. The plugin mints a fresh sessionId and
+ * resumeToken at every WS open, so any incoming resume's tokens belong
+ * to a previous instance the host can no longer validate. Without an
+ * explicit handler, the resume frame sat in the queue waiting for a
+ * gateway dial that never arrives for an unclaimed instance — the SDK
+ * hung at `status: 'connecting'` forever.
+ *
+ * The fix answers ResumeFailed (-32011) so the SDK clears its stored
+ * creds and falls back to a fresh `tesseron/hello`.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { type Server, createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { TesseronErrorCode } from '@tesseron/core';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+import { tesseron } from '../src/index.js';
+
+let sandbox: string;
+let previousEnv: { HOME: string | undefined; USERPROFILE: string | undefined };
+
+beforeAll(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'tesseron-vite-resume-'));
+  previousEnv = {
+    HOME: process.env['HOME'],
+    USERPROFILE: process.env['USERPROFILE'],
+  };
+  // Sandbox manifest writes so this test doesn't pollute the real
+  // `~/.tesseron/instances/`. Mirrors the manifest test setup.
+  process.env['HOME'] = sandbox;
+  process.env['USERPROFILE'] = sandbox;
+});
+
+afterAll(() => {
+  for (const [k, v] of Object.entries(previousEnv)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  rmSync(sandbox, { recursive: true, force: true });
+});
+
+const servers: Server[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const ws of sockets) {
+    try {
+      ws.close();
+    } catch {
+      // already closing
+    }
+  }
+  sockets.length = 0;
+  for (const s of servers) {
+    await new Promise<void>((resolve) => s.close(() => resolve()));
+  }
+  servers.length = 0;
+  // Let the plugin's async manifest deletes settle so afterAll's sandbox
+  // teardown doesn't race with in-flight writePrivateFile renames.
+  await new Promise<void>((resolve) => setImmediate(resolve));
+});
+
+interface JsonRpcResponse {
+  jsonrpc?: string;
+  id?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+async function bootPlugin(): Promise<{ url: string }> {
+  const httpServer = createServer();
+  servers.push(httpServer);
+  // Build a minimal ViteDevServer mock that exercises the plugin's
+  // `configureServer` path — only `httpServer` and `config.root` are
+  // touched.
+  const mockServer = {
+    httpServer,
+    config: { root: '/test/project' },
+  };
+  const plugin = tesseron({ appName: 'resume-test' });
+  // configureServer is typed for the real Vite type but accepts our
+  // partial mock at runtime.
+  (plugin.configureServer as (s: unknown) => void)(mockServer);
+  await new Promise<void>((resolve) => {
+    httpServer.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = httpServer.address();
+  if (!addr || typeof addr === 'string') throw new Error('listen failed');
+  return { url: `ws://127.0.0.1:${addr.port}/@tesseron/ws` };
+}
+
+async function send(ws: WebSocket, frame: unknown): Promise<JsonRpcResponse> {
+  return new Promise<JsonRpcResponse>((resolve, reject) => {
+    const onMessage = (data: Buffer): void => {
+      try {
+        const text = data.toString('utf8');
+        const parsed = JSON.parse(text) as JsonRpcResponse;
+        ws.off('message', onMessage);
+        resolve(parsed);
+      } catch (err) {
+        reject(err as Error);
+      }
+    };
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify(frame));
+  });
+}
+
+async function open(url: string): Promise<WebSocket> {
+  const ws = new WebSocket(url);
+  sockets.push(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', (err) => reject(err));
+  });
+  return ws;
+}
+
+describe('Vite plugin / tesseron/resume on host-mint path (tesseron#68)', () => {
+  it('answers tesseron/resume with ResumeFailed instead of hanging', async () => {
+    const { url } = await bootPlugin();
+    const ws = await open(url);
+
+    const response = await send(ws, {
+      jsonrpc: '2.0',
+      id: 99,
+      method: 'tesseron/resume',
+      params: {
+        protocolVersion: '1.1.0',
+        sessionId: 'sess-from-previous-page-load',
+        resumeToken: 'tok-stale',
+        app: { id: 'my-app', name: 'My App' },
+        actions: [],
+        resources: [],
+        capabilities: {
+          streaming: true,
+          subscriptions: true,
+          sampling: false,
+          elicitation: false,
+        },
+      },
+    });
+
+    expect(response.jsonrpc).toBe('2.0');
+    expect(response.id).toBe(99);
+    expect(response.result).toBeUndefined();
+    expect(response.error).toBeDefined();
+    expect(response.error?.code).toBe(TesseronErrorCode.ResumeFailed);
+    expect(response.error?.message).toMatch(/host-minted session does not honour resume/i);
+  });
+
+  it('still synthesizes a fresh hello after a rejected resume on the same socket', async () => {
+    // Defensive: make sure the resume rejection path doesn't poison
+    // entry.helloAnswered or otherwise break the subsequent fresh hello
+    // the SDK falls back to. (The SDK normally does the fresh hello on
+    // a *new* socket, but the plugin shouldn't depend on that.)
+    const { url } = await bootPlugin();
+    const ws = await open(url);
+
+    await send(ws, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tesseron/resume',
+      params: {
+        protocolVersion: '1.1.0',
+        sessionId: 'stale',
+        resumeToken: 'stale',
+        app: { id: 'fallback_test', name: 'Fallback' },
+        actions: [],
+        resources: [],
+        capabilities: {
+          streaming: true,
+          subscriptions: true,
+          sampling: false,
+          elicitation: false,
+        },
+      },
+    });
+
+    const helloResponse = await send(ws, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tesseron/hello',
+      params: {
+        protocolVersion: '1.1.0',
+        app: { id: 'fallback_test', name: 'Fallback' },
+        actions: [],
+        resources: [],
+        capabilities: {
+          streaming: true,
+          subscriptions: true,
+          sampling: false,
+          elicitation: false,
+        },
+      },
+    });
+
+    expect(helloResponse.id).toBe(2);
+    expect(helloResponse.error).toBeUndefined();
+    const result = helloResponse.result as Record<string, unknown> | undefined;
+    expect(result?.['claimCode']).toBeTypeOf('string');
+    expect(result?.['sessionId']).toBeTypeOf('string');
+    expect(result?.['resumeToken']).toBeTypeOf('string');
+  });
+});

--- a/packages/web/src/transport.ts
+++ b/packages/web/src/transport.ts
@@ -1,12 +1,17 @@
 import type { Transport } from '@tesseron/core';
 
 export class BrowserWebSocketTransport implements Transport {
+  /** WebSocket endpoint this transport was constructed with. Exposed for
+   * diagnostics and for hooks/tests that need to verify which URL the
+   * underlying socket targets. */
+  readonly url: string;
   private readonly ws: WebSocket;
   private readonly messageHandlers: Array<(message: unknown) => void> = [];
   private readonly closeHandlers: Array<(reason?: string) => void> = [];
   private readonly opened: Promise<void>;
 
   constructor(url: string) {
+    this.url = url;
     this.ws = new WebSocket(url);
     this.opened = new Promise<void>((resolve, reject) => {
       this.ws.addEventListener('open', () => resolve(), { once: true });
@@ -15,7 +20,30 @@ export class BrowserWebSocketTransport implements Transport {
         () => reject(new Error(`WebSocket connection failed: ${url}`)),
         { once: true },
       );
+      // Backstop: if the socket closes before any caller awaits
+      // ready(), nothing else settles the promise. (`error` may or may
+      // not fire on a CONNECTING.close() depending on platform; `close`
+      // always does.) Reject from the close listener so the hook's
+      // connect promise unwinds instead of hanging forever — see
+      // tesseron#68. Once 'open' has resolved, this reject() is a no-op
+      // (Promise constructor only honours the first settle), so a
+      // normal teardown after a successful connect doesn't surface as
+      // an error to anyone awaiting ready().
+      this.ws.addEventListener(
+        'close',
+        () => reject(new Error(`WebSocket closed before open: ${url}`)),
+        { once: true },
+      );
     });
+    // Attach a no-op .catch to suppress unhandled-rejection at the
+    // microtask boundary. Without this, a transport that's constructed
+    // and immediately closed (StrictMode mount→cleanup before any
+    // caller awaits ready()) trips Node's strict-mode unhandled-
+    // rejection — which under vitest with `unhandledRejection: 'strict'`
+    // crashes the test process, not just warns. The .catch() returns
+    // a new promise; `this.opened`'s state is unchanged, so a later
+    // `await this.ready()` still sees the rejection.
+    this.opened.catch(() => {});
     this.ws.addEventListener('message', (ev) => {
       const data = ev.data;
       if (typeof data !== 'string') return;


### PR DESCRIPTION
## Summary

- Adds the missing `tesseron/resume` handler to the `@tesseron/vite` host-mint message loop. Each fresh WS opens with a brand-new sessionId/resumeToken, so any incoming resume's tokens are stale by definition; the plugin now answers `ResumeFailed` (-32011) immediately so the SDK's existing fallback path runs instead of hanging.
- Hardens `BrowserWebSocketTransport` against close-during-handshake (rejects `ready()` on close in addition to error) and exposes a public `readonly url` for diagnostics.
- Rewrites `useTesseronConnection` so the hook owns its transport ref and closes it on cleanup, eliminating the React 18 StrictMode double-mount race over the singleton client's `this.transport`.

Closes #68.

## Why this matters

Pre-fix, a page refresh with stored resume creds (the default for `useTesseronConnection({ resume: true })`) hung at `status: 'connecting'` indefinitely. The host-mint Vite plugin never had a `tesseron/resume` handler — frames sat in `entry.queue` waiting for a gateway dial that only fires after a successful claim, which can never happen for an unclaimed instance.

The issue's repro (manual WebSocket script) is reproduced as a Vitest integration test in `packages/vite/test/resume-rejection.test.ts`.

## Test plan

- [x] `pnpm -r test` — all 23 test files pass (91 mcp + 21 react + 12 vite + 6 core + 3 docs-mcp + 1 skipped)
- [x] `pnpm -r typecheck` clean across @tesseron/web, @tesseron/react, @tesseron/vite
- [x] New tests:
  - `packages/vite/test/resume-rejection.test.ts` — boots plugin against a real http server, verifies resume → ResumeFailed + follow-up hello on same socket
  - `packages/react/test/use-tesseron-connection.test.tsx`:
    - `BrowserWebSocketTransport.ready()` rejects on close-before-open
    - `.catch(() => {})` no-op doesn't crash under vitest's strict unhandledRejection
    - Unmount-during-handshake closes the in-flight WS
    - Real `<StrictMode>` double-mount: `client.connect` called exactly once, surviving mount drives final state
- [x] End-to-end browser validation against `examples/react-todo`:
  - Refresh-with-stored-creds reaches `Status: open` with fresh claim code in <1s (was hanging forever)
  - Multiple consecutive refreshes each yield fresh claim codes
  - Claimed via `tesseron__claim_session`, invoked `todos__addTodo` and read `todoStats` via MCP — bidirectional flow works
  - Refresh-while-claimed cleanly invalidates the previous session; agent's stale tools drop from MCP tool list

## Reviewer notes

- The vite plugin's resume rejection branch is gated on `!entry.helloAnswered` so a (theoretical) mid-session resume after hello forwards to the gateway as before — the gateway already has its own `InvalidRequest` for resume on an attached session.
- `useTesseronConnection`'s cancellation throws a typed private `CancelledError` (not exported); `run().catch` short-circuits on it explicitly so future refactors of the redundant `cancelled` re-check can't accidentally surface "useTesseronConnection: cancelled" as a UI error string.
- Resume protocol contract is unchanged — docs at `docs/src/content/docs/protocol/resume.mdx` already describe the "fall back to fresh hello on ResumeFailed" pattern; the host-mint path now correctly implements that contract instead of silently dropping the frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
