### PR TITLE
feat: multi-platform AI coding assistant support

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,19 @@
+{
+  "name": "tesseron",
+  "interface": {
+    "displayName": "Tesseron Plugins"
+  },
+  "plugins": [
+    {
+      "name": "tesseron",
+      "source": {
+        "source": "local",
+        "path": "../../plugin"
+      },
+      "policy": {
+        "installation": "AVAILABLE"
+      },
+      "category": "Integration"
+    }
+  ]
+}

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,3 +1,5 @@
+@../AGENTS.md
+
 # Plugin & Skill Strategy Guide
 
 Strategies for the plugins enabled on this machine, at both user-level (`~/.claude/settings.json`) and project-level (`.claude/settings.json`). Written to keep future sessions from re-deriving what each plugin does and how to compose them. All claims are grounded in each plugin's own files; verify anything that looks stale before acting on it.

--- a/.continue/rules/tesseron.md
+++ b/.continue/rules/tesseron.md
@@ -1,0 +1,30 @@
+---
+name: Tesseron
+alwaysApply: true
+---
+
+Tesseron monorepo — TypeScript SDK + MCP gateway for typed web-app actions over WebSocket (no browser automation).
+
+## Packages (packages/)
+- `core` — protocol types, action builder (zero deps)
+- `web` / `server` — browser and Node SDKs
+- `react` / `svelte` / `vue` — framework adapters
+- `vite` — Vite plugin (dev bridge)
+- `mcp` — MCP gateway CLI
+- `docs-mcp` — docs as MCP server
+- `create-tesseron` — scaffolder
+
+## Development (pnpm + Turbo)
+- `pnpm install` — install deps
+- `pnpm build` — build all packages (tsup; run before tests)
+- `pnpm typecheck` — TypeScript check
+- `pnpm test` — Vitest
+- `pnpm lint` — Biome linter
+- `pnpm format` — Biome formatter
+- `pnpm build:plugin` — rebuild plugin/server/index.cjs
+
+## Conventions
+- TypeScript 5.7, Node 20+
+- Biome: 2-space indent, line-width 100, single quotes, trailing commas
+- Typed actions only — no browser automation
+- Branch: `main`

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,5 @@
+{
+  "context": {
+    "fileName": ["GEMINI.md"]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,25 @@
+Tesseron monorepo — TypeScript SDK + MCP gateway for typed web-app actions over WebSocket (no browser automation).
+
+## Packages (packages/)
+- `core` — protocol types, action builder (zero deps)
+- `web` / `server` — browser and Node SDKs
+- `react` / `svelte` / `vue` — framework adapters
+- `vite` — Vite plugin (dev bridge)
+- `mcp` — MCP gateway CLI
+- `docs-mcp` — docs as MCP server
+- `create-tesseron` — scaffolder
+
+## Development (pnpm + Turbo)
+- `pnpm install` — install deps
+- `pnpm build` — build all packages (tsup; run before tests)
+- `pnpm typecheck` — TypeScript check
+- `pnpm test` — Vitest
+- `pnpm lint` — Biome linter
+- `pnpm format` — Biome formatter
+- `pnpm build:plugin` — rebuild plugin/server/index.cjs
+
+## Conventions
+- TypeScript 5.7, Node 20+
+- Biome: 2-space indent, line-width 100, single quotes, trailing commas
+- Typed actions only — no browser automation
+- Branch: `main`

--- a/.kiro/steering/tesseron.md
+++ b/.kiro/steering/tesseron.md
@@ -1,0 +1,29 @@
+---
+inclusion: always
+---
+
+Tesseron monorepo — TypeScript SDK + MCP gateway for typed web-app actions over WebSocket (no browser automation).
+
+## Packages (packages/)
+- `core` — protocol types, action builder (zero deps)
+- `web` / `server` — browser and Node SDKs
+- `react` / `svelte` / `vue` — framework adapters
+- `vite` — Vite plugin (dev bridge)
+- `mcp` — MCP gateway CLI
+- `docs-mcp` — docs as MCP server
+- `create-tesseron` — scaffolder
+
+## Development (pnpm + Turbo)
+- `pnpm install` — install deps
+- `pnpm build` — build all packages (tsup; run before tests)
+- `pnpm typecheck` — TypeScript check
+- `pnpm test` — Vitest
+- `pnpm lint` — Biome linter
+- `pnpm format` — Biome formatter
+- `pnpm build:plugin` — rebuild plugin/server/index.cjs
+
+## Conventions
+- TypeScript 5.7, Node 20+
+- Biome: 2-space indent, line-width 100, single quotes, trailing commas
+- Typed actions only — no browser automation
+- Branch: `main`

--- a/.opencode/package.json
+++ b/.opencode/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@opencode-ai/plugin": "latest"
+  }
+}

