### PR TITLE
fix(ci): upgrade npm to enable trusted-publishing OIDC for the publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,13 @@ jobs:
           cache: pnpm
           registry-url: "https://registry.npmjs.org/"
 
+      # Trusted publishing OIDC for the actual `npm publish` PUT requires
+      # npm >= 11.5.1. Node 20 ships npm 10.x which only does OIDC for
+      # provenance signing — the publish itself falls back to bearer-token
+      # auth, hits an empty NODE_AUTH_TOKEN, and returns E404.
+      - name: Upgrade npm to a version with trusted-publishing support
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fourth time's the charm hopefully.

Trusted publishing is configured on npmjs.com and `NODE_AUTH_TOKEN` is gone, but the publish still 404s because **npm 10.x (shipped with Node 20) only does OIDC for provenance signing** — the actual `npm publish` PUT uses bearer-token auth and falls through to empty creds.

Fix: `npm install -g npm@latest` before the publish step. npm 11.5.1+ wires the OIDC trusted-publisher token through the publish PUT itself.

After merge, re-run `gh workflow run release.yml`. The 2.6.1 versions should finally land on npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)