### PR TITLE
chore: drop Thanks-@login changelog cringe

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "BrainBlend-AI/tesseron" }],
+  "changelog": ["./custom-changelog.cjs", { "repo": "BrainBlend-AI/tesseron" }],
   "commit": false,
   "fixed": [
     [

--- a/.changeset/custom-changelog.cjs
+++ b/.changeset/custom-changelog.cjs
@@ -1,0 +1,32 @@
+/**
+ * Thin wrapper around `@changesets/changelog-github` that rewrites the
+ * sycophantic "Thanks @<login>!" credit to "by <Name>" using a small
+ * GitHub-login → display-name map, falling back to `by @<login>` for
+ * unmapped contributors. Solo-maintained repo today, but the fallback
+ * keeps the behavior sensible if anyone else ever lands a PR.
+ */
+const github = require('@changesets/changelog-github').default;
+
+const NAME_MAP = {
+  KennyVaneetvelde: 'Kenny',
+};
+
+function rewriteThanks(line) {
+  return line.replace(/ Thanks ([^!]+)!/g, (_match, users) => {
+    const rewritten = users.replace(
+      /\[@(\w[\w-]*)\]\(([^)]+)\)/g,
+      (_, login) => NAME_MAP[login] ?? `@${login}`,
+    );
+    return ` by ${rewritten}`;
+  });
+}
+
+module.exports = {
+  default: {
+    getDependencyReleaseLine: github.getDependencyReleaseLine,
+    getReleaseLine: async (changeset, type, options) => {
+      const line = await github.getReleaseLine(changeset, type, options);
+      return rewriteThanks(line);
+    },
+  },
+};


### PR DESCRIPTION
Solo-maintained repo. The default `@changesets/changelog-github` formatter prepends `Thanks @<login>!` to every entry — designed for OSS where contributors are external, looks silly when the maintainer is thanking themselves in the release notes.

Custom wrapper at `.changeset/custom-changelog.cjs` keeps the rest of `@changesets/changelog-github` (PR/commit links, issue linkifying) but rewrites `Thanks @login!` to `by <Display>` via a small login -> display name map, falling back to `by @<login>` for unmapped contributors. Future external contributors still get attribution; just not via fake gratitude.

## Summary

<!-- One or two sentences describing what changed and why. -->

## Type

<!-- Check one. -->

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Breaking change (requires a major bump)
- [ ] Docs / examples only
- [ ] Internal refactor / tooling (no user-facing change)

## Changeset

<!-- If this changes any published package, run `pnpm changeset` and commit the file. -->

- [ ] I added a changeset (or this PR is docs/examples/internal only)

## Checklist

- [ ] `pnpm typecheck` passes locally
- [ ] `pnpm test` passes locally
- [ ] `pnpm lint` passes locally
- [ ] Every commit is `Signed-off-by:` per the [DCO](../CONTRIBUTING.md)