--- a/.opencode/plugins/tesseron.ts
+++ b/.opencode/plugins/tesseron.ts
@@ -1,0 +1,5 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+export const TesseronPlugin: Plugin = async (_ctx) => {
+  return {}
+}

--- a/.opencode/plugins/tesseron.ts
+++ b/.opencode/plugins/tesseron.ts
@@ -1,5 +1,5 @@
-import type { Plugin } from "@opencode-ai/plugin"
+import type { Plugin } from '@opencode-ai/plugin';
 
 export const TesseronPlugin: Plugin = async (_ctx) => {
-  return {}
-}
+  return {};
+};

--- a/.windsurf/rules/tesseron.md
+++ b/.windsurf/rules/tesseron.md
@@ -1,0 +1,29 @@
+---
+trigger: always_on
+---
+
+Tesseron monorepo — TypeScript SDK + MCP gateway for typed web-app actions over WebSocket (no browser automation).
+
+## Packages (packages/)
+- `core` — protocol types, action builder (zero deps)
+- `web` / `server` — browser and Node SDKs
+- `react` / `svelte` / `vue` — framework adapters
+- `vite` — Vite plugin (dev bridge)
+- `mcp` — MCP gateway CLI
+- `docs-mcp` — docs as MCP server
+- `create-tesseron` — scaffolder
+
+## Development (pnpm + Turbo)
+- `pnpm install` — install deps
+- `pnpm build` — build all packages (tsup; run before tests)
+- `pnpm typecheck` — TypeScript check
+- `pnpm test` — Vitest
+- `pnpm lint` — Biome linter
+- `pnpm format` — Biome formatter
+- `pnpm build:plugin` — rebuild plugin/server/index.cjs
+
+## Conventions
+- TypeScript 5.7, Node 20+
+- Biome: 2-space indent, line-width 100, single quotes, trailing commas
+- Typed actions only — no browser automation
+- Branch: `main`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Tesseron Monorepo
+
+Tesseron is a protocol SDK and MCP gateway that lets any web app expose typed actions to AI agents (Claude, Cursor, etc.) over WebSocket — no browser automation, no scraping, no Playwright.
+
+## How it works
+- Client apps register typed actions via an SDK package (`@tesseron/web`, `/react`, `/svelte`, `/vue`, `/server`)
+- The MCP gateway (`@tesseron/mcp`) runs locally, discovers registered apps via `~/.tesseron/tabs/`, and exposes their actions as MCP tools
+- Reverse-connection architecture: the gateway is a pure WebSocket client — no fixed ports, no env vars required
+
+## Packages (`packages/`)
+- `core` — protocol types, action builder (zero deps)
+- `web` — browser SDK
+- `server` — Node SDK
+- `react` / `svelte` / `vue` — framework adapters (hooks/runes/composables)
+- `vite` — Vite plugin, bridges browser tabs to the gateway in dev
+- `mcp` — MCP gateway CLI
+- `docs-mcp` — Tesseron docs as an MCP server
+- `create-tesseron` — project scaffolder (`npm create tesseron@latest`)
+
+## Development
+- Package manager: pnpm (workspace) + Turbo
+- `pnpm install` — install deps
+- `pnpm build` — build all packages (tsup, Turbo-orchestrated; `^build` must run before tests)
+- `pnpm typecheck` — TypeScript check across all packages
+- `pnpm test` — Vitest (65 tests across core + mcp)
+- `pnpm lint` — Biome linter
+- `pnpm format` — Biome formatter
+- `pnpm build:plugin` — rebuild `plugin/server/index.cjs` after gateway changes
+
+## Conventions
+- TypeScript 5.7, Node 20+
+- Biome for lint + format: 2-space indent, line-width 100, single quotes, trailing commas, semicolons
+- Zod-style action schemas for all typed actions (`z.object({...})`)
+- No browser automation — typed actions via SDK only
+- Branch: `main`
+
+## Plugin (`plugin/`)
+Distributable AI coding assistant plugin. Contains skills (`framework`, `tesseron-dev`, `tesseron-docs`), subagents (`tesseron-explorer`, `tesseron-reviewer`), and a pre-built MCP server binary (`plugin/server/index.cjs`). Rebuild with `pnpm build:plugin` after gateway changes.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "tesseron",
+  "version": "2.5.1",
+  "description": "MCP gateway that lets any web app expose typed actions to AI agents over WebSocket. Includes a framework skill, a tesseron-docs skill for authoritative spec lookups, a tesseron-dev wiring skill, and explorer/reviewer subagents.",
+  "author": {
+    "name": "Kenny Vaneetvelde",
+    "email": "kenny.vaneetvelde@gmail.com"
+  },
+  "homepage": "https://github.com/BrainBlend-AI/tesseron",
+  "repository": "https://github.com/BrainBlend-AI/tesseron",
+  "license": "MIT",
+  "keywords": ["mcp", "tesseron", "web-sdk", "actions", "react", "svelte", "vue", "websocket", "typescript"],
+  "interface": {
+    "displayName": "Tesseron",
+    "shortDescription": "Typed live-app actions for AI agents over WebSocket.",
+    "longDescription": "MCP gateway with reverse-connection architecture. No fixed ports, no env vars. Expose any web app's actions as MCP tools. Includes framework, tesseron-docs, and tesseron-dev skills plus isolated-context subagents.",
+    "developerName": "BrainBlend AI",
+    "category": "Integration",
+    "websiteURL": "https://github.com/BrainBlend-AI/tesseron"
+  },
+  "skills": "./skills/"
+}

