### PR TITLE
feat: agent recovery for invalidated claimed sessions (closes #69)

### DIFF
--- a/.changeset/agent-recovery-pending-claims-issue-69.md
+++ b/.changeset/agent-recovery-pending-claims-issue-69.md
@@ -1,0 +1,15 @@
+---
+'@tesseron/mcp': minor
+---
+
+Improve agent recovery when a claimed session is invalidated mid-conversation (closes #69).
+
+When a browser session is replaced by a fresh-hello (after an `@tesseron/react` resume race per #68, a manual reload, or any other condition that invalidates the prior session), agent-side MCP tools that hold a cached claim previously got a flat `No claimed session found for app "<id>".` error with no actionable recovery path. The agent's reflex of retrying `tesseron__claim_session` with the previously-known code also failed, leaving the user to read the new claim code from the app UI and paste it back manually.
+
+**`tesseron__list_pending_claims` (new meta tool).** Lists every claim code the gateway can currently redeem — gateway-minted sessions waiting in `pendingClaims`, plus host-minted manifests under `~/.tesseron/instances/` whose `boundAgent` is `null` and whose `expiresAt` (when present) hasn't elapsed. Each entry carries the code, app id, app name, source mint flow, and unix timestamps. The agent calls this on the failure path, picks the entry whose `app_id` matches its cached app, and re-pairs without a user round-trip. Surfaced in the default `both` and `meta` tool surfaces; suppressed in `dynamic`.
+
+**Improved error messages.** `tesseron__invoke_action` and `tesseron__read_resource` now name the recovery tool by name in the "No claimed session found" body, and inline the matching pending claim code(s) when one exists for the same app id. `tesseron__claim_session` similarly mentions other pending codes when the user typed a code the gateway doesn't have, so a typo doesn't dead-end.
+
+**Internal.** `Session` and `ZombieSession` carry a new `mintedAt: number` field set at session creation and preserved across resume so `getPendingClaims()` reports a stable timestamp for sorting. `TesseronGateway.getPendingClaims()` is the new public method the bridge consumes; it returns `PendingClaim[]` (also exported for embedders).
+
+Tests cover the new meta tool's empty + populated states, expired host-minted entry filtering, and the wrong-code claim path with a pending manifest discovered via `watchInstances`.

--- a/docs/src/content/docs/sdk/typescript/mcp.md
+++ b/docs/src/content/docs/sdk/typescript/mcp.md
@@ -81,10 +81,11 @@ When an MCP client spawns the gateway, the gateway exposes:
 - One built-in tool: `tesseron__claim_session`. Always present.
 - One tool per registered action across all connected sessions, named `<app_id>__<action_name>`.
 - One resource per registered resource, URI `tesseron://<app_id>/<resource_name>`.
-- Three meta-dispatcher tools in the default `both` / `meta` surface modes:
+- Four meta-dispatcher tools in the default `both` / `meta` surface modes:
   - `tesseron__list_actions` — enumerates every claimed session's actions and resources, plus the gateway's advertised MCP server name.
   - `tesseron__invoke_action({ app_id, action, args })` — calls any action without needing the per-app tool to be in the client's tool list.
   - `tesseron__read_resource({ app_id, name })` — reads a resource without needing the agent to know the client-side MCP server identifier (which varies by how the server is mounted; e.g. `plugin:tesseron:tesseron` under a Claude Code plugin vs. `tesseron` in a raw config). Prefer this over the generic `ReadMcpResourceTool`.
+  - `tesseron__list_pending_claims` — lists every claim code the gateway can currently redeem (gateway-minted sessions waiting for claim, plus host-minted manifests with an unconsumed code). Recovery path when a previously-claimed session is invalidated mid-conversation (browser refresh, dev-server reload, resume failure) and a tools/call returns "No claimed session found" — call this, pick the entry whose `app_id` matches, then call `tesseron__claim_session({ code })` to re-pair without asking the user to read the new code from the app UI. See [tesseron#69](https://github.com/BrainBlend-AI/tesseron/issues/69).
 - Full MCP logging (`sendLoggingMessage`), progress (`notifications/progress`), sampling (`createMessage`), and elicitation (`elicitInput`).
 
 Whenever a session connects, claims, or drops, the gateway emits `notifications/tools/list_changed` and `notifications/resources/list_changed`. The agent refreshes automatically.

--- a/packages/mcp/scripts/e2e-issue-69.mjs
+++ b/packages/mcp/scripts/e2e-issue-69.mjs
@@ -20,6 +20,7 @@
  * pending instance.
  */
 
+import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
@@ -32,6 +33,13 @@ import {
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../../..');
 const bundle = resolve(repoRoot, 'plugin/server/index.cjs');
+
+if (!existsSync(bundle)) {
+  console.error(
+    `[e2e] gateway bundle not found at ${bundle}. Run \`pnpm build:plugin\` from the repo root first.`,
+  );
+  process.exit(1);
+}
 
 console.log(`[e2e] gateway bundle: ${bundle}`);
 
@@ -173,6 +181,14 @@ try {
   console.error('[e2e] uncaught error:', err);
   process.exit(1);
 } finally {
-  await client.close().catch(() => {});
-  transport.close().catch(() => {});
+  // Surface cleanup errors as warnings instead of swallowing them — a wedged
+  // gateway or half-closed stdio pipe is worth knowing about even after the
+  // checks pass. Don't flip the exit code: the test result itself is the
+  // contract this script reports.
+  await client
+    .close()
+    .catch((e) => console.warn('[e2e] client.close failed:', e instanceof Error ? e.message : e));
+  await Promise.resolve(transport.close()).catch((e) =>
+    console.warn('[e2e] transport.close failed:', e instanceof Error ? e.message : e),
+  );
 }

--- a/packages/mcp/scripts/e2e-issue-69.mjs
+++ b/packages/mcp/scripts/e2e-issue-69.mjs
@@ -1,0 +1,178 @@
+/**
+ * Issue #69 end-to-end validation.
+ *
+ * Spawns the rebuilt plugin bundle (`plugin/server/index.cjs`) as the actual
+ * MCP gateway, dials it via the official MCP SDK over stdio, and walks
+ * through the recovery scenario from issue #69:
+ *
+ *   1. Wait for the live browser tab's claim code to appear in
+ *      `tesseron__list_pending_claims`.
+ *   2. Claim it. Invoke `todos__addTodo` to confirm the path is hot.
+ *   3. Ask the operator to refresh the browser tab (which mints a fresh
+ *      claim code). Wait for the gateway to discover the new code.
+ *   4. Try the cached `todos__addTodo` tool — must return the *new*
+ *      improved error (mentions the new code + recovery tool).
+ *   5. Call `tesseron__list_pending_claims` — must surface the new code.
+ *   6. Claim it. Re-invoke `todos__addTodo` — must succeed.
+ *
+ * Run with `node packages/mcp/scripts/e2e-issue-69.mjs`. Expects the
+ * react-todo dev server to be running on http://localhost:5174 with one
+ * pending instance.
+ */
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+  CallToolResultSchema,
+  ListToolsResultSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+const bundle = resolve(repoRoot, 'plugin/server/index.cjs');
+
+console.log(`[e2e] gateway bundle: ${bundle}`);
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: [bundle],
+});
+
+const client = new Client({ name: 'e2e-issue-69', version: '0.0.0' }, {
+  capabilities: { sampling: {}, elicitation: {} },
+});
+
+await client.connect(transport);
+console.log('[e2e] MCP client connected');
+
+async function callTool(name, args) {
+  const r = await client.request(
+    { method: 'tools/call', params: { name, arguments: args ?? {} } },
+    CallToolResultSchema,
+  );
+  const text = r.content.map((c) => (c.type === 'text' ? c.text : `[${c.type}]`)).join('');
+  return { text, isError: r.isError === true };
+}
+
+async function listToolNames() {
+  const r = await client.request({ method: 'tools/list' }, ListToolsResultSchema);
+  return r.tools.map((t) => t.name);
+}
+
+function fail(msg) {
+  console.error(`[e2e] FAIL: ${msg}`);
+  process.exit(1);
+}
+
+function pass(msg) {
+  console.log(`[e2e] PASS: ${msg}`);
+}
+
+async function waitForPendingCode(predicate, label, timeoutMs = 8_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const r = await callTool('tesseron__list_pending_claims', {});
+    if (r.text.startsWith('{')) {
+      const payload = JSON.parse(r.text);
+      const match = payload.pending_claims.find(predicate);
+      if (match) return match;
+    }
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  fail(`${label}: no matching pending claim within ${timeoutMs}ms`);
+}
+
+try {
+  // Step 0: confirm the new tool is exposed.
+  const tools = await listToolNames();
+  console.log(`[e2e] tools: ${tools.join(', ')}`);
+  if (!tools.includes('tesseron__list_pending_claims')) {
+    fail('tesseron__list_pending_claims is not in tools/list');
+  }
+  pass('tesseron__list_pending_claims appears in tools/list');
+
+  // Step 1: discover the live browser tab's pending claim.
+  const pendingBefore = await waitForPendingCode(
+    (c) => c.app_id === 'todos' || c.app_id === 'react-todo',
+    'initial pending claim',
+  );
+  console.log(`[e2e] discovered pending claim: ${JSON.stringify(pendingBefore)}`);
+  pass('list_pending_claims surfaces the live browser tab claim code');
+
+  // Step 2: claim it. The pre-bind list_pending_claims may report the
+  // manifest's `appName` (filesystem-friendly, e.g. "react-todo") rather
+  // than the SDK's real `app.id` ("todos"); the issue #69 fix populates
+  // the manifestAppName→appId cache once the bind completes, so subsequent
+  // list_pending_claims calls report the agent-visible app id.
+  const firstClaim = await callTool('tesseron__claim_session', { code: pendingBefore.code });
+  if (firstClaim.isError) fail(`first claim failed: ${firstClaim.text}`);
+  pass(`first claim succeeded: ${firstClaim.text.slice(0, 100)}...`);
+
+  // Parse the real app.id out of the claim result body (which lists
+  // `<app_id>__<action>` tool names). This is what an agent would learn
+  // from `tools/list_changed` after claim.
+  const toolMatch = firstClaim.text.match(/(\w+)__\w+/);
+  if (!toolMatch) fail('could not extract app_id from claim result');
+  const appId = toolMatch[1];
+  console.log(`[e2e] real app.id from bind: "${appId}" (manifest appName was "${pendingBefore.app_id}")`);
+
+  const addOk = await callTool(`${appId}__addTodo`, { text: 'pre-refresh todo' });
+  if (addOk.isError) fail(`addTodo on fresh session failed: ${addOk.text}`);
+  pass(`addTodo on fresh session: ${addOk.text}`);
+
+  // Step 3: pause for the operator to refresh the browser. Wait for a code
+  // that's both fresh-on-disk AND different from the one we already bound,
+  // ignoring any leftover manifests from previous test runs.
+  // After my fix, the cache is populated by the successful bind above, so the
+  // post-refresh pending claim should report `app_id` matching the SDK's real
+  // app.id (the same prefix the agent's cached `<app_id>__<action>` tools use).
+  const firstBindAt = Date.now();
+  console.log('\n[e2e] >>> REFRESH THE BROWSER TAB NOW (test waits 30s for a NEW claim code) <<<\n');
+  const pendingAfter = await waitForPendingCode(
+    (c) =>
+      c.app_id === appId &&
+      c.code !== pendingBefore.code &&
+      c.minted_at > firstBindAt &&
+      c.source === 'host-minted',
+    'post-refresh pending claim',
+    30_000,
+  );
+  console.log(`[e2e] discovered new pending claim: ${JSON.stringify(pendingAfter)}`);
+  if (pendingAfter.app_id !== appId) {
+    fail(`post-refresh entry app_id "${pendingAfter.app_id}" does not match expected "${appId}" — manifestAppName→appId cache failed to populate`);
+  }
+  pass(`list_pending_claims reports correct agent-visible app_id "${appId}" after refresh (cache populated by first bind)`);
+
+  // Step 4: cached tool call must hit the new error path.
+  const stale = await callTool(`${appId}__addTodo`, { text: 'should fail' });
+  if (!stale.isError) fail(`expected stale invoke to error, got: ${stale.text}`);
+  console.log(`[e2e] stale invoke error body: ${stale.text}`);
+  if (!stale.text.includes('tesseron__list_pending_claims')) {
+    fail('stale-invoke error body does not name tesseron__list_pending_claims');
+  }
+  if (!stale.text.includes(pendingAfter.code)) {
+    fail(`stale-invoke error body does not inline the new claim code ${pendingAfter.code}`);
+  }
+  pass('stale invoke surfaces improved error with new code + recovery tool name');
+
+  // Step 5: claim the new code via the same MCP tool.
+  const reclaim = await callTool('tesseron__claim_session', { code: pendingAfter.code });
+  if (reclaim.isError) fail(`reclaim failed: ${reclaim.text}`);
+  pass(`reclaim succeeded: ${reclaim.text.slice(0, 100)}...`);
+
+  // Step 6: action works again.
+  const addAgain = await callTool(`${appId}__addTodo`, { text: 'post-recovery todo' });
+  if (addAgain.isError) fail(`post-recovery addTodo failed: ${addAgain.text}`);
+  pass(`post-recovery addTodo: ${addAgain.text}`);
+
+  console.log('\n[e2e] ALL CHECKS PASSED');
+  process.exit(0);
+} catch (err) {
+  console.error('[e2e] uncaught error:', err);
+  process.exit(1);
+} finally {
+  await client.close().catch(() => {});
+  transport.close().catch(() => {});
+}

--- a/packages/mcp/scripts/e2e-issue-69.mjs
+++ b/packages/mcp/scripts/e2e-issue-69.mjs
@@ -21,14 +21,11 @@
  */
 
 import { existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import {
-  CallToolResultSchema,
-  ListToolsResultSchema,
-} from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResultSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../../..');
@@ -48,9 +45,12 @@ const transport = new StdioClientTransport({
   args: [bundle],
 });
 
-const client = new Client({ name: 'e2e-issue-69', version: '0.0.0' }, {
-  capabilities: { sampling: {}, elicitation: {} },
-});
+const client = new Client(
+  { name: 'e2e-issue-69', version: '0.0.0' },
+  {
+    capabilities: { sampling: {}, elicitation: {} },
+  },
+);
 
 await client.connect(transport);
 console.log('[e2e] MCP client connected');
@@ -124,7 +124,9 @@ try {
   const toolMatch = firstClaim.text.match(/(\w+)__\w+/);
   if (!toolMatch) fail('could not extract app_id from claim result');
   const appId = toolMatch[1];
-  console.log(`[e2e] real app.id from bind: "${appId}" (manifest appName was "${pendingBefore.app_id}")`);
+  console.log(
+    `[e2e] real app.id from bind: "${appId}" (manifest appName was "${pendingBefore.app_id}")`,
+  );
 
   const addOk = await callTool(`${appId}__addTodo`, { text: 'pre-refresh todo' });
   if (addOk.isError) fail(`addTodo on fresh session failed: ${addOk.text}`);
@@ -137,7 +139,9 @@ try {
   // post-refresh pending claim should report `app_id` matching the SDK's real
   // app.id (the same prefix the agent's cached `<app_id>__<action>` tools use).
   const firstBindAt = Date.now();
-  console.log('\n[e2e] >>> REFRESH THE BROWSER TAB NOW (test waits 30s for a NEW claim code) <<<\n');
+  console.log(
+    '\n[e2e] >>> REFRESH THE BROWSER TAB NOW (test waits 30s for a NEW claim code) <<<\n',
+  );
   const pendingAfter = await waitForPendingCode(
     (c) =>
       c.app_id === appId &&
@@ -149,9 +153,13 @@ try {
   );
   console.log(`[e2e] discovered new pending claim: ${JSON.stringify(pendingAfter)}`);
   if (pendingAfter.app_id !== appId) {
-    fail(`post-refresh entry app_id "${pendingAfter.app_id}" does not match expected "${appId}" — manifestAppName→appId cache failed to populate`);
+    fail(
+      `post-refresh entry app_id "${pendingAfter.app_id}" does not match expected "${appId}" — manifestAppName→appId cache failed to populate`,
+    );
   }
-  pass(`list_pending_claims reports correct agent-visible app_id "${appId}" after refresh (cache populated by first bind)`);
+  pass(
+    `list_pending_claims reports correct agent-visible app_id "${appId}" after refresh (cache populated by first bind)`,
+  );
 
   // Step 4: cached tool call must hit the new error path.
   const stale = await callTool(`${appId}__addTodo`, { text: 'should fail' });

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -126,6 +126,33 @@ export interface AgentCapabilityInfo {
 }
 
 /**
+ * One entry returned by {@link TesseronGateway.getPendingClaims}: a claim
+ * code the gateway can currently redeem, plus enough metadata for an agent
+ * to pick the right one. The MCP bridge serialises these as the body of
+ * `tesseron__list_pending_claims`. See tesseron#69.
+ */
+export interface PendingClaim {
+  /** 6-character pairing code in the `XXXX-XX` format. Pass to `tesseron__claim_session({ code })`. */
+  code: string;
+  /**
+   * App identifier. For gateway-minted claims this is `session.app.id`
+   * (matches the prefix on per-app MCP tools, e.g. `<appId>__<action>`).
+   * For host-minted claims, this is the manifest's `appName` field — in
+   * practice the same string, but the host hasn't sent `tesseron/hello`
+   * yet so the gateway can't promise authoritative parity until binding.
+   */
+  appId: string;
+  /** Human-readable display name. Falls back to {@link appId} for host-minted entries. */
+  appName: string;
+  /** Unix-millis when the gateway (or host) minted the code. */
+  mintedAt: number;
+  /** Which mint flow produced this claim — gateway-minted is the legacy v1.1 path. */
+  source: 'gateway-minted' | 'host-minted';
+  /** Unix-millis sliding TTL deadline; only present for host-minted claims that advertised one. */
+  expiresAt?: number;
+}
+
+/**
  * Operational event the gateway emits as `'gateway-log'` so an MCP bridge can
  * forward it to the connected agent via `notifications/message` (MCP
  * `sendLoggingMessage`). Solves the "user has to grep ~/.claude/" problem
@@ -179,6 +206,8 @@ interface ZombieSession {
   claimCode: string;
   claimed: boolean;
   claimedAt?: number;
+  /** Original session mintedAt, preserved across resume so the resumed session reports its true age. */
+  mintedAt: number;
   /** Timer that removes this zombie from {@link TesseronGateway.zombieSessions} once the TTL elapses. */
   evictTimer: ReturnType<typeof setTimeout>;
 }
@@ -238,6 +267,19 @@ export class TesseronGateway extends EventEmitter {
     string,
     { resolve: (s: Session) => void; reject: (err: Error) => void }
   >();
+  /**
+   * Cache mapping a host-minted manifest's `appName` (filesystem-friendly,
+   * usually the package name — e.g. `"react-todo"`) to the SDK-side `app.id`
+   * (the prefix on per-app MCP tools — e.g. `"todos"`) learned at v3 bind
+   * time. Used by {@link getPendingClaims} so a post-recovery list surfaces
+   * the same `app_id` an agent would see on per-app tool names; lets the
+   * agent's `<app_id>__<action>` cache match the new pending entry without
+   * a user round-trip. Lives for the gateway process — a stale entry only
+   * costs the agent a one-shot wrong app_id, which still recovers because
+   * `tesseron__claim_session` keys off the code, not the app id. See
+   * tesseron#69.
+   */
+  private readonly manifestAppNameToAppId = new Map<string, string>();
 
   constructor(private readonly options: GatewayOptions = {}) {
     super();
@@ -601,6 +643,68 @@ export class TesseronGateway extends EventEmitter {
   /** Sessions that have completed `tesseron/hello` but are waiting for a claim code. */
   getPendingSessions(): Session[] {
     return Array.from(this.sessions.values()).filter((s) => !s.claimed);
+  }
+
+  /**
+   * Snapshot of every claim code the gateway can currently redeem. Combines:
+   *
+   * - **Gateway-minted (legacy):** sessions that completed `tesseron/hello`
+   *   but haven't been claimed yet — entries from {@link pendingClaims}
+   *   joined to their {@link Session} for app metadata.
+   * - **Host-minted (`@tesseron/vite@2.2.0+` / `@tesseron/server` host-mint):**
+   *   manifests under `~/.tesseron/instances/` with `helloHandledByHost: true`
+   *   and a `hostMintedClaim` whose `boundAgent` is `null` and whose
+   *   `expiresAt` (when present) hasn't elapsed.
+   *
+   * Surfaced through the MCP bridge as `tesseron__list_pending_claims` so an
+   * agent whose previously-claimed session was invalidated (browser refresh,
+   * dev-server reload, resume failure) can self-discover the new claim code
+   * instead of asking the user to read it from the app UI. See tesseron#69.
+   */
+  getPendingClaims(): PendingClaim[] {
+    const out: PendingClaim[] = [];
+    for (const [code, sessionId] of this.pendingClaims) {
+      const session = this.sessions.get(sessionId);
+      if (!session) continue;
+      out.push({
+        code,
+        appId: session.app.id,
+        appName: session.app.name,
+        mintedAt: session.mintedAt,
+        source: 'gateway-minted',
+      });
+    }
+    const now = Date.now();
+    for (const manifest of this.hostMintedInstances.values()) {
+      const minted = manifest.hostMintedClaim;
+      if (!minted) continue;
+      // Filter out claims the host has already consumed or let expire — both
+      // would fail at `claimSession` time anyway, so listing them just sends
+      // the agent down a dead-end.
+      if (minted.boundAgent !== null) continue;
+      if (minted.expiresAt !== undefined && minted.expiresAt < now) continue;
+      // For host-minted entries the manifest only carries `appName` (the
+      // filesystem-friendly identifier — usually the package name, e.g.
+      // "react-todo"). The agent-visible app id (the prefix on per-app
+      // tools, e.g. "todos") only arrives at v3 bind time. Prefer the
+      // cached mapping when we've seen this SDK before, so the agent's
+      // `<app_id>__<action>` cache matches the entry without a user
+      // round-trip. Fall back to the manifest's appName when no prior
+      // bind has populated the cache (first-ever claim).
+      const cachedAppId = this.manifestAppNameToAppId.get(manifest.appName);
+      out.push({
+        code: minted.code,
+        appId: cachedAppId ?? manifest.appName,
+        appName: manifest.appName,
+        mintedAt: minted.mintedAt,
+        source: 'host-minted',
+        ...(minted.expiresAt !== undefined ? { expiresAt: minted.expiresAt } : {}),
+      });
+    }
+    // Sort by mintedAt descending so the newest claim — usually what the
+    // recovering agent wants — is first.
+    out.sort((a, b) => b.mintedAt - a.mintedAt);
+    return out;
   }
 
   /**
@@ -994,6 +1098,7 @@ export class TesseronGateway extends EventEmitter {
           claimCode: closedSession.claimCode,
           claimed: closedSession.claimed,
           claimedAt: closedSession.claimedAt,
+          mintedAt: closedSession.mintedAt,
           evictTimer,
         });
       }
@@ -1078,9 +1183,18 @@ export class TesseronGateway extends EventEmitter {
           claimCode: bindContext.code,
           claimed: true,
           claimedAt,
+          mintedAt: claimedAt,
           resumeToken,
         };
         this.sessions.set(sessionId, session);
+        // Remember the manifest-appName → real app.id mapping so a future
+        // pending-claim discovery for the same SDK process (after a refresh
+        // / dev-server reload) can report the agent-visible app id rather
+        // than the filesystem-friendly manifest name. See tesseron#69.
+        const boundManifest = this.hostMintedInstances.get(bindContext.instanceId);
+        if (boundManifest) {
+          this.manifestAppNameToAppId.set(boundManifest.appName, helloParams.app.id);
+        }
         logToStderr(
           `[tesseron] host-mint session "${helloParams.app.name}" (${sessionId}) — bound to claim code ${bindContext.code}`,
         );
@@ -1145,6 +1259,7 @@ export class TesseronGateway extends EventEmitter {
       const sessionId = generateSessionId();
       const resumeToken = generateResumeToken();
       const claimCode = generateClaimCode();
+      const mintedAt = Date.now();
       session = {
         id: sessionId,
         app: helloParams.app,
@@ -1155,6 +1270,7 @@ export class TesseronGateway extends EventEmitter {
         capabilities: helloParams.capabilities,
         claimCode,
         claimed: false,
+        mintedAt,
         resumeToken,
       };
       this.sessions.set(sessionId, session);
@@ -1174,7 +1290,7 @@ export class TesseronGateway extends EventEmitter {
         appId: helloParams.app.id,
         appName: helloParams.app.name,
         gatewayPid: process.pid,
-        mintedAt: Date.now(),
+        mintedAt,
       });
       logToStderr(
         `[tesseron] new session "${helloParams.app.name}" (${sessionId}) — claim code: ${claimCode}`,
@@ -1330,6 +1446,7 @@ export class TesseronGateway extends EventEmitter {
         claimCode: zombie.claimCode,
         claimed: zombie.claimed,
         claimedAt: zombie.claimedAt,
+        mintedAt: zombie.mintedAt,
         resumeToken: rotatedResumeToken,
       };
       this.sessions.set(zombie.id, session);

--- a/packages/mcp/src/gateway.ts
+++ b/packages/mcp/src/gateway.ts
@@ -135,21 +135,32 @@ export interface PendingClaim {
   /** 6-character pairing code in the `XXXX-XX` format. Pass to `tesseron__claim_session({ code })`. */
   code: string;
   /**
-   * App identifier. For gateway-minted claims this is `session.app.id`
-   * (matches the prefix on per-app MCP tools, e.g. `<appId>__<action>`).
-   * For host-minted claims, this is the manifest's `appName` field — in
-   * practice the same string, but the host hasn't sent `tesseron/hello`
-   * yet so the gateway can't promise authoritative parity until binding.
+   * App identifier. For gateway-minted claims this is `session.app.id` (matches
+   * the prefix on per-app MCP tools, e.g. `<appId>__<action>`). For host-minted
+   * claims this is best-effort: the cached real `app.id` if this SDK has bound
+   * before in this gateway process, otherwise the manifest's filesystem-friendly
+   * `appName`. Authoritative parity only after the first successful bind.
    */
   appId: string;
   /** Human-readable display name. Falls back to {@link appId} for host-minted entries. */
   appName: string;
   /** Unix-millis when the gateway (or host) minted the code. */
   mintedAt: number;
-  /** Which mint flow produced this claim — gateway-minted is the legacy v1.1 path. */
+  /**
+   * Which mint flow produced this claim. `gateway-minted` is the pre-host-mint
+   * fallback used when the SDK doesn't set `helloHandledByHost` (still active in
+   * v2 — every legacy SDK bridges through this path).
+   */
   source: 'gateway-minted' | 'host-minted';
   /** Unix-millis sliding TTL deadline; only present for host-minted claims that advertised one. */
   expiresAt?: number;
+  /**
+   * Manifest-side instance identifier. Only set for host-minted entries — lets
+   * an agent disambiguate two SDKs that happen to share an `appName` (e.g. two
+   * worktrees of the same package running side-by-side). Per tesseron#69's
+   * suggested shape.
+   */
+  instanceId?: string;
 }
 
 /**
@@ -270,14 +281,17 @@ export class TesseronGateway extends EventEmitter {
   /**
    * Cache mapping a host-minted manifest's `appName` (filesystem-friendly,
    * usually the package name — e.g. `"react-todo"`) to the SDK-side `app.id`
-   * (the prefix on per-app MCP tools — e.g. `"todos"`) learned at v3 bind
-   * time. Used by {@link getPendingClaims} so a post-recovery list surfaces
-   * the same `app_id` an agent would see on per-app tool names; lets the
-   * agent's `<app_id>__<action>` cache match the new pending entry without
-   * a user round-trip. Lives for the gateway process — a stale entry only
-   * costs the agent a one-shot wrong app_id, which still recovers because
-   * `tesseron__claim_session` keys off the code, not the app id. See
-   * tesseron#69.
+   * (the prefix on per-app MCP tools — e.g. `"todos"`). Populated in the
+   * host-mint hello handler when the SDK reports its real `app.id`. Used by
+   * {@link getPendingClaims} so a post-recovery list surfaces the same
+   * `app_id` an agent would see on per-app tool names; lets the agent's
+   * `<app_id>__<action>` cache match the new pending entry without a user
+   * round-trip. Lives for the gateway process — a stale entry only costs
+   * the agent a one-shot wrong app_id, which still recovers because
+   * `tesseron__claim_session` keys off the code, not the app id. Two SDKs
+   * with the same `appName` (e.g. two worktrees of the same package) will
+   * stomp each other's entry; the `instanceId` field on `PendingClaim`
+   * gives the agent a disambiguator. See tesseron#69.
    */
   private readonly manifestAppNameToAppId = new Map<string, string>();
 
@@ -648,10 +662,10 @@ export class TesseronGateway extends EventEmitter {
   /**
    * Snapshot of every claim code the gateway can currently redeem. Combines:
    *
-   * - **Gateway-minted (legacy):** sessions that completed `tesseron/hello`
-   *   but haven't been claimed yet — entries from {@link pendingClaims}
-   *   joined to their {@link Session} for app metadata.
-   * - **Host-minted (`@tesseron/vite@2.2.0+` / `@tesseron/server` host-mint):**
+   * - **Gateway-minted:** sessions that completed `tesseron/hello` but
+   *   haven't been claimed yet — entries from {@link pendingClaims} joined
+   *   to their {@link Session} for app metadata.
+   * - **Host-minted (`@tesseron/vite` / `@tesseron/server` host-mint):**
    *   manifests under `~/.tesseron/instances/` with `helloHandledByHost: true`
    *   and a `hostMintedClaim` whose `boundAgent` is `null` and whose
    *   `expiresAt` (when present) hasn't elapsed.
@@ -682,15 +696,25 @@ export class TesseronGateway extends EventEmitter {
       // would fail at `claimSession` time anyway, so listing them just sends
       // the agent down a dead-end.
       if (minted.boundAgent !== null) continue;
-      if (minted.expiresAt !== undefined && minted.expiresAt < now) continue;
-      // For host-minted entries the manifest only carries `appName` (the
-      // filesystem-friendly identifier — usually the package name, e.g.
-      // "react-todo"). The agent-visible app id (the prefix on per-app
-      // tools, e.g. "todos") only arrives at v3 bind time. Prefer the
-      // cached mapping when we've seen this SDK before, so the agent's
+      // `Number.isFinite` rejects NaN/Infinity from a malformed manifest so
+      // the downstream `new Date(expiresAt).toISOString()` in the bridge
+      // can't throw RangeError on an out-of-range value the `< now`
+      // comparison would silently let through (NaN < now is `false`).
+      if (
+        minted.expiresAt !== undefined &&
+        (!Number.isFinite(minted.expiresAt) || minted.expiresAt < now)
+      ) {
+        continue;
+      }
+      if (!Number.isFinite(minted.mintedAt)) continue;
+      // The manifest only carries `appName` (the filesystem-friendly
+      // identifier — usually the package name, e.g. "react-todo"). The
+      // agent-visible app id (the prefix on per-app tools, e.g. "todos")
+      // only arrives at the host-mint hello/bind. Prefer the cached
+      // mapping when we've seen this SDK before, so the agent's
       // `<app_id>__<action>` cache matches the entry without a user
-      // round-trip. Fall back to the manifest's appName when no prior
-      // bind has populated the cache (first-ever claim).
+      // round-trip. Fall back to the manifest's appName for the
+      // first-ever claim (no prior bind has populated the cache).
       const cachedAppId = this.manifestAppNameToAppId.get(manifest.appName);
       out.push({
         code: minted.code,
@@ -698,6 +722,7 @@ export class TesseronGateway extends EventEmitter {
         appName: manifest.appName,
         mintedAt: minted.mintedAt,
         source: 'host-minted',
+        instanceId: manifest.instanceId,
         ...(minted.expiresAt !== undefined ? { expiresAt: minted.expiresAt } : {}),
       });
     }
@@ -1194,6 +1219,15 @@ export class TesseronGateway extends EventEmitter {
         const boundManifest = this.hostMintedInstances.get(bindContext.instanceId);
         if (boundManifest) {
           this.manifestAppNameToAppId.set(boundManifest.appName, helloParams.app.id);
+        } else {
+          // Manifest already evicted between claimSession's lookup and the
+          // bind hello firing (TTL race or concurrent delete). The agent
+          // recovery flow falls back to reporting the manifest's appName
+          // on next list_pending_claims; visible here so an operator
+          // chasing wrong-app-id reports knows where to look.
+          logToStderr(
+            `[tesseron] cache miss: host-mint manifest for instance ${bindContext.instanceId} evicted before bind handler ran — manifestAppName→appId mapping skipped`,
+          );
         }
         logToStderr(
           `[tesseron] host-mint session "${helloParams.app.name}" (${sessionId}) — bound to claim code ${bindContext.code}`,

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -31,6 +31,7 @@ const META_TOOL_CLAIM_SESSION = 'tesseron__claim_session';
 const META_TOOL_LIST_ACTIONS = 'tesseron__list_actions';
 const META_TOOL_INVOKE_ACTION = 'tesseron__invoke_action';
 const META_TOOL_READ_RESOURCE = 'tesseron__read_resource';
+const META_TOOL_LIST_PENDING_CLAIMS = 'tesseron__list_pending_claims';
 const PREFIX_SEPARATOR = '__';
 const RESOURCE_SCHEME = 'tesseron:';
 const DEFAULT_SERVER_NAME = 'tesseron';
@@ -112,6 +113,16 @@ const META_DISPATCHER_TOOLS = [
         },
       },
       required: ['app_id', 'name'],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: META_TOOL_LIST_PENDING_CLAIMS,
+    description:
+      'List every claim code the gateway can currently redeem (gateway-minted sessions waiting for claim, plus host-minted manifests with an unconsumed code). Recovery path when a previously-claimed session was invalidated mid-conversation (browser refresh, dev-server reload, resume failure) and tools/call returns "No claimed session found": call this, pick the entry whose app_id matches, then call tesseron__claim_session({ code }) to re-pair without asking the user to read the new code from the app UI. Returns an empty list when no claim is pending — in that case, ask the user to reload the app.',
+    inputSchema: {
+      type: 'object' as const,
+      properties: {},
       additionalProperties: false,
     },
   },
@@ -345,6 +356,9 @@ export class McpAgentBridge {
       if (name === META_TOOL_LIST_ACTIONS) {
         return this.handleListActions();
       }
+      if (name === META_TOOL_LIST_PENDING_CLAIMS) {
+        return this.handleListPendingClaims();
+      }
       if (name === META_TOOL_READ_RESOURCE) {
         return this.handleReadResource(args);
       }
@@ -377,7 +391,7 @@ export class McpAgentBridge {
       }
       const session = this.latestClaimedByApp(appId);
       if (!session) {
-        return errorResult(`No claimed session found for app "${appId}".`);
+        return errorResult(this.noClaimedSessionMessage(appId));
       }
 
       if (progressToken !== undefined) {
@@ -582,6 +596,74 @@ export class McpAgentBridge {
     };
   }
 
+  /**
+   * Build the body of `tesseron__list_pending_claims`. Each entry has the
+   * shape an agent needs to call `tesseron__claim_session({ code })` next:
+   * the code itself, the app id (matches the `<app_id>__<action>` tool
+   * prefix), the human display name, the source mint flow, and the unix
+   * timestamps for filtering. The empty-list branch returns advisory text
+   * — strict programmatic agents key off `pending_claims.length` while
+   * looser ones still get a helpful instruction. See tesseron#69.
+   */
+  private handleListPendingClaims(): {
+    content: Array<{ type: 'text'; text: string }>;
+  } {
+    const claims = this.gateway.getPendingClaims();
+    if (claims.length === 0) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: 'No pending claims. The gateway has nothing to redeem right now — ask the user to (re)open the app and read the new claim code from its UI, then call tesseron__claim_session({ code }).',
+          },
+        ],
+      };
+    }
+    const payload = {
+      pending_claims: claims.map((c) => ({
+        code: c.code,
+        app_id: c.appId,
+        app_name: c.appName,
+        minted_at: c.mintedAt,
+        minted_at_iso: new Date(c.mintedAt).toISOString(),
+        source: c.source,
+        ...(c.expiresAt !== undefined
+          ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() }
+          : {}),
+      })),
+      next_step: `Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.`,
+    };
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify(payload, null, 2),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Recovery hint surfaced when an action / resource call lands on an
+   * `appId` that has no claimed session — the most common cause is that
+   * the prior session was invalidated mid-conversation (browser tab
+   * refresh, dev-server reload, `tesseron/resume` failure) and the agent
+   * still holds the cached app id from before. Mentions the recovery
+   * tool by name so the agent doesn't have to guess. See tesseron#69.
+   */
+  private noClaimedSessionMessage(appId: string): string {
+    const pending = this.gateway.getPendingClaims();
+    const matching = pending.filter((c) => c.appId === appId);
+    if (matching.length > 0) {
+      const codes = matching.map((c) => c.code).join(', ');
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`;
+    }
+    if (pending.length > 0) {
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure). The gateway has ${pending.length} pending claim(s) for other apps — call ${META_TOOL_LIST_PENDING_CLAIMS} to see them, or ask the user to reload "${appId}" and read its new claim code from the app UI.`;
+    }
+    return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and no pending claim is waiting. Ask the user to reload the app, then call ${META_TOOL_CLAIM_SESSION}({ code }) with the new claim code shown in the app UI. ${META_TOOL_LIST_PENDING_CLAIMS} returns any newly-pending claims if the user reloads while you wait.`;
+  }
+
   private async handleReadResource(args: Record<string, unknown>): Promise<{
     content: Array<{ type: 'text'; text: string }>;
     isError?: boolean;
@@ -595,7 +677,7 @@ export class McpAgentBridge {
     }
     const session = this.latestClaimedByApp(appId);
     if (!session) {
-      return errorResult(`No claimed session found for app "${appId}".`);
+      return errorResult(this.noClaimedSessionMessage(appId));
     }
     if (!session.resources.some((r) => r.name === resourceName)) {
       return errorResult(
@@ -652,8 +734,21 @@ export class McpAgentBridge {
           `Claim code "${code.toUpperCase()}" was minted at ${minted} by gateway pid ${foreign.gatewayPid}, which is no longer running. Have the web app reconnect to mint a fresh code, then claim that one.`,
         );
       }
+      // Surface the live pending claims so an agent retrying with a stale
+      // cached code (post-#69 recovery path) can self-correct without a
+      // user round-trip. The list is short (one entry per pending session)
+      // so embedding it in the error keeps the agent's next action obvious.
+      const pending = this.gateway.getPendingClaims();
+      if (pending.length > 0) {
+        const summary = pending
+          .map((c) => `"${c.code}" (app "${c.appId}", source ${c.source})`)
+          .join('; ');
+        return errorResult(
+          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}. If the user typed the wrong code, retry with one of those. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`,
+        );
+      }
       return errorResult(
-        `No pending session found for code "${code}". Has the web app connected, and is the code current?`,
+        `No pending session found for code "${code}". Has the web app connected, and is the code current? Call ${META_TOOL_LIST_PENDING_CLAIMS} to see what the gateway currently has pending; if empty, ask the user to reload the app.`,
       );
     }
     const toolNames = session.actions.map((a) => `${session.app.id}${PREFIX_SEPARATOR}${a.name}`);

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -22,6 +22,7 @@ import { assertValidElicitSchema } from '@tesseron/core/internal';
 import type {
   ForeignClaim,
   GatewayLogEvent,
+  PendingClaim,
   ResourceSubscription,
   TesseronGateway,
 } from './gateway.js';
@@ -35,6 +36,14 @@ const META_TOOL_LIST_PENDING_CLAIMS = 'tesseron__list_pending_claims';
 const PREFIX_SEPARATOR = '__';
 const RESOURCE_SCHEME = 'tesseron:';
 const DEFAULT_SERVER_NAME = 'tesseron';
+/**
+ * Cap on the number of pending claims inlined in `tesseron__claim_session`'s
+ * "no pending session" error body. Bounds the error string in multi-app dev
+ * workflows so a typo on one app doesn't dump every other claim's metadata
+ * (and so MCP clients that truncate long messages still see something useful).
+ * The agent gets the full list via `tesseron__list_pending_claims`.
+ */
+const PENDING_CLAIM_PREVIEW_MAX = 3;
 
 const CLAIM_TOOL = {
   name: META_TOOL_CLAIM_SESSION,
@@ -627,6 +636,7 @@ export class McpAgentBridge {
         minted_at: c.mintedAt,
         minted_at_iso: new Date(c.mintedAt).toISOString(),
         source: c.source,
+        ...(c.instanceId !== undefined ? { instance_id: c.instanceId } : {}),
         ...(c.expiresAt !== undefined
           ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() }
           : {}),
@@ -648,15 +658,33 @@ export class McpAgentBridge {
    * `appId` that has no claimed session — the most common cause is that
    * the prior session was invalidated mid-conversation (browser tab
    * refresh, dev-server reload, `tesseron/resume` failure) and the agent
-   * still holds the cached app id from before. Mentions the recovery
-   * tool by name so the agent doesn't have to guess. See tesseron#69.
+   * still holds the cached app id from before. See tesseron#69.
+   *
+   * Wrapped in try/catch so a malformed manifest that would otherwise
+   * crash {@link TesseronGateway.getPendingClaims} still leaves the agent
+   * with the original "no claimed session" hint instead of swallowing it
+   * inside a JSON-RPC InternalError.
    */
   private noClaimedSessionMessage(appId: string): string {
-    const pending = this.gateway.getPendingClaims();
+    let pending: ReturnType<TesseronGateway['getPendingClaims']> = [];
+    try {
+      pending = this.gateway.getPendingClaims();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      void this.server
+        .sendLoggingMessage({
+          level: 'warning',
+          logger: 'tesseron.recovery',
+          data: {
+            message: `pending-claims enrichment failed while building no-claimed-session error: ${reason}`,
+          },
+        })
+        .catch(() => {});
+    }
     const matching = pending.filter((c) => c.appId === appId);
     if (matching.length > 0) {
       const codes = matching.map((c) => c.code).join(', ');
-      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`;
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry.`;
     }
     if (pending.length > 0) {
       return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure). The gateway has ${pending.length} pending claim(s) for other apps — call ${META_TOOL_LIST_PENDING_CLAIMS} to see them, or ask the user to reload "${appId}" and read its new claim code from the app UI.`;
@@ -736,15 +764,37 @@ export class McpAgentBridge {
       }
       // Surface the live pending claims so an agent retrying with a stale
       // cached code (post-#69 recovery path) can self-correct without a
-      // user round-trip. The list is short (one entry per pending session)
-      // so embedding it in the error keeps the agent's next action obvious.
-      const pending = this.gateway.getPendingClaims();
+      // user round-trip. Cap the inlined list at PENDING_CLAIM_PREVIEW_MAX
+      // so a multi-app dev workflow doesn't bloat the error string (and
+      // direct the agent at the meta tool for the rest). Wrap in try/catch
+      // so a malformed manifest can't escalate this user error into an
+      // opaque internal one.
+      let pending: PendingClaim[] = [];
+      try {
+        pending = this.gateway.getPendingClaims();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        void this.server
+          .sendLoggingMessage({
+            level: 'warning',
+            logger: 'tesseron.recovery',
+            data: {
+              message: `pending-claims enrichment failed while building no-pending-session error: ${reason}`,
+            },
+          })
+          .catch(() => {});
+      }
       if (pending.length > 0) {
-        const summary = pending
+        const preview = pending.slice(0, PENDING_CLAIM_PREVIEW_MAX);
+        const summary = preview
           .map((c) => `"${c.code}" (app "${c.appId}", source ${c.source})`)
           .join('; ');
+        const overflowSuffix =
+          pending.length > preview.length
+            ? ` (showing the ${preview.length} most-recent of ${pending.length}; call ${META_TOOL_LIST_PENDING_CLAIMS} for the full list)`
+            : '';
         return errorResult(
-          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}. If the user typed the wrong code, retry with one of those. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`,
+          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}${overflowSuffix}. If the user typed the wrong code, retry with one of those.`,
         );
       }
       return errorResult(

--- a/packages/mcp/src/mcp-bridge.ts
+++ b/packages/mcp/src/mcp-bridge.ts
@@ -641,7 +641,8 @@ export class McpAgentBridge {
           ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() }
           : {}),
       })),
-      next_step: `Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.`,
+      next_step:
+        'Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.',
     };
     return {
       content: [

--- a/packages/mcp/src/session.ts
+++ b/packages/mcp/src/session.ts
@@ -25,6 +25,13 @@ export interface Session {
   claimed: boolean;
   claimedAt?: number;
   /**
+   * Unix-millis timestamp of when the session was created (i.e. when the
+   * gateway processed `tesseron/hello`). Lets {@link TesseronGateway.getPendingClaims}
+   * report a stable mintedAt to the agent without re-reading the on-disk
+   * claim breadcrumb.
+   */
+  mintedAt: number;
+  /**
    * Opaque server-issued token returned in the session's {@link WelcomeResult}.
    * The SDK stashes this alongside {@link Session.id} to rejoin via
    * `tesseron/resume` after a transport drop. Rotated on every successful

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -879,15 +879,12 @@ describe('Pending claim recovery (tesseron#69)', () => {
 
       const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
       expect(result.isError).toBe(false);
-      // Either "No pending claims" text or a payload that doesn't list the expired entry.
-      if (!result.text.startsWith('{')) {
-        expect(result.text).toMatch(/no pending claims/i);
-      } else {
-        const payload = JSON.parse(result.text) as {
-          pending_claims: Array<{ code: string }>;
-        };
-        expect(payload.pending_claims.find((c) => c.code === 'BBBB-33')).toBeUndefined();
-      }
+      // Expired entries are filtered before serialisation, so only an
+      // expired claim means an empty list and the empty-state message.
+      // Asserting the exact shape pins the contract: future code that
+      // accidentally surfaces expired claims (or returns the JSON payload
+      // anyway with an empty `pending_claims`) will fail this test.
+      expect(result.text).toMatch(/no pending claims/i);
     } finally {
       await harness.cleanup();
     }
@@ -910,6 +907,132 @@ describe('Pending claim recovery (tesseron#69)', () => {
       expect(failed.isError).toBe(true);
       expect(failed.text).toContain('CCCC-44');
       expect(failed.text).toContain('mistypeapp');
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  /**
+   * Cache-mapping unit test for the fix that motivated half this PR — without
+   * `manifestAppNameToAppId`, `tesseron__list_pending_claims` reports the
+   * manifest's filesystem-friendly `appName` (e.g. "react-todo") rather than
+   * the SDK's real `app.id` (e.g. "todos"), and the agent's cached
+   * `<app_id>__<action>` tools never line up. The original bug was caught
+   * end-to-end against a real browser; this asserts the same invariant in
+   * isolation so a refactor that drops the cache write at bind time
+   * (gateway.ts host-mint hello handler) fails fast.
+   */
+  it('host-minted entries report the cached real app.id once the bind has run', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      // Seed the cache the way a successful host-mint bind would. Going
+      // through the real bind path would require an SDK round-trip; the
+      // public method is the same shape from both directions, so direct
+      // seeding still tests the invariant.
+      const gw = harness.gateway as unknown as {
+        manifestAppNameToAppId: Map<string, string>;
+      };
+      gw.manifestAppNameToAppId.set('manifest-flavor', 'real-app-id');
+
+      await writePendingManifest({
+        instancesDir: harness.instancesDir,
+        instanceId: 'inst-cache-1',
+        appName: 'manifest-flavor',
+        code: 'DDDD-55',
+      });
+      await new Promise((r) => setTimeout(r, 2_500));
+
+      const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
+      expect(result.isError).toBe(false);
+      const payload = JSON.parse(result.text) as {
+        pending_claims: Array<{ code: string; app_id: string; app_name: string; instance_id?: string }>;
+      };
+      const entry = payload.pending_claims.find((c) => c.code === 'DDDD-55');
+      expect(entry, 'entry should be present').toBeTruthy();
+      expect(entry?.app_id).toBe('real-app-id');
+      expect(entry?.app_name).toBe('manifest-flavor');
+      expect(entry?.instance_id).toBe('inst-cache-1');
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('tesseron__list_pending_claims surfaces gateway-minted entries (legacy pendingClaims source)', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      // Directly seed the legacy maps. `@tesseron/server` no longer takes the
+      // gateway-mint path (always uses host-mint), so the only way to cover
+      // this branch in isolation is to populate gateway internals. Pre-host-mint
+      // SDKs and downstream forks still rely on this code path.
+      const gw = harness.gateway as unknown as {
+        pendingClaims: Map<string, string>;
+        sessions: Map<string, unknown>;
+      };
+      const sessionId = 's_legacy_test';
+      gw.sessions.set(sessionId, {
+        id: sessionId,
+        app: { id: 'legacyapp', name: 'Legacy App', origin: 'http://test' },
+        actions: [],
+        resources: [],
+        capabilities: { streaming: true, subscriptions: true, sampling: false, elicitation: false },
+        claimCode: 'EEEE-66',
+        claimed: false,
+        mintedAt: Date.now(),
+        resumeToken: 'fake',
+        // transport + dispatcher absent — getPendingClaims reads only
+        // app.id, app.name, mintedAt, claimed, claimCode.
+      });
+      gw.pendingClaims.set('EEEE-66', sessionId);
+
+      const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
+      expect(result.isError).toBe(false);
+      const payload = JSON.parse(result.text) as {
+        pending_claims: Array<{ code: string; app_id: string; source: string; instance_id?: string }>;
+      };
+      const entry = payload.pending_claims.find((c) => c.code === 'EEEE-66');
+      expect(entry).toBeTruthy();
+      expect(entry?.app_id).toBe('legacyapp');
+      expect(entry?.source).toBe('gateway-minted');
+      // gateway-minted entries don't carry an instance_id (the field is
+      // host-minted-only per the `PendingClaim` definition).
+      expect(entry?.instance_id).toBeUndefined();
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('tesseron__invoke_action on a stale appId returns the recovery hint with the matching pending code', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      // Pre-populate the cache so the host-minted entry reports the agent-visible
+      // `app.id` ("todos") rather than the manifest's `appName` ("recoveryapp"),
+      // matching the recovery scenario from issue #69.
+      const gw = harness.gateway as unknown as {
+        manifestAppNameToAppId: Map<string, string>;
+      };
+      gw.manifestAppNameToAppId.set('recoveryapp', 'todos');
+
+      await writePendingManifest({
+        instancesDir: harness.instancesDir,
+        instanceId: 'inst-stale-1',
+        appName: 'recoveryapp',
+        code: 'FFFF-77',
+      });
+      await new Promise((r) => setTimeout(r, 2_500));
+
+      // Agent invokes a per-app tool whose appId no longer has a claimed
+      // session. Pre-#69 this returned a flat "No claimed session found"
+      // string; now it must inline the matching pending code and name the
+      // recovery tool.
+      const failed = await callBridgeTool(harness.client, 'tesseron__invoke_action', {
+        app_id: 'todos',
+        action: 'addTodo',
+        args: { text: 'whatever' },
+      });
+      expect(failed.isError).toBe(true);
+      expect(failed.text).toContain('todos');
+      expect(failed.text).toContain('FFFF-77');
+      expect(failed.text).toContain('tesseron__claim_session');
     } finally {
       await harness.cleanup();
     }

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -137,6 +137,7 @@ describe('Tesseron MCP integration', () => {
       'tesseron__list_actions',
       'tesseron__invoke_action',
       'tesseron__read_resource',
+      'tesseron__list_pending_claims',
     ]);
   });
 
@@ -725,6 +726,196 @@ describe('Tesseron MCP integration', () => {
   });
 });
 
+describe('Pending claim recovery (tesseron#69)', () => {
+  /**
+   * Build a fresh gateway+bridge pair that watches a sandboxed
+   * `~/.tesseron/instances/` directory. Lets us write fake host-minted
+   * manifests directly to disk and observe the gateway pick them up — the
+   * test avoids the SDK dance because `@tesseron/server` always uses the
+   * v1.2 bind subprotocol, which auto-claims at dial time and never leaves
+   * a pending state we can enumerate.
+   */
+  async function buildRecoveryBridge(): Promise<{
+    gateway: TesseronGateway;
+    client: Client;
+    sandbox: Sandbox;
+    instancesDir: string;
+    cleanup: () => Promise<void>;
+  }> {
+    const localSandbox = prepareSandbox();
+    // Pre-create ~/.tesseron/instances so the gateway's fs.watch attaches
+    // immediately on startup. Without this the watcher falls back to the 2 s
+    // polling tick, which makes every test wait at least that long for the
+    // first manifest discovery.
+    const { mkdir } = await import('node:fs/promises');
+    const instancesDir = `${localSandbox.dir}/.tesseron/instances`;
+    await mkdir(instancesDir, { recursive: true });
+    const gw = new TesseronGateway();
+    const br = new McpAgentBridge({ gateway: gw });
+    const [agentSide, gatewaySide] = InMemoryTransport.createLinkedPair();
+    await br.connect(gatewaySide);
+    const c = new Client({ name: 'recovery-test', version: '0.0.0' });
+    await c.connect(agentSide);
+    const stopWatch = gw.watchInstances();
+    return {
+      gateway: gw,
+      client: c,
+      sandbox: localSandbox,
+      instancesDir,
+      cleanup: async () => {
+        stopWatch();
+        await c.close().catch(() => {});
+        await gw.stop().catch(() => {});
+        localSandbox.cleanup();
+      },
+    };
+  }
+
+  async function callBridgeTool(
+    c: Client,
+    name: string,
+    args: unknown,
+  ): Promise<{ text: string; isError: boolean }> {
+    const result = await c.request(
+      { method: 'tools/call', params: { name, arguments: (args ?? {}) as Record<string, unknown> } },
+      CallToolResultSchema,
+    );
+    const text = result.content.map((p) => (p.type === 'text' ? p.text : `[${p.type}]`)).join('');
+    return { text, isError: result.isError === true };
+  }
+
+  async function writePendingManifest(opts: {
+    instancesDir: string;
+    instanceId: string;
+    appName: string;
+    code: string;
+    mintedAt?: number;
+    expiresAt?: number;
+  }): Promise<void> {
+    const { mkdir, writeFile } = await import('node:fs/promises');
+    await mkdir(opts.instancesDir, { recursive: true });
+    const manifest = {
+      version: 2,
+      instanceId: opts.instanceId,
+      appName: opts.appName,
+      addedAt: Date.now(),
+      pid: process.pid,
+      transport: { kind: 'ws' as const, url: 'ws://127.0.0.1:1/never' },
+      helloHandledByHost: true,
+      hostMintedClaim: {
+        code: opts.code,
+        sessionId: `s_test_${opts.instanceId}`,
+        resumeToken: 'test-resume-token',
+        mintedAt: opts.mintedAt ?? Date.now(),
+        ...(opts.expiresAt !== undefined ? { expiresAt: opts.expiresAt } : {}),
+        boundAgent: null,
+      },
+    };
+    await writeFile(`${opts.instancesDir}/${opts.instanceId}.json`, JSON.stringify(manifest));
+  }
+
+  it('tesseron__list_pending_claims is empty when nothing is pending', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
+      expect(result.isError).toBe(false);
+      expect(result.text).toMatch(/no pending claims/i);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('tesseron__list_pending_claims surfaces a host-minted pending claim discovered on disk', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      await writePendingManifest({
+        instancesDir: harness.instancesDir,
+        instanceId: 'inst-recovery-1',
+        appName: 'recoveryapp',
+        code: 'AAAA-22',
+      });
+      // Wait for the watcher to pick up the file. With instancesDir
+      // pre-created in the harness, fs.watch attaches before the manifest
+      // is written and the discovery callback runs on the next tick. A
+      // generous safety margin covers Windows' occasional fs.watch misses
+      // (the gateway's 2 s polling fallback then catches them).
+      await new Promise((r) => setTimeout(r, 2_500));
+
+      const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
+      expect(result.isError).toBe(false);
+      const payload = JSON.parse(result.text) as {
+        pending_claims: Array<{
+          code: string;
+          app_id: string;
+          app_name: string;
+          source: string;
+          minted_at: number;
+        }>;
+        next_step: string;
+      };
+      const entry = payload.pending_claims.find((c) => c.code === 'AAAA-22');
+      expect(entry).toBeTruthy();
+      expect(entry?.app_id).toBe('recoveryapp');
+      expect(entry?.source).toBe('host-minted');
+      expect(typeof entry?.minted_at).toBe('number');
+      expect(payload.next_step).toMatch(/tesseron__claim_session/);
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('tesseron__list_pending_claims omits expired host-minted claims', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      await writePendingManifest({
+        instancesDir: harness.instancesDir,
+        instanceId: 'inst-expired-1',
+        appName: 'staleapp',
+        code: 'BBBB-33',
+        // Expired 1 minute ago — should be filtered out.
+        expiresAt: Date.now() - 60_000,
+      });
+      await new Promise((r) => setTimeout(r, 2_500));
+
+      const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
+      expect(result.isError).toBe(false);
+      // Either "No pending claims" text or a payload that doesn't list the expired entry.
+      if (!result.text.startsWith('{')) {
+        expect(result.text).toMatch(/no pending claims/i);
+      } else {
+        const payload = JSON.parse(result.text) as {
+          pending_claims: Array<{ code: string }>;
+        };
+        expect(payload.pending_claims.find((c) => c.code === 'BBBB-33')).toBeUndefined();
+      }
+    } finally {
+      await harness.cleanup();
+    }
+  });
+
+  it('tesseron__claim_session error lists pending claims when the typed code does not match any', async () => {
+    const harness = await buildRecoveryBridge();
+    try {
+      await writePendingManifest({
+        instancesDir: harness.instancesDir,
+        instanceId: 'inst-mistype-1',
+        appName: 'mistypeapp',
+        code: 'CCCC-44',
+      });
+      await new Promise((r) => setTimeout(r, 2_500));
+
+      const failed = await callBridgeTool(harness.client, 'tesseron__claim_session', {
+        code: 'XXXX-99',
+      });
+      expect(failed.isError).toBe(true);
+      expect(failed.text).toContain('CCCC-44');
+      expect(failed.text).toContain('mistypeapp');
+    } finally {
+      await harness.cleanup();
+    }
+  });
+});
+
 describe('Tool surface modes', () => {
   async function buildBridge(toolSurface: 'dynamic' | 'meta' | 'both'): Promise<{
     gateway: TesseronGateway;
@@ -776,6 +967,7 @@ describe('Tool surface modes', () => {
       expect(names).not.toContain('tesseron__list_actions');
       expect(names).not.toContain('tesseron__invoke_action');
       expect(names).not.toContain('tesseron__read_resource');
+      expect(names).not.toContain('tesseron__list_pending_claims');
     } finally {
       await cleanup();
     }
@@ -790,6 +982,7 @@ describe('Tool surface modes', () => {
       expect(names).toContain('tesseron__list_actions');
       expect(names).toContain('tesseron__invoke_action');
       expect(names).toContain('tesseron__read_resource');
+      expect(names).toContain('tesseron__list_pending_claims');
       expect(names).not.toContain('modeapp__ping');
       // dispatcher still works even though the per-app tool isn't listed
       const dispatched = await c.request(
@@ -817,6 +1010,7 @@ describe('Tool surface modes', () => {
       expect(names).toContain('tesseron__list_actions');
       expect(names).toContain('tesseron__invoke_action');
       expect(names).toContain('tesseron__read_resource');
+      expect(names).toContain('tesseron__list_pending_claims');
       expect(names).toContain('modeapp__ping');
     } finally {
       await cleanup();

--- a/packages/mcp/test/integration.test.ts
+++ b/packages/mcp/test/integration.test.ts
@@ -777,7 +777,10 @@ describe('Pending claim recovery (tesseron#69)', () => {
     args: unknown,
   ): Promise<{ text: string; isError: boolean }> {
     const result = await c.request(
-      { method: 'tools/call', params: { name, arguments: (args ?? {}) as Record<string, unknown> } },
+      {
+        method: 'tools/call',
+        params: { name, arguments: (args ?? {}) as Record<string, unknown> },
+      },
       CallToolResultSchema,
     );
     const text = result.content.map((p) => (p.type === 'text' ? p.text : `[${p.type}]`)).join('');
@@ -945,7 +948,12 @@ describe('Pending claim recovery (tesseron#69)', () => {
       const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
       expect(result.isError).toBe(false);
       const payload = JSON.parse(result.text) as {
-        pending_claims: Array<{ code: string; app_id: string; app_name: string; instance_id?: string }>;
+        pending_claims: Array<{
+          code: string;
+          app_id: string;
+          app_name: string;
+          instance_id?: string;
+        }>;
       };
       const entry = payload.pending_claims.find((c) => c.code === 'DDDD-55');
       expect(entry, 'entry should be present').toBeTruthy();
@@ -987,7 +995,12 @@ describe('Pending claim recovery (tesseron#69)', () => {
       const result = await callBridgeTool(harness.client, 'tesseron__list_pending_claims', {});
       expect(result.isError).toBe(false);
       const payload = JSON.parse(result.text) as {
-        pending_claims: Array<{ code: string; app_id: string; source: string; instance_id?: string }>;
+        pending_claims: Array<{
+          code: string;
+          app_id: string;
+          source: string;
+          instance_id?: string;
+        }>;
       };
       const entry = payload.pending_claims.find((c) => c.code === 'EEEE-66');
       expect(entry).toBeTruthy();

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19504,14 +19504,17 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
   /**
    * Cache mapping a host-minted manifest's `appName` (filesystem-friendly,
    * usually the package name — e.g. `"react-todo"`) to the SDK-side `app.id`
-   * (the prefix on per-app MCP tools — e.g. `"todos"`) learned at v3 bind
-   * time. Used by {@link getPendingClaims} so a post-recovery list surfaces
-   * the same `app_id` an agent would see on per-app tool names; lets the
-   * agent's `<app_id>__<action>` cache match the new pending entry without
-   * a user round-trip. Lives for the gateway process — a stale entry only
-   * costs the agent a one-shot wrong app_id, which still recovers because
-   * `tesseron__claim_session` keys off the code, not the app id. See
-   * tesseron#69.
+   * (the prefix on per-app MCP tools — e.g. `"todos"`). Populated in the
+   * host-mint hello handler when the SDK reports its real `app.id`. Used by
+   * {@link getPendingClaims} so a post-recovery list surfaces the same
+   * `app_id` an agent would see on per-app tool names; lets the agent's
+   * `<app_id>__<action>` cache match the new pending entry without a user
+   * round-trip. Lives for the gateway process — a stale entry only costs
+   * the agent a one-shot wrong app_id, which still recovers because
+   * `tesseron__claim_session` keys off the code, not the app id. Two SDKs
+   * with the same `appName` (e.g. two worktrees of the same package) will
+   * stomp each other's entry; the `instanceId` field on `PendingClaim`
+   * gives the agent a disambiguator. See tesseron#69.
    */
   manifestAppNameToAppId = /* @__PURE__ */ new Map();
   /**
@@ -19791,10 +19794,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
   /**
    * Snapshot of every claim code the gateway can currently redeem. Combines:
    *
-   * - **Gateway-minted (legacy):** sessions that completed `tesseron/hello`
-   *   but haven't been claimed yet — entries from {@link pendingClaims}
-   *   joined to their {@link Session} for app metadata.
-   * - **Host-minted (`@tesseron/vite@2.2.0+` / `@tesseron/server` host-mint):**
+   * - **Gateway-minted:** sessions that completed `tesseron/hello` but
+   *   haven't been claimed yet — entries from {@link pendingClaims} joined
+   *   to their {@link Session} for app metadata.
+   * - **Host-minted (`@tesseron/vite` / `@tesseron/server` host-mint):**
    *   manifests under `~/.tesseron/instances/` with `helloHandledByHost: true`
    *   and a `hostMintedClaim` whose `boundAgent` is `null` and whose
    *   `expiresAt` (when present) hasn't elapsed.
@@ -19822,7 +19825,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       const minted = manifest.hostMintedClaim;
       if (!minted) continue;
       if (minted.boundAgent !== null) continue;
-      if (minted.expiresAt !== void 0 && minted.expiresAt < now) continue;
+      if (minted.expiresAt !== void 0 && (!Number.isFinite(minted.expiresAt) || minted.expiresAt < now)) {
+        continue;
+      }
+      if (!Number.isFinite(minted.mintedAt)) continue;
       const cachedAppId = this.manifestAppNameToAppId.get(manifest.appName);
       out.push({
         code: minted.code,
@@ -19830,6 +19836,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
         appName: manifest.appName,
         mintedAt: minted.mintedAt,
         source: "host-minted",
+        instanceId: manifest.instanceId,
         ...minted.expiresAt !== void 0 ? { expiresAt: minted.expiresAt } : {}
       });
     }
@@ -20186,6 +20193,10 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
         const boundManifest = this.hostMintedInstances.get(bindContext.instanceId);
         if (boundManifest) {
           this.manifestAppNameToAppId.set(boundManifest.appName, helloParams.app.id);
+        } else {
+          logToStderr(
+            `[tesseron] cache miss: host-mint manifest for instance ${bindContext.instanceId} evicted before bind handler ran \u2014 manifestAppName\u2192appId mapping skipped`
+          );
         }
         logToStderr(
           `[tesseron] host-mint session "${helloParams.app.name}" (${sessionId2}) \u2014 bound to claim code ${bindContext.code}`
@@ -26133,6 +26144,7 @@ var META_TOOL_LIST_PENDING_CLAIMS = "tesseron__list_pending_claims";
 var PREFIX_SEPARATOR = "__";
 var RESOURCE_SCHEME = "tesseron:";
 var DEFAULT_SERVER_NAME = "tesseron";
+var PENDING_CLAIM_PREVIEW_MAX = 3;
 var CLAIM_TOOL = {
   name: META_TOOL_CLAIM_SESSION,
   description: 'Claim a pending Tesseron session by its 6-character code (format: XXXX-XX) so its actions appear as MCP tools. Web apps display this code in their UI when the user clicks "Connect Claude".',
@@ -26615,6 +26627,7 @@ var McpAgentBridge = class {
         minted_at: c.mintedAt,
         minted_at_iso: new Date(c.mintedAt).toISOString(),
         source: c.source,
+        ...c.instanceId !== void 0 ? { instance_id: c.instanceId } : {},
         ...c.expiresAt !== void 0 ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() } : {}
       })),
       next_step: `Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.`
@@ -26633,15 +26646,32 @@ var McpAgentBridge = class {
    * `appId` that has no claimed session — the most common cause is that
    * the prior session was invalidated mid-conversation (browser tab
    * refresh, dev-server reload, `tesseron/resume` failure) and the agent
-   * still holds the cached app id from before. Mentions the recovery
-   * tool by name so the agent doesn't have to guess. See tesseron#69.
+   * still holds the cached app id from before. See tesseron#69.
+   *
+   * Wrapped in try/catch so a malformed manifest that would otherwise
+   * crash {@link TesseronGateway.getPendingClaims} still leaves the agent
+   * with the original "no claimed session" hint instead of swallowing it
+   * inside a JSON-RPC InternalError.
    */
   noClaimedSessionMessage(appId) {
-    const pending = this.gateway.getPendingClaims();
+    let pending = [];
+    try {
+      pending = this.gateway.getPendingClaims();
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      void this.server.sendLoggingMessage({
+        level: "warning",
+        logger: "tesseron.recovery",
+        data: {
+          message: `pending-claims enrichment failed while building no-claimed-session error: ${reason}`
+        }
+      }).catch(() => {
+      });
+    }
     const matching = pending.filter((c) => c.appId === appId);
     if (matching.length > 0) {
       const codes = matching.map((c) => c.code).join(", ");
-      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`;
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry.`;
     }
     if (pending.length > 0) {
       return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure). The gateway has ${pending.length} pending claim(s) for other apps \u2014 call ${META_TOOL_LIST_PENDING_CLAIMS} to see them, or ask the user to reload "${appId}" and read its new claim code from the app UI.`;
@@ -26700,11 +26730,26 @@ var McpAgentBridge = class {
           `Claim code "${code.toUpperCase()}" was minted at ${minted} by gateway pid ${foreign.gatewayPid}, which is no longer running. Have the web app reconnect to mint a fresh code, then claim that one.`
         );
       }
-      const pending = this.gateway.getPendingClaims();
+      let pending = [];
+      try {
+        pending = this.gateway.getPendingClaims();
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        void this.server.sendLoggingMessage({
+          level: "warning",
+          logger: "tesseron.recovery",
+          data: {
+            message: `pending-claims enrichment failed while building no-pending-session error: ${reason}`
+          }
+        }).catch(() => {
+        });
+      }
       if (pending.length > 0) {
-        const summary = pending.map((c) => `"${c.code}" (app "${c.appId}", source ${c.source})`).join("; ");
+        const preview = pending.slice(0, PENDING_CLAIM_PREVIEW_MAX);
+        const summary = preview.map((c) => `"${c.code}" (app "${c.appId}", source ${c.source})`).join("; ");
+        const overflowSuffix = pending.length > preview.length ? ` (showing the ${preview.length} most-recent of ${pending.length}; call ${META_TOOL_LIST_PENDING_CLAIMS} for the full list)` : "";
         return errorResult(
-          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}. If the user typed the wrong code, retry with one of those. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`
+          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}${overflowSuffix}. If the user typed the wrong code, retry with one of those.`
         );
       }
       return errorResult(

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -19502,6 +19502,19 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
    */
   hostMintedClaimResolvers = /* @__PURE__ */ new Map();
   /**
+   * Cache mapping a host-minted manifest's `appName` (filesystem-friendly,
+   * usually the package name — e.g. `"react-todo"`) to the SDK-side `app.id`
+   * (the prefix on per-app MCP tools — e.g. `"todos"`) learned at v3 bind
+   * time. Used by {@link getPendingClaims} so a post-recovery list surfaces
+   * the same `app_id` an agent would see on per-app tool names; lets the
+   * agent's `<app_id>__<action>` cache match the new pending entry without
+   * a user round-trip. Lives for the gateway process — a stale entry only
+   * costs the agent a one-shot wrong app_id, which still recovers because
+   * `tesseron__claim_session` keys off the code, not the app id. See
+   * tesseron#69.
+   */
+  manifestAppNameToAppId = /* @__PURE__ */ new Map();
+  /**
    * Write a discovery / dial-outcome event to stderr (kept for grep-ability)
    * and emit it as `'gateway-log'` so any attached MCP bridge can forward it
    * to the connected agent via `notifications/message`. Used by the discovery
@@ -19774,6 +19787,54 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
   /** Sessions that have completed `tesseron/hello` but are waiting for a claim code. */
   getPendingSessions() {
     return Array.from(this.sessions.values()).filter((s) => !s.claimed);
+  }
+  /**
+   * Snapshot of every claim code the gateway can currently redeem. Combines:
+   *
+   * - **Gateway-minted (legacy):** sessions that completed `tesseron/hello`
+   *   but haven't been claimed yet — entries from {@link pendingClaims}
+   *   joined to their {@link Session} for app metadata.
+   * - **Host-minted (`@tesseron/vite@2.2.0+` / `@tesseron/server` host-mint):**
+   *   manifests under `~/.tesseron/instances/` with `helloHandledByHost: true`
+   *   and a `hostMintedClaim` whose `boundAgent` is `null` and whose
+   *   `expiresAt` (when present) hasn't elapsed.
+   *
+   * Surfaced through the MCP bridge as `tesseron__list_pending_claims` so an
+   * agent whose previously-claimed session was invalidated (browser refresh,
+   * dev-server reload, resume failure) can self-discover the new claim code
+   * instead of asking the user to read it from the app UI. See tesseron#69.
+   */
+  getPendingClaims() {
+    const out = [];
+    for (const [code, sessionId] of this.pendingClaims) {
+      const session = this.sessions.get(sessionId);
+      if (!session) continue;
+      out.push({
+        code,
+        appId: session.app.id,
+        appName: session.app.name,
+        mintedAt: session.mintedAt,
+        source: "gateway-minted"
+      });
+    }
+    const now = Date.now();
+    for (const manifest of this.hostMintedInstances.values()) {
+      const minted = manifest.hostMintedClaim;
+      if (!minted) continue;
+      if (minted.boundAgent !== null) continue;
+      if (minted.expiresAt !== void 0 && minted.expiresAt < now) continue;
+      const cachedAppId = this.manifestAppNameToAppId.get(manifest.appName);
+      out.push({
+        code: minted.code,
+        appId: cachedAppId ?? manifest.appName,
+        appName: manifest.appName,
+        mintedAt: minted.mintedAt,
+        source: "host-minted",
+        ...minted.expiresAt !== void 0 ? { expiresAt: minted.expiresAt } : {}
+      });
+    }
+    out.sort((a, b) => b.mintedAt - a.mintedAt);
+    return out;
   }
   /**
    * Look up the cross-gateway breadcrumb for `code` in `~/.tesseron/claims/`.
@@ -20063,6 +20124,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           claimCode: closedSession.claimCode,
           claimed: closedSession.claimed,
           claimedAt: closedSession.claimedAt,
+          mintedAt: closedSession.mintedAt,
           evictTimer
         });
       }
@@ -20117,9 +20179,14 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
           claimCode: bindContext.code,
           claimed: true,
           claimedAt,
+          mintedAt: claimedAt,
           resumeToken: resumeToken2
         };
         this.sessions.set(sessionId2, session);
+        const boundManifest = this.hostMintedInstances.get(bindContext.instanceId);
+        if (boundManifest) {
+          this.manifestAppNameToAppId.set(boundManifest.appName, helloParams.app.id);
+        }
         logToStderr(
           `[tesseron] host-mint session "${helloParams.app.name}" (${sessionId2}) \u2014 bound to claim code ${bindContext.code}`
         );
@@ -20163,6 +20230,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
       const sessionId = generateSessionId();
       const resumeToken = generateResumeToken();
       const claimCode = generateClaimCode();
+      const mintedAt = Date.now();
       session = {
         id: sessionId,
         app: helloParams.app,
@@ -20173,6 +20241,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
         capabilities: helloParams.capabilities,
         claimCode,
         claimed: false,
+        mintedAt,
         resumeToken
       };
       this.sessions.set(sessionId, session);
@@ -20184,7 +20253,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
         appId: helloParams.app.id,
         appName: helloParams.app.name,
         gatewayPid: process.pid,
-        mintedAt: Date.now()
+        mintedAt
       });
       logToStderr(
         `[tesseron] new session "${helloParams.app.name}" (${sessionId}) \u2014 claim code: ${claimCode}`
@@ -20287,6 +20356,7 @@ var TesseronGateway = class extends import_node_events.EventEmitter {
         claimCode: zombie.claimCode,
         claimed: zombie.claimed,
         claimedAt: zombie.claimedAt,
+        mintedAt: zombie.mintedAt,
         resumeToken: rotatedResumeToken
       };
       this.sessions.set(zombie.id, session);
@@ -26059,6 +26129,7 @@ var META_TOOL_CLAIM_SESSION = "tesseron__claim_session";
 var META_TOOL_LIST_ACTIONS = "tesseron__list_actions";
 var META_TOOL_INVOKE_ACTION = "tesseron__invoke_action";
 var META_TOOL_READ_RESOURCE = "tesseron__read_resource";
+var META_TOOL_LIST_PENDING_CLAIMS = "tesseron__list_pending_claims";
 var PREFIX_SEPARATOR = "__";
 var RESOURCE_SCHEME = "tesseron:";
 var DEFAULT_SERVER_NAME = "tesseron";
@@ -26127,6 +26198,15 @@ var META_DISPATCHER_TOOLS = [
         }
       },
       required: ["app_id", "name"],
+      additionalProperties: false
+    }
+  },
+  {
+    name: META_TOOL_LIST_PENDING_CLAIMS,
+    description: 'List every claim code the gateway can currently redeem (gateway-minted sessions waiting for claim, plus host-minted manifests with an unconsumed code). Recovery path when a previously-claimed session was invalidated mid-conversation (browser refresh, dev-server reload, resume failure) and tools/call returns "No claimed session found": call this, pick the entry whose app_id matches, then call tesseron__claim_session({ code }) to re-pair without asking the user to read the new code from the app UI. Returns an empty list when no claim is pending \u2014 in that case, ask the user to reload the app.',
+    inputSchema: {
+      type: "object",
+      properties: {},
       additionalProperties: false
     }
   }
@@ -26292,6 +26372,9 @@ var McpAgentBridge = class {
       if (name === META_TOOL_LIST_ACTIONS) {
         return this.handleListActions();
       }
+      if (name === META_TOOL_LIST_PENDING_CLAIMS) {
+        return this.handleListPendingClaims();
+      }
       if (name === META_TOOL_READ_RESOURCE) {
         return this.handleReadResource(args);
       }
@@ -26320,7 +26403,7 @@ var McpAgentBridge = class {
       }
       const session = this.latestClaimedByApp(appId);
       if (!session) {
-        return errorResult(`No claimed session found for app "${appId}".`);
+        return errorResult(this.noClaimedSessionMessage(appId));
       }
       if (progressToken !== void 0) {
         this.progressCursors.set(progressToken, 0);
@@ -26503,6 +26586,68 @@ var McpAgentBridge = class {
       ]
     };
   }
+  /**
+   * Build the body of `tesseron__list_pending_claims`. Each entry has the
+   * shape an agent needs to call `tesseron__claim_session({ code })` next:
+   * the code itself, the app id (matches the `<app_id>__<action>` tool
+   * prefix), the human display name, the source mint flow, and the unix
+   * timestamps for filtering. The empty-list branch returns advisory text
+   * — strict programmatic agents key off `pending_claims.length` while
+   * looser ones still get a helpful instruction. See tesseron#69.
+   */
+  handleListPendingClaims() {
+    const claims = this.gateway.getPendingClaims();
+    if (claims.length === 0) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: "No pending claims. The gateway has nothing to redeem right now \u2014 ask the user to (re)open the app and read the new claim code from its UI, then call tesseron__claim_session({ code })."
+          }
+        ]
+      };
+    }
+    const payload = {
+      pending_claims: claims.map((c) => ({
+        code: c.code,
+        app_id: c.appId,
+        app_name: c.appName,
+        minted_at: c.mintedAt,
+        minted_at_iso: new Date(c.mintedAt).toISOString(),
+        source: c.source,
+        ...c.expiresAt !== void 0 ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() } : {}
+      })),
+      next_step: `Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.`
+    };
+    return {
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(payload, null, 2)
+        }
+      ]
+    };
+  }
+  /**
+   * Recovery hint surfaced when an action / resource call lands on an
+   * `appId` that has no claimed session — the most common cause is that
+   * the prior session was invalidated mid-conversation (browser tab
+   * refresh, dev-server reload, `tesseron/resume` failure) and the agent
+   * still holds the cached app id from before. Mentions the recovery
+   * tool by name so the agent doesn't have to guess. See tesseron#69.
+   */
+  noClaimedSessionMessage(appId) {
+    const pending = this.gateway.getPendingClaims();
+    const matching = pending.filter((c) => c.appId === appId);
+    if (matching.length > 0) {
+      const codes = matching.map((c) => c.code).join(", ");
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and a fresh code is now pending: ${codes}. Call ${META_TOOL_CLAIM_SESSION}({ code: "<one of these>" }) to re-pair, then retry. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`;
+    }
+    if (pending.length > 0) {
+      return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure). The gateway has ${pending.length} pending claim(s) for other apps \u2014 call ${META_TOOL_LIST_PENDING_CLAIMS} to see them, or ask the user to reload "${appId}" and read its new claim code from the app UI.`;
+    }
+    return `No claimed session found for app "${appId}". The previous session was likely lost (browser refresh, dev-server reload, or a tesseron/resume failure) and no pending claim is waiting. Ask the user to reload the app, then call ${META_TOOL_CLAIM_SESSION}({ code }) with the new claim code shown in the app UI. ${META_TOOL_LIST_PENDING_CLAIMS} returns any newly-pending claims if the user reloads while you wait.`;
+  }
   async handleReadResource(args) {
     const appId = typeof args["app_id"] === "string" ? args["app_id"] : "";
     const resourceName = typeof args["name"] === "string" ? args["name"] : "";
@@ -26513,7 +26658,7 @@ var McpAgentBridge = class {
     }
     const session = this.latestClaimedByApp(appId);
     if (!session) {
-      return errorResult(`No claimed session found for app "${appId}".`);
+      return errorResult(this.noClaimedSessionMessage(appId));
     }
     if (!session.resources.some((r) => r.name === resourceName)) {
       return errorResult(
@@ -26555,8 +26700,15 @@ var McpAgentBridge = class {
           `Claim code "${code.toUpperCase()}" was minted at ${minted} by gateway pid ${foreign.gatewayPid}, which is no longer running. Have the web app reconnect to mint a fresh code, then claim that one.`
         );
       }
+      const pending = this.gateway.getPendingClaims();
+      if (pending.length > 0) {
+        const summary = pending.map((c) => `"${c.code}" (app "${c.appId}", source ${c.source})`).join("; ");
+        return errorResult(
+          `No pending session found for code "${code}". The gateway currently has ${pending.length} other pending claim(s): ${summary}. If the user typed the wrong code, retry with one of those. ${META_TOOL_LIST_PENDING_CLAIMS} returns the same data with timestamps.`
+        );
+      }
       return errorResult(
-        `No pending session found for code "${code}". Has the web app connected, and is the code current?`
+        `No pending session found for code "${code}". Has the web app connected, and is the code current? Call ${META_TOOL_LIST_PENDING_CLAIMS} to see what the gateway currently has pending; if empty, ask the user to reload the app.`
       );
     }
     const toolNames = session.actions.map((a) => `${session.app.id}${PREFIX_SEPARATOR}${a.name}`);

--- a/plugin/server/index.cjs
+++ b/plugin/server/index.cjs
@@ -26630,7 +26630,7 @@ var McpAgentBridge = class {
         ...c.instanceId !== void 0 ? { instance_id: c.instanceId } : {},
         ...c.expiresAt !== void 0 ? { expires_at: c.expiresAt, expires_at_iso: new Date(c.expiresAt).toISOString() } : {}
       })),
