### PR TITLE
fix(ci): remove NODE_AUTH_TOKEN — trusted publishing is the only auth path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,9 +60,9 @@ jobs:
           title: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NODE_AUTH_TOKEN is only needed for the *first* publish of each
-          # package. Once trusted publishing is configured on npmjs.com for
-          # each @tesseron/* package, the OIDC token from `id-token: write`
-          # takes over and this secret can be removed.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Trusted publishing is configured on npmjs.com for every @tesseron/*
+          # package; the OIDC token from `id-token: write` is the auth path.
+          # NODE_AUTH_TOKEN must NOT be set — when both are present npm prefers
+          # the legacy token and (if it has been revoked or rotated away) fails
+          # the publish with E404 even though provenance signing succeeded.
           NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Trusted publishing is now configured on npmjs.com for every `@tesseron/*` package. When both `NODE_AUTH_TOKEN` and the OIDC token are present, npm prefers the legacy token; if that token has been rotated/revoked the publish fails with E404 even though OIDC provenance signing succeeded — which is exactly what's happening on PR #77's release run.

Dropping `NODE_AUTH_TOKEN` so OIDC is the only auth route. The `NPM_TOKEN` secret can be deleted from the repo settings after this merges (not strictly required, but tidier).

After merge, re-run `gh workflow run release.yml` and the existing 2.6.1 versions should publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)