--- a/plugin/.codex-plugin/plugin.json
+++ b/plugin/.codex-plugin/plugin.json
@@ -9,7 +9,17 @@
   "homepage": "https://github.com/BrainBlend-AI/tesseron",
   "repository": "https://github.com/BrainBlend-AI/tesseron",
   "license": "MIT",
-  "keywords": ["mcp", "tesseron", "web-sdk", "actions", "react", "svelte", "vue", "websocket", "typescript"],
+  "keywords": [
+    "mcp",
+    "tesseron",
+    "web-sdk",
+    "actions",
+    "react",
+    "svelte",
+    "vue",
+    "websocket",
+    "typescript"
+  ],
   "interface": {
     "displayName": "Tesseron",
     "shortDescription": "Typed live-app actions for AI agents over WebSocket.",


### PR DESCRIPTION
## Summary

- **AGENTS.md** — universal project context (Tesseron overview, packages, pnpm+Turbo commands, Biome conventions)
- **GEMINI.md** + `.gemini/settings.json` — Gemini CLI
- **`.github/copilot-instructions.md`** — GitHub Copilot (inline content)
- **`.windsurf/rules/tesseron.md`** — Windsurf (`trigger: always_on`)
- **`.kiro/steering/tesseron.md`** — Kiro (`inclusion: always`)
- **`.continue/rules/tesseron.md`** — Continue.dev (`alwaysApply: true`)
- **`.opencode/plugins/tesseron.ts`** — OpenCode (named export, auto-loaded from `.opencode/plugins/`)
- **`plugin/.codex-plugin/plugin.json`** — Codex plugin manifest alongside existing `.claude-plugin/` (shared `skills/` dir)
- **`.agents/plugins/marketplace.json`** — Codex repo marketplace
- **`.claude/CLAUDE.md`** — prepended `@../AGENTS.md` so Claude Code picks up shared context before the plugin strategy guide

No skill symlinks needed — `.agents/skills/` is the canonical path already read natively by Gemini CLI and Cursor.

## Test plan

- [ ] Open repo in Gemini CLI — verify AGENTS.md context loads
- [ ] Open repo in Cursor — verify AGENTS.md is picked up natively
- [ ] Verify `.agents/plugins/marketplace.json` is valid JSON
- [ ] Verify `plugin/.codex-plugin/plugin.json` is valid JSON
- [ ] Check `.claude/CLAUDE.md` starts with `@../AGENTS.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)