### PR TITLE
fix(mcp): drop prepublishOnly to avoid parallel-publish dist race

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -45,8 +45,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "start": "tsx src/cli.ts",
-    "build": "tsup",
-    "prepublishOnly": "pnpm build"
+    "build": "tsup"
   },
   "dependencies": {
     "@tesseron/core": "workspace:*",


### PR DESCRIPTION
8/9 packages published successfully on the v2.6.1 release run; `@tesseron/mcp` failed with esbuild `Could not resolve "@tesseron/core"` because:

- `pnpm changeset publish` runs each package's `prepublishOnly` in parallel.
- Every published package has `prepublishOnly: pnpm build` and every tsup config has `clean: true`.
- Most packages bundle nothing from siblings, so their races are harmless.
- `@tesseron/mcp`'s CLI bundle uses `noExternal: [/.*/]` and reads `@tesseron/core/dist/` via esbuild. When `@tesseron/core`'s parallel prepublishOnly wipes its dist before rebuilding, mcp's tsup sees an empty directory and bails.

Fix: drop the redundant `prepublishOnly` from mcp. CI's existing Build step (`pnpm -r build` in the Release workflow) already builds mcp once cleanly without contention before changesets publish runs.

After merge, re-run `gh workflow run release.yml` and `@tesseron/mcp@2.6.1` should publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)