-      next_step: `Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at.`
+      next_step: "Pick the entry whose app_id matches the app you were operating on, then call tesseron__claim_session({ code }) with its code. If multiple entries match, prefer the one with the largest minted_at."
     };
     return {
       content: [


### PR DESCRIPTION
Closes #69.

## The problem

When a browser session is replaced by a fresh-hello (after the `@tesseron/react` resume race per #68, a manual refresh, or any other path that invalidates the prior session), agent-side MCP tools that hold a cached claim previously got a flat error with no actionable recovery path:

```
Error: No claimed session found for app "tesseron_video_editor".
```

The agent's natural reflex — re-claiming with the previously-known code — also failed:

```
Error: No pending session found for code "KSMU-YY". Has the web app connected, and is the code current?
```

…leaving the agent stuck. The user-facing recovery is to read the new claim code from the browser tab and paste it into the chat, which is a context switch the agent could short-circuit if the gateway gave it a useful hint.

## What this PR does

Implements options 1 and 2 from #69. Option 3 (auto-rebind cached claims) is deliberately skipped — the issue itself flagged it as the speculative one because there's no agent-trustworthy identity for "this is the same app the agent paired with earlier."

### `tesseron__list_pending_claims` (new meta tool)

Returns every claim code the gateway can currently redeem:
- **Gateway-minted (legacy `@tesseron/mcp` < 2.4.0 path):** sessions that completed `tesseron/hello` but haven't been claimed — joined to their `Session` for app metadata.
- **Host-minted (`@tesseron/vite@2.2.0+` / `@tesseron/server` host-mint):** manifests under `~/.tesseron/instances/` with `helloHandledByHost: true` whose `boundAgent` is `null` and whose `expiresAt` (when present) hasn't elapsed.

Each entry carries `code`, `app_id`, `app_name`, `minted_at` (+ ISO), `source`, optional `expires_at` (+ ISO). Sorted newest-first. Surfaced in the default `both` and `meta` tool surfaces; suppressed in `dynamic`.

### Improved error messages

- `tesseron__invoke_action` / `tesseron__read_resource` "No claimed session found for app X" now: (a) explains the likely cause (refresh / dev-server reload / resume failure), (b) inlines the pending claim code(s) for the same app id when present, (c) names `tesseron__list_pending_claims` as the discovery tool.
- `tesseron__claim_session` "No pending session found for code" now lists other pending claims so a typo doesn't dead-end.

### `manifestAppName → app.id` cache (subtle but critical)

The host-minted manifest's `appName` (e.g. `"react-todo"`, the package name) is **not** the same string as the SDK's `app.id` (e.g. `"todos"`, the prefix on per-app MCP tools). Without a fix, `list_pending_claims` would report `app_id: "react-todo"` and the agent's cached `<app_id>__<action>` cache (keyed on `"todos"`) would never match.

The gateway now remembers the `manifest.appName → real app.id` mapping at v3 bind time and reports the cached real app id on subsequent `list_pending_claims` calls. Stale entries only cost one wrong app_id (the agent recovers anyway because `tesseron__claim_session` keys off the code, not the app id).

This bug was caught by the end-to-end validation, not by unit tests — exactly the kind of issue that hides when you mock the SDK side.

### Plumbing

- `Session.mintedAt` and `ZombieSession.mintedAt` added (preserved across resume) so `getPendingClaims()` has a stable sort key without re-reading the on-disk breadcrumb.
- `TesseronGateway.getPendingClaims()` is the new public method the bridge consumes; returns `PendingClaim[]` (also exported for embedders).

## Test plan

- [x] Unit tests added in `packages/mcp/test/integration.test.ts` (4 new tests: empty + populated `list_pending_claims`, expired-host-minted filtering, wrong-code claim path with a pending manifest discovered via `watchInstances`). Bridge harness pre-creates `~/.tesseron/instances/` so `fs.watch` attaches before manifest writes.
- [x] All 95 MCP tests pass.
- [x] Repo-wide typecheck clean (`pnpm typecheck`).
- [x] Repo-wide test pass (`pnpm test`).
- [x] Plugin bundle rebuilt (`plugin/server/index.cjs`) — required for CI per project convention.
- [x] **End-to-end validation against real Chrome + rebuilt `plugin/server/index.cjs`:**
  - Opened `examples/react-todo` in real Chrome via `claude-in-chrome`.
  - `tesseron__list_pending_claims` exposed in tools/list.
  - Discovered the live browser tab's claim code; first claim succeeded.
  - Pre-refresh `todos__addTodo` succeeded — todo "pre-refresh todo" rendered in React DOM.
  - Refreshed the browser via `window.location.reload()`.
  - Post-refresh `tesseron__list_pending_claims` correctly reported `app_id: "todos"` (not `"react-todo"` — proves the cache mapping works).
  - Cached `todos__addTodo` invocation returned the new improved error: `"No claimed session found for app "todos". The previous session was likely lost (...) and a fresh code is now pending: 44D9-W9, ... Call tesseron__claim_session({ code: "<one of these>" }) to re-pair, then retry."`
  - `tesseron__claim_session` with the new code succeeded.
  - Post-recovery `todos__addTodo` succeeded — "post-recovery todo" actually rendered in the React DOM (verified via `document.body.innerText`).
  - End-to-end harness preserved at `packages/mcp/scripts/e2e-issue-69.mjs` for future debugging.

## Files

- `packages/mcp/src/gateway.ts` — `PendingClaim`, `getPendingClaims()`, `manifestAppNameToAppId` cache, `Session.mintedAt` plumbing
- `packages/mcp/src/mcp-bridge.ts` — `tesseron__list_pending_claims` meta tool, recovery hints in error messages
- `packages/mcp/src/session.ts` — `Session.mintedAt`
- `packages/mcp/test/integration.test.ts` — 4 new tests for the recovery flow
- `packages/mcp/scripts/e2e-issue-69.mjs` — reproducible end-to-end harness for the issue
- `docs/src/content/docs/sdk/typescript/mcp.md` — documents the new meta tool
- `plugin/server/index.cjs` — rebuilt bundle (CI requirement)
- `.changeset/agent-recovery-pending-claims-issue-69.md` — `@tesseron/mcp` minor bump
