### PR TITLE
feat(pi): add @tesseron/pi Pi coding-agent extension package

### DIFF
--- a/.changeset/add-pi-package.md
+++ b/.changeset/add-pi-package.md
@@ -1,0 +1,15 @@
+---
+'@tesseron/core': minor
+'@tesseron/web': minor
+'@tesseron/server': minor
+'@tesseron/react': minor
+'@tesseron/mcp': minor
+'@tesseron/docs-mcp': minor
+'@tesseron/pi': minor
+---
+
+feat: add `@tesseron/pi` Pi coding-agent plugin
+
+New workspace package shipping a Pi extension (`@mariozechner/pi-coding-agent`) that exposes the Tesseron MCP gateway and docs server as eight typed Pi tools (`tesseron_claim_session`, `tesseron_list_actions`, `tesseron_list_pending_claims`, `tesseron_invoke_action`, `tesseron_read_resource`, `tesseron_docs_list`, `tesseron_docs_search`, `tesseron_docs_read`) plus the same five-skill bundle the Claude/Codex plugin ships. Install with `pi install -l npm:@tesseron/pi@<v>`.
+
+The Pi extension uses a hand-rolled stdio JSON-RPC client (no `@modelcontextprotocol/sdk` dep) to spawn `npx -y @tesseron/{mcp,docs-mcp}@<version>` as child processes and forward `tools/call` requests. Pinned `@tesseron/mcp` version stays in lockstep with the rest of the SDK fixed group via an extension to `scripts/sync-plugin-version.mjs`, which now also mirrors `plugin/skills/` → `packages/pi/skills/` and fails CI on any drift.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,8 @@
       "@tesseron/server",
       "@tesseron/react",
       "@tesseron/mcp",
-      "@tesseron/docs-mcp"
+      "@tesseron/docs-mcp",
+      "@tesseron/pi"
     ]
   ],
   "linked": [],

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,8 @@ repo; do not introduce one.
 
 The plugin no longer ships a pre-bundled gateway. `plugin/.mcp.json` invokes
 `@tesseron/mcp` and `@tesseron/docs-mcp` via `npx -y <pkg>@<version>`, with the
-version pinned to the plugin's own. Six fields move together on every release:
+version pinned to the plugin's own. Eight surfaces and one mirror tree move
+together on every release:
 
 - `plugin/.claude-plugin/plugin.json#version`
 - `.claude-plugin/marketplace.json#metadata.version` (Claude marketplace)
@@ -50,10 +51,20 @@ version pinned to the plugin's own. Six fields move together on every release:
 - `.agents/plugins/marketplace.json#plugins[0].version` (Codex marketplace)
 - `plugin/.mcp.json#mcpServers.tesseron.args`
 - `plugin/.mcp.json#mcpServers.tesseron-docs.args`
+- `packages/pi/package.json#version` (Pi extension package)
+- `packages/pi/extensions/tesseron.ts#TESSERON_MCP_VERSION` (Pi's pinned npx target)
+- `packages/pi/skills/**` (byte-identical mirror of `plugin/skills/**`)
 
 `scripts/sync-plugin-version.mjs` is the contract. Run `pnpm sync-plugin-version`
 to fix drift, or `pnpm sync-plugin-version --check` (CI does this) to fail fast.
 The release flow chains it via `pnpm version-packages` (changesets entry point).
+
+The skill mirror exists because Pi has no idiomatic primitive for sharing skill
+folders across packages — `bundledDependencies` doesn't bundle pnpm
+`workspace:*` packages, and Pi's `pi.skills` paths can't escape the package
+root. **Edit only the `plugin/skills/` copy.** The script blows away
+`packages/pi/skills/` and re-mirrors from the plugin source on every default
+run; CI's `--check` mode catches any drift loudly.
 
 There is no `plugin/server/` directory and no `pnpm build:plugin` script. Do not
 recreate them.

--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@
   <img alt="Protocol 1.0.0" src="https://img.shields.io/badge/Protocol-1.0.0-f59e0b?style=flat-square&labelColor=0b1220">
   <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-5.7-3178c6?style=flat-square&logo=typescript&logoColor=white&labelColor=0b1220">
   <img alt="Node 20+" src="https://img.shields.io/badge/Node-%E2%89%A5%2020-339933?style=flat-square&logo=node.js&logoColor=white&labelColor=0b1220">
-  <img alt="Tests" src="https://img.shields.io/badge/Tests-65%20passing-22c55e?style=flat-square&labelColor=0b1220">
+  <img alt="Tests" src="https://img.shields.io/badge/Tests-98%20passing-22c55e?style=flat-square&labelColor=0b1220">
 </p>
 
 <p>
   <a href="https://brainblend-ai.github.io/tesseron/"><b>Docs</b></a> &nbsp;·&nbsp;
   <a href="./examples"><b>Examples</b></a> &nbsp;·&nbsp;
-  <a href="#quick-install-claude-code"><b>Install</b></a> &nbsp;·&nbsp;
+  <a href="#install"><b>Install</b></a> &nbsp;·&nbsp;
   <a href="#packages"><b>Packages</b></a> &nbsp;·&nbsp;
   <a href="https://discord.gg/J3W9b5AZJR"><b>Discord</b></a> &nbsp;·&nbsp;
   <a href="https://github.com/BrainBlend-AI/tesseron/discussions"><b>Discussions</b></a>
@@ -37,7 +37,7 @@
 Live applications (browser tabs, Electron/Tauri desktop apps, Node daemons, CLIs) declare actions with a Zod-style builder; agents (Claude Code, Claude Desktop, Cursor, Copilot, Codex, Cline, ...) call them as MCP tools. Your real handler runs against your real state. **No browser automation, no scraping, no Playwright.**
 
 <p align="center">
-  <img src="./assets/diagrams/pieces-fit-together.png" alt="USER prompts the agent; YOUR APP (browser or Node, using @tesseron/web or /server) connects over WebSocket to the MCP GATEWAY (@tesseron/mcp on :7475); the MCP GATEWAY bridges to the MCP CLIENT (Claude Code, Desktop, Cursor) over MCP stdio." width="900">
+  <img src="./assets/diagrams/pieces-fit-together.png" alt="USER prompts the agent; YOUR APP (browser or Node, using @tesseron/web or /server) opens a loopback WebSocket and announces itself; the MCP GATEWAY (@tesseron/mcp) discovers it via ~/.tesseron/instances/ and dials in; the gateway bridges to the MCP CLIENT (Claude Code, Codex, OpenCode, Pi, Cursor, Claude Desktop, ...) over stdio." width="900">
 </p>
 
 ## Why Tesseron
@@ -47,16 +47,60 @@ Live applications (browser tabs, Electron/Tauri desktop apps, Node daemons, CLIs
 - **MCP-native.** Every action, resource, and capability maps to a standard MCP primitive. Users pick their agent.
 - **Click-to-connect.** Six-character claim code handshake. No API keys, no OAuth dance, no per-client configuration.
 - **First-class capabilities.** `ctx.confirm` for yes/no, `ctx.elicit` for schema-validated prompts, `ctx.sample` for agent LLM calls, `ctx.progress` for streaming updates, subscribable resources for live reads.
-- **Bundled delivery.** The MCP gateway ships inside a [Claude Code plugin](./plugin) — one install command and you're done.
+- **Cross-client delivery.** First-class install paths for Claude Code, Codex, OpenCode, and Pi — each one a single command or short config snippet that wires the [MCP gateway](./packages/mcp) in. No bundled binary; the gateway is `npx -y @tesseron/mcp@<version>` on demand.
 
-## Quick install (Claude Code)
+## Install
+
+Tesseron has first-class install paths for four agent clients. Pick the one you use:
+
+### Claude Code
 
 ```text
 /plugin marketplace add BrainBlend-AI/tesseron
 /plugin install tesseron@tesseron
 ```
 
-That installs the [`tesseron`](./plugin) Claude Code plugin, which spawns the MCP gateway automatically and registers it as an MCP server. Then drop [`@tesseron/web`](./packages/web), [`@tesseron/server`](./packages/server), or [`@tesseron/react`](./packages/react) into your app, declare actions, and let Claude drive your real UI.
+Installs the [`tesseron`](./plugin) Claude Code plugin. The MCP gateway and docs server are launched on demand via `npx`.
+
+### Codex CLI
+
+```bash
+codex plugin marketplace add BrainBlend-AI/tesseron
+```
+
+Codex consumes the same plugin manifest as Claude Code, so the gateway, docs server, and skills come along automatically.
+
+### Pi
+
+```bash
+pi install -l npm:@tesseron/pi@2.6.1
+```
+
+Installs the [`@tesseron/pi`](./packages/pi) package as a project-local Pi extension (`-l` writes to `.pi/settings.json`). Pi auto-installs missing project-local packages on every run, so this also doubles as the team-share command. Drop the `-l` for a global install.
+
+### OpenCode
+
+OpenCode reads MCP servers from `opencode.json` rather than a plugin manifest. Save this as `.opencode/opencode.json` in your project root (or `~/.config/opencode/opencode.json` for global use):
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "tesseron": { "type": "local", "command": ["npx", "-y", "@tesseron/mcp@2.6.1"], "enabled": true },
+    "tesseron-docs": { "type": "local", "command": ["npx", "-y", "@tesseron/docs-mcp@2.6.1"], "enabled": true }
+  }
+}
+```
+
+To also pick up the skill bundle, point OpenCode's `skills.paths` at a clone of [`plugin/skills/`](./plugin/skills) — see [`plugin/README.md`](./plugin/README.md#opencode) for the snippet.
+
+### Other MCP clients
+
+Claude Desktop, Cursor, VS Code Copilot, Cline, and any other MCP-compatible client work too — the gateway is plain stdio MCP. See the one-time setup in [`examples/README.md`](./examples/README.md#2-wire-the-mcp-gateway-into-your-mcp-client).
+
+### Then in your app
+
+Drop [`@tesseron/web`](./packages/web), [`@tesseron/server`](./packages/server), [`@tesseron/react`](./packages/react), [`@tesseron/svelte`](./packages/svelte), or [`@tesseron/vue`](./packages/vue) into your project, declare actions, and let the agent drive your real UI:
 
 ```ts
 import { tesseron } from '@tesseron/web';
@@ -76,8 +120,6 @@ tesseron
 await tesseron.connect();
 ```
 
-For other MCP clients (Claude Desktop, Cursor, Codex, VS Code Copilot, ...) see the one-time setup in [`examples/README.md`](./examples/README.md#2-wire-the-mcp-gateway-into-your-mcp-client).
-
 See [`examples/`](./examples) for working apps in vanilla TS, React, Svelte, Vue, Express, and plain Node.
 
 ## Packages
@@ -87,12 +129,17 @@ See [`examples/`](./examples) for working apps in vanilla TS, React, Svelte, Vue
 | [`@tesseron/core`](./packages/core) | Protocol types, action builder. Zero runtime deps beyond Standard Schema. |
 | [`@tesseron/web`](./packages/web) | Browser SDK. |
 | [`@tesseron/server`](./packages/server) | Node SDK. |
-| [`@tesseron/mcp`](./packages/mcp) | MCP gateway server (CLI; bundled into the plugin). |
 | [`@tesseron/react`](./packages/react) | React hooks adapter. |
+| [`@tesseron/svelte`](./packages/svelte) | Svelte 5 adapter. |
+| [`@tesseron/vue`](./packages/vue) | Vue 3 adapter. |
+| [`@tesseron/vite`](./packages/vite) | Vite plugin: dev-server bridge for browser tabs to dial the gateway over the same origin as your app. |
+| [`@tesseron/mcp`](./packages/mcp) | MCP gateway server (`tesseron-mcp` CLI; launched by each client's install path via `npx`). |
+| [`@tesseron/docs-mcp`](./packages/docs-mcp) | MCP server that serves the Tesseron docs (`search_docs`, `read_doc`, `list_docs`) for chapter-and-verse spec lookups inside agent sessions. |
+| [`@tesseron/pi`](./packages/pi) | Pi coding-agent extension: wraps `@tesseron/mcp` + `@tesseron/docs-mcp` as 8 typed Pi tools and ships the same skill bundle as the Claude/Codex plugin. |
 | [`@tesseron/devtools`](./packages/devtools) | In-browser debug UI served by the MCP gateway *(private stub, not yet published)*. |
 | [`create-tesseron`](./packages/create-tesseron) | `npm create tesseron@latest` scaffolder *(private stub, not yet published)*. |
 
-The Claude Code plugin lives at [`plugin/`](./plugin), exposed via the marketplace manifest at [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json).
+The Claude Code / Codex plugin lives at [`plugin/`](./plugin), exposed via the marketplace manifests at [`.claude-plugin/marketplace.json`](./.claude-plugin/marketplace.json) (Claude) and [`.agents/plugins/marketplace.json`](./.agents/plugins/marketplace.json) (Codex).
 
 ## Client capability support
 
@@ -115,19 +162,20 @@ For the authoritative, continuously-updated list of which client supports which 
 
 ## Status
 
-**v1.0** shipped April 2026. The protocol is stable at [**1.0.0**](./docs/src/content/docs/protocol) and intentionally kept small: bidirectional JSON-RPC 2.0 over WebSocket, dynamic MCP tool registration, click-to-connect handshake, streaming progress, cancellation, sampling, confirmation, schema-validated elicitation, subscribable resources.
+**v1.0** shipped April 2026; the SDK is at **v2.6** as of writing. The protocol is stable at [**1.0.0**](./docs/src/content/docs/protocol) and intentionally kept small: bidirectional JSON-RPC 2.0 over WebSocket, dynamic MCP tool registration, click-to-connect handshake, streaming progress, cancellation, sampling, confirmation, schema-validated elicitation, subscribable resources, session resume.
 
-Published to npm (all at **v1.0.1**): `@tesseron/core`, `@tesseron/web`, `@tesseron/server`, `@tesseron/react`, `@tesseron/mcp`. The JS/TS SDKs are the reference implementation; the protocol spec is [CC BY 4.0](./docs/src/content/docs/protocol/LICENSE) so anyone can write a compatible client or server in any language.
+Published to npm: `@tesseron/{core,web,server,react,mcp,docs-mcp,pi}` ship in lockstep at the same version (currently **2.6.1**). `@tesseron/{svelte,vue,vite}` version independently. The JS/TS SDKs are the reference implementation; the protocol spec is [CC BY 4.0](./docs/src/content/docs/protocol/LICENSE) so anyone can write a compatible client or server in any language.
 
-On the roadmap: Svelte/Vue adapters, the devtools UI, a Streamable HTTP transport, a Python SDK, and bindings for desktop-native runtimes (Rust for Tauri, etc.).
+On the roadmap: the devtools UI, a Streamable HTTP transport, a Python SDK, and bindings for desktop-native runtimes (Rust for Tauri, etc.).
 
 ## Development
 
 ```bash
 pnpm install
 pnpm typecheck
-pnpm test                                    # 65 tests across core + mcp
-pnpm --filter @tesseron/mcp build:plugin     # rebuild plugin/server/index.cjs after gateway changes
+pnpm test                            # vitest across core + mcp
+pnpm lint                            # biome
+pnpm sync-plugin-version --check     # CI guard: plugin manifests + Pi pin + skill mirror in lockstep
 ```
 
 ## Contributing

--- a/packages/pi/LICENSE
+++ b/packages/pi/LICENSE
@@ -1,0 +1,114 @@
+Business Source License 1.1
+
+License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
+"Business Source License" is a trademark of MariaDB Corporation Ab.
+
+-----------------------------------------------------------------------------
+
+Parameters
+
+Licensor:             Kenny Vaneetvelde
+
+Licensed Work:        Tesseron
+                      The Licensed Work is (c) 2026 Kenny Vaneetvelde.
+
+Additional Use Grant: You may make production use of the Licensed Work,
+                      provided your use does not include offering the
+                      Licensed Work, or a substantial portion of its
+                      functionality, to third parties as a hosted or
+                      managed service.
+
+                      For clarity, permitted uses include (but are not
+                      limited to): embedding the Licensed Work in your
+                      own applications (commercial or otherwise),
+                      internal use within your organization, consulting
+                      engagements that integrate the Licensed Work into
+                      client applications, redistributing modified or
+                      unmodified copies of the Licensed Work, and running
+                      the gateway locally on end-user machines as part
+                      of the user's own tooling.
+
+Change Date:          Four years from the date the Licensed Work is
+                      published. For each release of the Licensed Work,
+                      the Change Date is four years from the publication
+                      date of that release.
+
+Change License:       Apache License, Version 2.0
+
+-----------------------------------------------------------------------------
+
+Terms
+
+The Licensor hereby grants you the right to copy, modify, create derivative
+works, redistribute, and make non-production use of the Licensed Work. The
+Licensor may make an Additional Use Grant, above, permitting limited
+production use.
+
+Effective on the Change Date, or the fourth anniversary of the first
+publicly available distribution of a specific version of the Licensed Work
+under this License, whichever comes first, the Licensor hereby grants you
+rights under the terms of the Change License, and the rights granted in the
+paragraph above terminate.
+
+If your use of the Licensed Work does not comply with the requirements
+currently in effect as described in this License, you must purchase a
+commercial license from the Licensor, its affiliated entities, or authorized
+resellers, or you must refrain from using the Licensed Work.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in
+this License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, NON-INFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+
+MariaDB hereby grants you permission to use this License's text to license
+your works, and to refer to it using the trademark "Business Source License",
+as long as you comply with the Covenants of Licensor below.
+
+-----------------------------------------------------------------------------
+
+Covenants of Licensor
+
+In consideration of the right to use this License's text and the "Business
+Source License" name and trademark, Licensor covenants to MariaDB, and to
+all other recipients of the licensed work to be provided by Licensor:
+
+1. To specify as the Change License the GPL Version 2.0 or any later version,
+   or a license that is compatible with GPL Version 2.0 or a later version,
+   where "compatible" means that software provided under the Change License
+   can be included in a program with software provided under GPL Version 2.0
+   or a later version. Licensor may specify additional Change Licenses
+   without limitation.
+
+2. To either: (a) specify an additional grant of rights to use that does not
+   impose any additional restriction on the right granted in this License,
+   as the Additional Use Grant; or (b) insert the text "None".
+
+3. To specify a Change Date.
+
+4. Not to modify this License in any other way.
+
+-----------------------------------------------------------------------------
+
+Notice
+
+The Business Source License (this document, or the "License") is not an
+Open Source license. However, the Licensed Work will eventually be made
+available under an Open Source License, as stated in this License.

--- a/packages/pi/README.md
+++ b/packages/pi/README.md
@@ -1,0 +1,119 @@
+# @tesseron/pi
+
+Pi coding-agent plugin for [Tesseron](https://github.com/BrainBlend-AI/tesseron). Drops the Tesseron MCP gateway into [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) as a single-command install **and** gives Pi the same skill bundle the Claude Code / Codex plugin ships. Once installed, any web app speaking the Tesseron wire protocol over WebSocket can expose typed actions to Pi's LLM as Pi tools — no browser automation, no scraping.
+
+## What you get
+
+- **Eight Pi tools** that wrap the Tesseron MCP gateway (`@tesseron/mcp`) and docs server (`@tesseron/docs-mcp`):
+  - `tesseron_claim_session` — pair a Tesseron-enabled app to Pi via its 6-character claim code.
+  - `tesseron_list_actions` — enumerate actions and resources exposed by claimed sessions.
+  - `tesseron_list_pending_claims` — recovery path when a claim went stale (browser refresh, dev-server reload).
+  - `tesseron_invoke_action` — invoke a typed action on a claimed session.
+  - `tesseron_read_resource` — read a resource exposed by a claimed session.
+  - `tesseron_docs_list` / `tesseron_docs_search` / `tesseron_docs_read` — chapter-and-verse Tesseron docs lookup, BM25-indexed.
+- **The same five skills** the Claude/Codex plugin ships:
+  - `framework` — quick-reference mental model for the Tesseron SDK.
+  - `tesseron-docs` — authoritative-lookup skill that calls `tesseron_docs_*`.
+  - `tesseron-dev` — picks the right consumer package (`@tesseron/web`, `/server`, `/react`, `/svelte`, `/vue`) and wires the canonical API into a project's entry point.
+  - `tesseron-explorer` — maps an existing Tesseron codebase.
+  - `tesseron-reviewer` — Tesseron-specific code review.
+- **A `/tesseron` slash command** that prints the tool surface and the claim-code workflow.
+
+## Install
+
+Requires **Node 20+** with `npx` on `PATH`. On first call the package fetches `@tesseron/mcp` and `@tesseron/docs-mcp` from npm, which adds a one-time cold-start cost; subsequent launches use the npm cache.
+
+### Project-local install (recommended)
+
+Run from the root of the project where you want Tesseron tools available to Pi:
+
+```bash
+pi install -l npm:@tesseron/pi@2.6.1
+```
+
+`-l` writes the entry to `.pi/settings.json` so the package is restored on every Pi run in this project. Pi automatically installs missing project-local packages on startup, so this also serves as the team-share command.
+
+### Global install
+
+If you want Tesseron tools available in every Pi session regardless of cwd:
+
+```bash
+pi install npm:@tesseron/pi@2.6.1
+```
+
+This writes to `~/.pi/agent/settings.json`.
+
+### Try without installing
+
+```bash
+pi -e npm:@tesseron/pi@2.6.1
+```
+
+The `-e` (or `--extension`) flag installs to a temp dir for the current run only. Useful for one-off Tesseron-driven sessions.
+
+### Verify
+
+Start Pi in any project that has the package installed:
+
+```bash
+pi
+/tesseron
+```
+
+The `/tesseron` command prints the tool surface. The eight `tesseron_*` tools should appear in `/tools` (or whatever Pi's tool-list command is in your version).
+
+## How to use the gateway
+
+1. **In your web app**, import `@tesseron/web` (or `/server`, `/react`, `/svelte`, `/vue`), declare actions with the Zod-style builder, and call `tesseron.connect()`. The SDK binds a loopback WebSocket endpoint and writes an instance file to `~/.tesseron/instances/<id>.json`. The Tesseron MCP gateway watches that directory and dials in — no port to configure, no env vars.
+
+2. **The web app displays a 6-character claim code** (returned in the welcome handshake — see [`@tesseron/web`](https://github.com/BrainBlend-AI/tesseron/tree/main/packages/web) for the typical UI placement).
+
+3. **In Pi, say:** `claim session ABCD-XY` (replace with the actual code). Pi calls `tesseron_claim_session`, the gateway pairs the session, and your app's actions become callable via `tesseron_invoke_action`.
+
+4. **Drive your app from chat.** Each `tesseron_invoke_action` call runs the typed handler you declared — mutating whatever state your app owns. The browser (or service) updates in real time.
+
+For complete runnable walkthroughs, see the repo's [examples/](https://github.com/BrainBlend-AI/tesseron/tree/main/examples).
+
+## What ships in this package
+
+```
+@tesseron/pi/
+├── extensions/
+│   └── tesseron.ts        # the Pi extension factory + tool registrations
+└── skills/
+    ├── framework/         # mental-model skill + 11 reference files
+    ├── tesseron-dev/      # SDK integration skill
+    ├── tesseron-docs/     # authoritative docs lookup skill
+    ├── tesseron-explorer/ # codebase-mapping skill
+    └── tesseron-reviewer/ # framework-specific code review skill
+```
+
+The extension is a single TypeScript file loaded directly by Pi via [jiti](https://github.com/unjs/jiti) — no compile step.
+
+## How it works under the hood
+
+The extension spawns two MCP servers as child processes via `npx -y @tesseron/mcp@<version>` and `npx -y @tesseron/docs-mcp@<version>` (with `cmd /c` on Windows to navigate around npm's `.cmd` shim quirk). Each Pi `execute()` call translates to a JSON-RPC `tools/call` request over the child's stdio, and the result content is normalized into Pi's `(TextContent | ImageContent)[]` shape. Errors from the gateway (e.g. "no claimed session") arrive as `isError: true` from MCP and get re-thrown so Pi reports them as failed tool calls (Pi sets the `isError` flag by `throw`, never by return value).
+
+The pinned `@tesseron/mcp` version is kept in lockstep with the rest of the Tesseron SDK by [`scripts/sync-plugin-version.mjs`](https://github.com/BrainBlend-AI/tesseron/blob/main/scripts/sync-plugin-version.mjs) — never edit the `TESSERON_MCP_VERSION` constant in `extensions/tesseron.ts` by hand.
+
+## Skill source
+
+The skill bundle is mirrored from `plugin/skills/` (the Claude Code / Codex plugin's skill source). Edits land there; the sync script keeps `packages/pi/skills/` byte-identical and CI fails any drift. See [`AGENTS.md`](https://github.com/BrainBlend-AI/tesseron/blob/main/AGENTS.md) for the contract.
+
+## Compatibility
+
+- **Pi**: `@mariozechner/pi-coding-agent` 0.70.x or newer.
+- **Node**: 20.6+ (matches Pi's engine).
+- **Tesseron SDK**: matches the `@tesseron/mcp` version pinned in this package's extension. Currently `2.6.x`.
+
+## Links
+
+- Tesseron protocol + SDKs: https://github.com/BrainBlend-AI/tesseron
+- Examples: https://github.com/BrainBlend-AI/tesseron/tree/main/examples
+- `@tesseron/mcp` (gateway, used by this package): https://www.npmjs.com/package/@tesseron/mcp
+- `@tesseron/docs-mcp` (docs server, used by this package): https://www.npmjs.com/package/@tesseron/docs-mcp
+- Pi: https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent
+
+## License
+
+BUSL-1.1 © Kenny Vaneetvelde — see [`LICENSE`](./LICENSE).

--- a/packages/pi/extensions/tesseron.ts
+++ b/packages/pi/extensions/tesseron.ts
@@ -1,0 +1,469 @@
+import { type ChildProcessWithoutNullStreams, spawn } from 'node:child_process';
+import type { ImageContent, TextContent } from '@mariozechner/pi-ai';
+import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';
+import { Type } from 'typebox';
+
+// Pinned in lockstep with `@tesseron/mcp` by `scripts/sync-plugin-version.mjs`.
+// Do not edit by hand — `pnpm sync-plugin-version` rewrites this constant.
+const TESSERON_MCP_VERSION = '2.6.1';
+
+type JsonRpcId = number;
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0';
+  id: JsonRpcId;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+interface RawMcpContent {
+  type?: string;
+  text?: string;
+  data?: string;
+  mimeType?: string;
+  [key: string]: unknown;
+}
+
+interface ToolCallResult {
+  content?: RawMcpContent[];
+  isError?: boolean;
+  structuredContent?: unknown;
+}
+
+const PROTOCOL_VERSION = '2024-11-05';
+const REQUEST_TIMEOUT_MS = 60_000;
+
+/**
+ * Minimal stdio JSON-RPC 2.0 client for an MCP server child process.
+ *
+ * Does not depend on `@modelcontextprotocol/sdk` — its dep tree (express, hono,
+ * ajv, ~30-50 MB installed) is not worth carrying for the narrow surface we
+ * need here. We control both ends, so the framing is straightforward:
+ * newline-delimited JSON on stdin/stdout, init handshake then `tools/call`.
+ */
+class StdioMcp {
+  private child?: ChildProcessWithoutNullStreams;
+  private buffer = '';
+  private nextId: JsonRpcId = 1;
+  private readonly pending = new Map<
+    JsonRpcId,
+    {
+      resolve: (value: unknown) => void;
+      reject: (err: Error) => void;
+      timer: NodeJS.Timeout;
+    }
+  >();
+  private initPromise?: Promise<void>;
+  private exited = false;
+
+  constructor(
+    private readonly spec: { command: string; args: string[] },
+    private readonly label: string,
+  ) {}
+
+  async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+    await this.ensureInitialized();
+    const result = (await this.request('tools/call', {
+      name,
+      arguments: args,
+    })) as ToolCallResult;
+    return result;
+  }
+
+  shutdown(): void {
+    if (!this.child || this.exited) return;
+    try {
+      this.child.kill();
+    } catch {
+      // best-effort
+    }
+  }
+
+  private ensureInitialized(): Promise<void> {
+    if (!this.initPromise) {
+      this.initPromise = this.initialize().catch((err) => {
+        // Reset so the next call retries cleanly instead of returning a stale
+        // rejected promise forever.
+        this.initPromise = undefined;
+        throw err;
+      });
+    }
+    return this.initPromise;
+  }
+
+  private async initialize(): Promise<void> {
+    this.spawn();
+    await this.request('initialize', {
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: {},
+      clientInfo: { name: '@tesseron/pi', version: TESSERON_MCP_VERSION },
+    });
+    this.notify('notifications/initialized', {});
+  }
+
+  private spawn(): void {
+    const child = spawn(this.spec.command, this.spec.args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      // shell:false keeps argv structured. On Windows we use { cmd /c npx … }
+      // so the shim is invoked via cmd; on POSIX we exec npx directly.
+      shell: false,
+    });
+    this.child = child;
+    child.stdout.on('data', (chunk: Buffer) => this.onData(chunk));
+    child.stderr.on('data', () => {
+      // Discard MCP server stderr — Pi already shows it via the pi-coding-agent
+      // log surface if anything goes wrong, and forwarding it as ctx.ui.notify
+      // would be very noisy on cold-start (npx fetch + install).
+    });
+    child.on('exit', () => this.onExit());
+    child.on('error', (err: Error) => this.onSpawnError(err));
+  }
+
+  private onData(chunk: Buffer): void {
+    this.buffer += chunk.toString('utf8');
+    let newline = this.buffer.indexOf('\n');
+    while (newline !== -1) {
+      const line = this.buffer.slice(0, newline).trim();
+      this.buffer = this.buffer.slice(newline + 1);
+      if (line.length > 0) this.handleMessage(line);
+      newline = this.buffer.indexOf('\n');
+    }
+  }
+
+  private handleMessage(line: string): void {
+    let msg: JsonRpcResponse;
+    try {
+      msg = JSON.parse(line) as JsonRpcResponse;
+    } catch {
+      return;
+    }
+    if (typeof msg.id !== 'number') return; // notification or stray frame
+    const pending = this.pending.get(msg.id);
+    if (!pending) return;
+    this.pending.delete(msg.id);
+    clearTimeout(pending.timer);
+    if (msg.error) {
+      pending.reject(new Error(`[${this.label}] ${msg.error.message} (code ${msg.error.code})`));
+    } else {
+      pending.resolve(msg.result);
+    }
+  }
+
+  private onExit(): void {
+    this.exited = true;
+    const err = new Error(`[${this.label}] MCP server exited`);
+    for (const { reject, timer } of this.pending.values()) {
+      clearTimeout(timer);
+      reject(err);
+    }
+    this.pending.clear();
+  }
+
+  private onSpawnError(err: Error): void {
+    this.exited = true;
+    const wrapped = new Error(`[${this.label}] failed to spawn: ${err.message}`);
+    for (const { reject, timer } of this.pending.values()) {
+      clearTimeout(timer);
+      reject(wrapped);
+    }
+    this.pending.clear();
+  }
+
+  private request(method: string, params: unknown): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = this.nextId++;
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`[${this.label}] ${method} timed out after ${REQUEST_TIMEOUT_MS}ms`));
+      }, REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { resolve, reject, timer });
+      const payload: JsonRpcRequest = { jsonrpc: '2.0', id, method, params };
+      this.write(payload);
+    });
+  }
+
+  private notify(method: string, params: unknown): void {
+    this.write({ jsonrpc: '2.0', method, params });
+  }
+
+  private write(message: unknown): void {
+    if (!this.child) return;
+    try {
+      this.child.stdin.write(`${JSON.stringify(message)}\n`);
+    } catch {
+      // stdin closed; the exit handler will reject pending requests.
+    }
+  }
+}
+
+function npxSpec(pkg: string, version: string): { command: string; args: string[] } {
+  // On Windows, libuv's raw uv_spawn cannot resolve .cmd shims without
+  // shell:true. Routing through `cmd /c` sidesteps it.
+  if (process.platform === 'win32') {
+    return { command: 'cmd', args: ['/c', 'npx', '-y', `${pkg}@${version}`] };
+  }
+  return { command: 'npx', args: ['-y', `${pkg}@${version}`] };
+}
+
+function normalizeContent(items: RawMcpContent[]): (TextContent | ImageContent)[] {
+  return items.map((item): TextContent | ImageContent => {
+    if (
+      item.type === 'image' &&
+      typeof item.data === 'string' &&
+      typeof item.mimeType === 'string'
+    ) {
+      return { type: 'image', data: item.data, mimeType: item.mimeType };
+    }
+    if (item.type === 'text' && typeof item.text === 'string') {
+      return { type: 'text', text: item.text };
+    }
+    // Resource / audio / unknown content kinds — fall back to a stringified
+    // text block so the model still sees the payload instead of empty content.
+    return { type: 'text', text: JSON.stringify(item) };
+  });
+}
+
+function textFromMcp(result: ToolCallResult): string {
+  const parts = (result.content ?? [])
+    .filter((c) => c.type === 'text' && typeof c.text === 'string')
+    .map((c) => c.text as string);
+  if (parts.length > 0) return parts.join('\n');
+  return JSON.stringify(result.structuredContent ?? result, null, 2);
+}
+
+function passThroughResult(result: ToolCallResult): {
+  content: (TextContent | ImageContent)[];
+  details: ToolCallResult;
+} {
+  // Tesseron MCP errors arrive as `isError: true` with text content describing
+  // the failure. Pi's runtime sets isError by THROW, not by returning a flag —
+  // so re-raise so the tool result is reported as failed to the model.
+  if (result.isError) {
+    throw new Error(textFromMcp(result));
+  }
+  return {
+    content: normalizeContent(result.content ?? []),
+    details: result,
+  };
+}
+
+const NoArgsSchema = Type.Object({}, { additionalProperties: false });
+
+export default function tesseronExtension(pi: ExtensionAPI): void {
+  const tesseron = new StdioMcp(npxSpec('@tesseron/mcp', TESSERON_MCP_VERSION), 'tesseron');
+  const docs = new StdioMcp(npxSpec('@tesseron/docs-mcp', TESSERON_MCP_VERSION), 'tesseron-docs');
+
+  pi.on('session_shutdown', () => {
+    tesseron.shutdown();
+    docs.shutdown();
+  });
+
+  // ---------- Gateway tools (5) ----------
+
+  pi.registerTool({
+    name: 'tesseron_claim_session',
+    label: 'Tesseron: Claim Session',
+    description:
+      'Claim a pending Tesseron session by its 6-character code (format: XXXX-XX) so its actions appear as Tesseron tools. Web apps display this code when the user clicks "Connect Pi".',
+    promptSnippet: 'Claim a Tesseron web-app session by 6-char code so its actions become callable',
+    promptGuidelines: [
+      'Use tesseron_claim_session when the user reads a 6-character claim code from a Tesseron-enabled web app.',
+      'After tesseron_claim_session succeeds, call tesseron_list_actions to discover the app_id and which actions it exposes.',
+    ],
+    parameters: Type.Object({
+      code: Type.String({ description: 'The 6-character claim code, e.g. "ABCD-23".' }),
+    }),
+    async execute(_id, params) {
+      return passThroughResult(
+        await tesseron.callTool('tesseron__claim_session', { code: params.code }),
+      );
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_list_actions',
+    label: 'Tesseron: List Actions',
+    description:
+      'List every action and resource registered by currently claimed Tesseron sessions, grouped by app_id.',
+    promptSnippet: 'List Tesseron actions and resources currently exposed by claimed sessions',
+    promptGuidelines: [
+      'Call tesseron_list_actions before tesseron_invoke_action to discover the exact app_id + action name pair to call.',
+    ],
+    parameters: NoArgsSchema,
+    async execute() {
+      return passThroughResult(await tesseron.callTool('tesseron__list_actions', {}));
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_list_pending_claims',
+    label: 'Tesseron: List Pending Claims',
+    description:
+      'List every claim code the gateway can currently redeem (gateway-minted sessions waiting for claim, plus host-minted manifests with an unconsumed code). Recovery path when a previously claimed session was invalidated mid-conversation.',
+    promptSnippet:
+      'List unredeemed Tesseron claim codes when a previously-claimed session has gone stale',
+    promptGuidelines: [
+      'Use tesseron_list_pending_claims when an action call returns "No claimed session found" — pick the entry whose app_id matches and re-claim with tesseron_claim_session.',
+    ],
+    parameters: NoArgsSchema,
+    async execute() {
+      return passThroughResult(await tesseron.callTool('tesseron__list_pending_claims', {}));
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_invoke_action',
+    label: 'Tesseron: Invoke Action',
+    description:
+      'Invoke any action on a currently claimed Tesseron session by app_id and action name.',
+    promptSnippet: 'Invoke a typed Tesseron action exposed by a claimed web app',
+    promptGuidelines: [
+      'Use tesseron_invoke_action to drive a Tesseron-enabled app via its typed action surface instead of browser automation.',
+      'Pass the unprefixed action name (e.g. "addTodo"), not the namespaced MCP tool name.',
+    ],
+    parameters: Type.Object({
+      app_id: Type.String({
+        description:
+          'The claimed session\'s app id (e.g. "svelte_todo"). Use tesseron_list_actions to enumerate.',
+      }),
+      action: Type.String({
+        description:
+          'The action name registered by the app (e.g. "addTodo"). NOT the namespaced MCP tool name.',
+      }),
+      args: Type.Optional(
+        Type.Object(
+          {},
+          {
+            additionalProperties: true,
+            description:
+              "Arguments object for the action handler. Shape must match the action's declared input schema.",
+          },
+        ),
+      ),
+    }),
+    async execute(_id, params) {
+      return passThroughResult(
+        await tesseron.callTool('tesseron__invoke_action', {
+          app_id: params.app_id,
+          action: params.action,
+          args: params.args ?? {},
+        }),
+      );
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_read_resource',
+    label: 'Tesseron: Read Resource',
+    description:
+      'Read a resource exposed by a claimed Tesseron session. Takes the Tesseron app_id + resource name directly.',
+    promptSnippet: 'Read a Tesseron resource by app_id + resource name',
+    promptGuidelines: [
+      'Use tesseron_read_resource for state observation; use tesseron_invoke_action for state mutation.',
+    ],
+    parameters: Type.Object({
+      app_id: Type.String({
+        description: 'The claimed session\'s app id (e.g. "svelte_todo").',
+      }),
+      name: Type.String({
+        description:
+          'The resource name registered by the app (e.g. "todoStats"). NOT the full tesseron:// URI.',
+      }),
+    }),
+    async execute(_id, params) {
+      return passThroughResult(
+        await tesseron.callTool('tesseron__read_resource', {
+          app_id: params.app_id,
+          name: params.name,
+        }),
+      );
+    },
+  });
+
+  // ---------- Docs tools (3) ----------
+
+  pi.registerTool({
+    name: 'tesseron_docs_list',
+    label: 'Tesseron Docs: List',
+    description:
+      'List every Tesseron documentation page with title, slug, section, short description, and related slugs.',
+    promptSnippet: 'List the Tesseron docs catalogue with slugs, sections, and descriptions',
+    promptGuidelines: [
+      'Call tesseron_docs_list before tesseron_docs_search when you want to scan the full catalogue.',
+    ],
+    parameters: NoArgsSchema,
+    async execute() {
+      return passThroughResult(await docs.callTool('list_docs', {}));
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_docs_search',
+    label: 'Tesseron Docs: Search',
+    description:
+      'Full-text search across Tesseron docs (BM25, title- and description-weighted). Returns ranked hits with short snippets.',
+    promptSnippet:
+      'BM25-search the Tesseron docs and follow promising hits with tesseron_docs_read',
+    promptGuidelines: [
+      'Call tesseron_docs_search for any precision question about Tesseron protocol or SDK behavior; follow up with tesseron_docs_read on the top hits.',
+    ],
+    parameters: Type.Object({
+      query: Type.String({
+        description: 'Free-form query. Supports multiple terms; fuzzy + prefix matching are on.',
+      }),
+      limit: Type.Optional(
+        Type.Integer({
+          minimum: 1,
+          maximum: 20,
+          description: 'Maximum hits to return. Default 8, hard cap 20.',
+        }),
+      ),
+    }),
+    async execute(_id, params) {
+      const args: Record<string, unknown> = { query: params.query };
+      const limit = params['limit'];
+      if (limit !== undefined) args['limit'] = limit;
+      return passThroughResult(await docs.callTool('search_docs', args));
+    },
+  });
+
+  pi.registerTool({
+    name: 'tesseron_docs_read',
+    label: 'Tesseron Docs: Read',
+    description:
+      'Return the full markdown body of a Tesseron docs page plus its structured frontmatter (title, description, section, related). Slug format: `<section>/<basename>` without extension (e.g. `protocol/handshake`).',
+    promptSnippet: 'Read a full Tesseron docs page by slug',
+    promptGuidelines: [
+      'Use tesseron_docs_read for chapter-and-verse questions about Tesseron behavior — quote it back at the user instead of paraphrasing.',
+    ],
+    parameters: Type.Object({
+      slug: Type.String({
+        description:
+          'Page slug (e.g. "protocol/handshake"). Use tesseron_docs_list or tesseron_docs_search to discover valid slugs.',
+      }),
+    }),
+    async execute(_id, params) {
+      return passThroughResult(await docs.callTool('read_doc', { slug: params.slug }));
+    },
+  });
+
+  // ---------- Slash command ----------
+
+  pi.registerCommand('tesseron', {
+    description: 'Show the Tesseron tool surface and the claim-code workflow.',
+    handler: (_args, ctx) => {
+      ctx.ui.notify(
+        'Tesseron tools: tesseron_claim_session, tesseron_list_actions, tesseron_list_pending_claims, tesseron_invoke_action, tesseron_read_resource. Docs tools: tesseron_docs_list, tesseron_docs_search, tesseron_docs_read. Workflow: open a Tesseron-enabled web app, copy the 6-char claim code, then ask Pi to call tesseron_claim_session({ code }).',
+        'info',
+      );
+      return Promise.resolve();
+    },
+  });
+}

--- a/packages/pi/package.json
+++ b/packages/pi/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@tesseron/pi",
+  "version": "2.6.1",
+  "description": "Pi coding-agent plugin for Tesseron — typed action/resource tools + skills bundle, backed by @tesseron/mcp and @tesseron/docs-mcp via stdio.",
+  "license": "BUSL-1.1",
+  "author": {
+    "name": "Kenny Vaneetvelde",
+    "email": "kenny.vaneetvelde@gmail.com",
+    "url": "https://brainblendai.com/"
+  },
+  "homepage": "https://github.com/BrainBlend-AI/tesseron#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BrainBlend-AI/tesseron.git",
+    "directory": "packages/pi"
+  },
+  "bugs": {
+    "url": "https://github.com/BrainBlend-AI/tesseron/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "pi-coding-agent",
+    "tesseron",
+    "mcp",
+    "ai-agents",
+    "actions",
+    "websocket"
+  ],
+  "type": "module",
+  "files": ["extensions", "skills", "README.md", "LICENSE"],
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"]
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "@mariozechner/pi-coding-agent": "*",
+    "@mariozechner/pi-agent-core": "*",
+    "@mariozechner/pi-ai": "*",
+    "@mariozechner/pi-tui": "*",
+    "typebox": "*"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.70.6",
+    "@mariozechner/pi-agent-core": "^0.70.6",
+    "@mariozechner/pi-ai": "^0.70.6",
+    "@mariozechner/pi-tui": "^0.70.6",
+    "@types/node": "^22.0.0",
+    "typebox": "^1.1.24",
+    "typescript": "^5.7.0"
+  }
+}

--- a/packages/pi/skills/framework/SKILL.md
+++ b/packages/pi/skills/framework/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: framework
+description: Quick-reference mental model for the Tesseron TypeScript SDK — core abstractions (app, action, resource, handler, ActionContext, transport, session, gateway), canonical imports per consumer package (`@tesseron/web`, `/server`, `/react`, `/core`, `/mcp`), and the minimum-viable-app template. Load when the user is starting Tesseron work, wiring a first action or resource, deciding which consumer package to import, writing a handler for the first time, or orienting on how the pieces fit together. Triggers on code that imports from `@tesseron/*`, on calls to `tesseron.action(...)`, `tesseron.resource(...)`, `tesseron.connect(...)`, `useTesseronAction`, `useTesseronResource`, or `useTesseronConnection`, and on broad questions like "what is Tesseron", "how do actions work", "where do I start". For authoritative specs — exact wire format, error code tables, handshake and resume shapes, full protocol behaviour — prefer the `tesseron-docs` skill, which queries the live `@tesseron/docs-mcp` server. This skill is the cheat sheet; `tesseron-docs` is the manual.
+---
+
+# Tesseron Framework
+
+Tesseron is a TypeScript protocol + SDK that lets a live web app expose typed, prefixed actions and resources to MCP-compatible AI agents (Claude Code, Claude Desktop, Cursor, and others) over WebSocket. Instead of the agent automating a browser to drive the UI, the app directly tells the agent *what it can do*. Each tool invocation runs a real handler against real state — no DOM scraping, no screenshot analysis.
+
+This skill orients Claude on the framework and routes to focused reference files as the task requires.
+
+## Core abstractions
+
+| Concept | Class / symbol | Role |
+|---|---|---|
+| App | `tesseron.app({...})` | Stable identity (`id`, `name`, `description`) announced in the welcome handshake |
+| Action | `ActionDefinition` via `tesseron.action(name)...handler(fn)` | A named operation the agent can invoke as an MCP tool |
+| Resource | `ResourceDefinition` via `tesseron.resource(name)...read(fn)`/`.subscribe(fn)` | Readable and/or subscribable state exposed to the agent |
+| Handler | `ActionHandler<I, O>` | `(input, ctx) => Promise<O> | O` — runs inside the app, with validated input |
+| Context | `ActionContext` | Per-invocation runtime: `signal`, `agent`, `agentCapabilities`, `client`, `progress`, `sample`, `confirm`, `elicit`, `log` |
+| Transport | `Transport` interface | JSON-RPC 2.0 bidirectional channel; `BrowserWebSocketTransport`, `NodeWebSocketTransport`, or custom |
+| Session | `WelcomeResult` from `tesseron.connect(...)` | `sessionId`, `claimCode`, `resumeToken`, `capabilities`, invoking `agent` |
+| Gateway | `@tesseron/mcp` | Bridges `tesseron/*` JSON-RPC ↔ MCP; launched automatically by the Claude Code plugin |
+
+Every action/resource uses a Standard-Schema-compatible validator (Zod, Valibot, Typebox) for input/output.
+
+## Canonical imports
+
+```ts
+// Browser
+import { tesseron, BrowserWebSocketTransport, DEFAULT_GATEWAY_URL } from '@tesseron/web';
+
+// Node (headless server, CLI, daemon)
+import { tesseron, NodeWebSocketTransport, DEFAULT_GATEWAY_URL } from '@tesseron/server';
+
+// React (co-located inside components)
+import { useTesseronAction, useTesseronResource, useTesseronConnection } from '@tesseron/react';
+
+// Core (protocol types, errors, transport interface — useful for custom transports/tests)
+import type { ActionContext, Transport, WelcomeResult, ResumeCredentials } from '@tesseron/core';
+import {
+  TesseronError,
+  TesseronErrorCode,
+  SamplingNotAvailableError,
+  ElicitationNotAvailableError,
+  TimeoutError,
+  CancelledError,
+  ResumeFailedError,
+} from '@tesseron/core';
+```
+
+Do not import from package internals (`@tesseron/core/dist/...` or relative paths across packages). Only the top-level exports are part of the public API.
+
+## Minimum viable app
+
+```ts
+import { tesseron } from '@tesseron/web';
+import { z } from 'zod';
+
+tesseron.app({
+  id: 'my_todo',
+  name: 'My Todo App',
+  description: 'A todo app driven by Claude through Tesseron.',
+});
+
+const todos: Array<{ id: string; text: string; done: boolean }> = [];
+
+tesseron
+  .action('addTodo')
+  .describe('Add a new todo item to the list. Returns the created todo.')
+  .input(z.object({ text: z.string().min(1) }))
+  .handler(({ text }) => {
+    const todo = { id: crypto.randomUUID(), text, done: false };
+    todos.push(todo);
+    return todo;
+  });
+
+tesseron
+  .resource('todos')
+  .describe('All current todos.')
+  .output(z.array(z.object({ id: z.string(), text: z.string(), done: z.boolean() })))
+  .read(() => todos);
+
+const welcome = await tesseron.connect();
+console.log(`Claim code: ${welcome.claimCode}`);
+```
+
+In Claude, the user then says `claim session <code>` and the app's `addTodo` action appears as a typed MCP tool. Full runnable versions live in `examples/` (vanilla, React, Svelte, Vue, Express, Node).
+
+## Decision routing
+
+Pick the reference file that matches the task. Each is loaded only when read.
+
+| Task | Reference |
+|---|---|
+| Design an action — input/output/annotations/timeout/handler shape | [references/actions.md](references/actions.md) |
+| Expose readable / subscribable state to the agent | [references/resources.md](references/resources.md) |
+| Use `ctx.sample`, `ctx.confirm`, `ctx.elicit`, `ctx.progress`, `ctx.log`, or `ctx.signal` inside a handler | [references/context.md](references/context.md) |
+| Connect, pick a transport, write a custom one, reconnect with resume | [references/transports.md](references/transports.md) |
+| Wire actions/resources into a React app, manage connection UI | [references/react.md](references/react.md) |
+| Understand the JSON-RPC wire protocol: methods, payloads, errors, resume | [references/protocol.md](references/protocol.md) |
+| Pick an input/output validator (Zod / Valibot / Typebox), pass the right `jsonSchema` | [references/schemas.md](references/schemas.md) |
+| Handle errors — codes, subclasses, `instanceof` patterns, resume failures | [references/errors.md](references/errors.md) |
+| Configure the gateway — env vars, origin allowlist, tool surface modes, multi-app | [references/gateway.md](references/gateway.md) |
+| Write unit/integration tests with mock transports and context | [references/testing.md](references/testing.md) |
+| Tesseron-specific structural rules — which `@tesseron/*` package per stack, where `tesseron.app(...)` goes, `app.id` rules, version lockstep, multi-app layout | [references/project-structure.md](references/project-structure.md) |
+
+When a concept is unclear, start from the user's verb: *add an action* → actions, *push a live value* → resources, *ask the LLM to pick something* → context (`ctx.sample`), *let the user confirm* → context (`ctx.confirm` / `ctx.elicit`), *my session died on reload* → transports (resume).
+
+## Working style
+
+Follow these defaults unless the project says otherwise. The reference files go deeper on each.
+
+**Describe every action for the LLM, not the developer.** The `.describe(...)` string and field descriptions in the input schema are the only hints the agent has to decide when to call the action and what arguments to pass. A missing or vague description is effectively an unused tool.
+
+**Schemas are the runtime contract.** `.input(schema)` validates before the handler runs; invalid input is rejected with an `InputValidation` error without invoking the handler. Use a Standard-Schema validator (Zod is most common, Valibot and Typebox also work). Plain TypeScript types are not runtime validators.
+
+**Annotate destructive actions.** `.annotate({ destructive: true })` and `requiresConfirmation: true` let the agent surface a confirmation to the user before invoking. `readOnly: true` on pure getters helps the agent reason about side effects.
+
+**Forward `ctx.signal` to every cancellable async op.** `fetch`, child-process, database calls, long timers — all should accept `signal: ctx.signal` so gateway-initiated cancellation propagates through the call stack.
+
+**Call `ctx.progress(...)` on operations longer than ~1–2 seconds.** The agent surfaces progress to the user; handlers that don't emit look frozen.
+
+**Capability-check before `sample` and `elicit`.** Calling them on an agent that doesn't support the capability throws `SamplingNotAvailableError` / `ElicitationNotAvailableError`. `ctx.confirm(...)` is the exception — it collapses to `false` on any non-accept, which is the safe default for destructive ops.
+
+**Persist `{sessionId, resumeToken}` after each successful connect.** The resume token rotates on every successful resume, so always write back the freshest token from the latest `WelcomeResult`. On reconnect failure (`ResumeFailedError`), fall back to a fresh `connect()` without resume options.
+
+**Resources that push updates emit an initial value then a cleanup.** The `subscribe((emit) => { emit(current); registry.add(emit); return () => registry.delete(emit); })` shape is canonical. Missing the initial emit leaves the first read hanging; missing the return leaks the subscription.
+
+**In React, hooks register once at mount and cleanup on unmount.** Pass a fresh handler closure on every render — the hook stores it in a ref. `useCallback` / `useMemo` around the handler is unnecessary. Put `useTesseronConnection(...)` at the app root, not per-component.
+
+## When the user wants to add Tesseron to a project
+
+Delegate to the sibling `tesseron-dev` skill. It handles picking the right `@tesseron/*` consumer package, installing it with the project's existing package manager, and inserting the canonical Tesseron API (`tesseron.app(...)` + one action + one resource + `tesseron.connect()`) at module scope of the entry point.
+
+Project creation itself (scaffolding `package.json`, `tsconfig.json`, bundler config, picking framework versions) is outside Tesseron's scope — the user uses whichever upstream scaffolder or framework-specific skill they prefer. `tesseron-dev` works the same way whether the project was created five seconds ago or five years ago.
+
+## When the user wants to understand an existing codebase
+
+The `tesseron-explorer` skill auto-triggers on requests like "explore", "map", "understand how X works", or "trace" against a Tesseron project. It walks the codebase and produces a compact architecture map (apps, actions, resources, context-method use, transports, React hooks, session lifecycle, essential-reading list).
+
+For a small project (a single `main.ts` + one or two actions), reading the files directly is usually faster than loading the explorer skill.
+
+## When the user wants a review
+
+The `tesseron-reviewer` skill auto-triggers on requests to review, audit, check, or validate Tesseron code. It runs against the diff or paths the user names and returns a confidence-filtered list of framework-specific issues with ready-to-apply fixes. It complements generic code review; do not duplicate its checks in the main thread.
+
+## Versioning and compatibility
+
+- TypeScript 5.7+ (strict mode, `noUncheckedIndexedAccess` recommended).
+- Node 20+ for server / gateway processes (Node 18 *may* work for consumers but 20+ is what the monorepo tests against).
+- Protocol version `1.0.0`. Session resume (`tesseron/resume`) added in SDK v1.1.
+- Package versions travel together: `@tesseron/core`, `/web`, `/server`, `/react`, `/mcp` are released in lockstep. Match them within a minor version.
+- `@standard-schema/spec ^1.0.0` is the only runtime dependency of `@tesseron/core`.
+
+## Anti-patterns (surface these in review)
+
+- Calling `tesseron.connect()` before `tesseron.app(...)` — connect throws.
+- Chaining anything after `.handler(...)` on an action builder — `.handler(...)` returns the finalized `ActionDefinition`, not the builder. Silent bug.
+- Skipping `.describe(...)` on an action or resource — the LLM has no signal to pick the tool.
+- Plain TypeScript `interface` / `type` passed to `.input(...)` — not a validator. Use Zod / Valibot / Typebox.
+- `.subscribe(...)` that does not return a cleanup function — leaks the subscription.
+- `.subscribe(...)` that does not emit an initial value — the first read blocks waiting for a push.
+- Calling `ctx.sample(...)` / `ctx.elicit(...)` without a `ctx.agentCapabilities.*` check — throws on clients that don't support the capability.
+- Not forwarding `ctx.signal` to `fetch` or other cancellable ops — gateway cancellation cannot propagate.
+- Persisting a stale `resumeToken` — the token rotates on every successful resume; stale tokens fail with `ResumeFailedError`.
+- Storing `claimCode` — it's one-shot pairing, not authentication. Throw it away after the user pastes it.
+- Hardcoding `ws://localhost:7475` throughout the codebase instead of using `DEFAULT_GATEWAY_URL`.
+- `TESSERON_HOST=0.0.0.0` without `TESSERON_ORIGIN_ALLOWLIST` — exposes the gateway to arbitrary origins.
+- Multiple `useTesseronConnection(...)` hooks in the same app — each creates its own session.
+- `useCallback` / `useMemo` wrapping a `useTesseronAction` handler — unnecessary; the hook refs the handler itself.
+- `error.code === -32006` magic-number checks instead of `instanceof SamplingNotAvailableError`.
+
+For deeper guidance load the relevant reference file above. For code-review runs, delegate to the `tesseron-reviewer` subagent.

--- a/packages/pi/skills/framework/references/actions.md
+++ b/packages/pi/skills/framework/references/actions.md
@@ -1,0 +1,181 @@
+# Actions (`ActionBuilder` + `ActionDefinition`)
+
+## Contents
+- The builder chain
+- Shape of an action definition
+- Annotations
+- Timeouts
+- Strict output validation
+- Sync vs async handlers
+- Registering multiple actions
+- Removing actions at runtime
+- Common mistakes
+
+## The builder chain
+
+```ts
+import { tesseron } from '@tesseron/web'; // or '@tesseron/server'
+import { z } from 'zod';
+
+tesseron
+  .action('addTodo')
+  .describe('Add a new todo item to the list. Returns the created todo.')
+  .input(z.object({ text: z.string().min(1), tag: z.string().optional() }))
+  .output(z.object({ id: z.string(), text: z.string(), done: z.boolean() }))
+  .annotate({ destructive: false, readOnly: false })
+  .timeout({ ms: 10_000 })
+  .strictOutput()
+  .handler(({ text, tag }) => {
+    const todo = { id: crypto.randomUUID(), text, done: false, tag };
+    todos.push(todo);
+    return todo;
+  });
+```
+
+Each method except `.handler(...)` returns the builder for chaining. `.handler(...)` is the **terminal call** — it commits the action and returns an `ActionDefinition`. Chaining anything after `.handler(...)` operates on the frozen definition, not the builder, and the chain call is silently dropped.
+
+Call order does not matter between `.describe()`, `.input()`, `.output()`, `.annotate()`, `.timeout()`, and `.strictOutput()`. Only `.handler()` must be last.
+
+## Shape of an action definition
+
+```ts
+interface ActionDefinition<I, O> {
+  name: string;
+  description: string;
+  inputSchema?: StandardSchemaV1<I>;
+  outputSchema?: StandardSchemaV1<O>;
+  annotations: ActionAnnotations;
+  timeoutMs: number;
+  strictOutput: boolean;
+  handler: ActionHandler<I, O>;
+}
+
+type ActionHandler<I, O> = (input: I, ctx: ActionContext) => Promise<O> | O;
+```
+
+Once registered, the action is announced in the `tesseron/hello` handshake and exposed to the agent as an MCP tool named `<app_id>__<action_name>` (see `gateway.md`).
+
+## `.describe(...)`
+
+The description is the primary hint the LLM uses to pick the tool. Write for the model.
+
+```ts
+// Good — explicit purpose, explicit return
+.describe('Mark a todo as completed. Returns the updated todo.')
+
+// Good — covers intent + key behavior
+.describe('Search the user\'s todos by text. Returns matching items sorted by recency.')
+
+// Bad — vague
+.describe('Todo stuff')
+
+// Bad — refers to implementation
+.describe('Calls updateTodoInDB and then refreshes the view')
+```
+
+Field descriptions in the input schema matter just as much:
+
+```ts
+.input(z.object({
+  text: z.string().min(1).describe('The text content of the todo item'),
+  tag: z.string().optional().describe('Optional tag for categorization, e.g. "work" or "home"'),
+}))
+```
+
+Zod's `.describe(...)` on individual fields flows through `z.toJSONSchema(...)` into the manifest the agent sees.
+
+## Annotations
+
+```ts
+interface ActionAnnotations {
+  readOnly?: boolean;
+  destructive?: boolean;
+  requiresConfirmation?: boolean;
+}
+```
+
+- **`readOnly: true`** — Pure getters or queries that never mutate state. Helps the agent reason about side effects.
+- **`destructive: true`** — Deletes, resets, outbound side effects the user cannot trivially undo.
+- **`requiresConfirmation: true`** — The agent should surface a confirmation UI before invoking. Pair with `destructive` for deletes; use alone for anything the user should consciously authorize (sending email, posting publicly, charging a card).
+
+```ts
+.annotate({ destructive: true, requiresConfirmation: true })
+```
+
+Annotations are advisory — the gateway forwards them to the agent, but the agent is free to invoke regardless. Still set them accurately so the agent can present the right UX.
+
+## Timeouts
+
+Default is **60 seconds**. Override per-action:
+
+```ts
+.timeout({ ms: 5_000 })   // cut off at 5 seconds
+.timeout({ ms: 120_000 }) // allow 2 minutes for a long operation
+```
+
+When the timeout fires, the handler is **not** automatically cancelled — the gateway sends an `actions/cancel` notification, which fires `ctx.signal`. Handlers must observe `ctx.signal` to actually abort the work; see `context.md`.
+
+## Strict output validation
+
+By default, output validation is **informational** — if the output fails the schema, a warning is logged but the value is still returned to the agent. Set `.strictOutput()` to make validation a hard gate:
+
+```ts
+.output(z.object({ id: z.string(), done: z.boolean() }))
+.strictOutput()
+.handler(() => ({ id: 'abc', done: 'yes' })) // throws HandlerError, agent sees failure
+```
+
+Use strict output when the agent's next step depends on the exact shape. Skip it when you want fault tolerance for shapes that may evolve.
+
+## Sync vs async handlers
+
+Handlers may be sync or async. Tesseron awaits the return value either way, so `return value` and `return Promise.resolve(value)` are equivalent.
+
+```ts
+// Sync — fine for in-memory mutations
+.handler(({ id }) => todos.delete(id))
+
+// Async — required for I/O
+.handler(async ({ id }, ctx) => {
+  const res = await fetch(`/api/todos/${id}`, { method: 'DELETE', signal: ctx.signal });
+  if (!res.ok) throw new Error(`delete failed: ${res.status}`);
+  return { id, deleted: true };
+})
+```
+
+When the handler does any I/O that respects an `AbortSignal`, forward `ctx.signal`. Gateway cancellation propagates through the signal; handlers that ignore it keep running after cancellation.
+
+## Registering multiple actions
+
+Register all actions **before** calling `tesseron.connect(...)`. They're announced in the initial `tesseron/hello` welcome handshake.
+
+```ts
+tesseron.app({ id: 'todos', name: 'Todos' });
+
+tesseron.action('addTodo').describe('...').input(...).handler(...);
+tesseron.action('completeTodo').describe('...').input(...).handler(...);
+tesseron.action('listTodos').describe('...').annotate({ readOnly: true }).handler(...);
+
+await tesseron.connect();
+```
+
+Actions registered after `connect()` are valid but must be announced via `actions/list_changed` — the SDK does this automatically. Agents that honor `notifications/tools/list_changed` pick them up; agents that freeze their tool list at startup will not.
+
+## Removing actions at runtime
+
+```ts
+tesseron.removeAction('addTodo');
+```
+
+Sends `actions/list_changed` to the gateway so the agent can refresh. Useful for feature flags, permission-scoped actions, or actions that depend on transient app state.
+
+## Common mistakes
+
+- **Chaining after `.handler(...)`.** `.handler(...)` is terminal; subsequent `.describe(...)` / `.annotate(...)` calls operate on the frozen `ActionDefinition` and do nothing useful. Put all chain calls before `.handler(...)`.
+- **Skipping `.describe(...)`.** The LLM picks tools by description; an undescribed action is effectively invisible.
+- **Plain TypeScript types passed to `.input(...)`.** `interface User { ... }` is a compile-time type, not a runtime validator. Wrap in Zod / Valibot / Typebox.
+- **Not forwarding `ctx.signal` to `fetch` / child processes.** Cancellation from the gateway cannot propagate; timeouts fire but the work keeps running.
+- **Forgetting `.annotate({ destructive: true })` on deletes.** The agent loses the signal to surface confirmation UX.
+- **Setting a huge `.timeout({ ms: ... })` as a substitute for progress reporting.** Long operations should `ctx.progress(...)` periodically, not hide behind a 10-minute timeout.
+- **Relying on output validation without `.strictOutput()`.** Default is informational; handler-returned garbage still reaches the agent. Add `.strictOutput()` when correctness matters.
+- **Registering actions inside handlers, loops, or conditionals.** Register at module load (for the singleton) or on component mount (for React hooks), not inside request-handling code.

--- a/packages/pi/skills/framework/references/context.md
+++ b/packages/pi/skills/framework/references/context.md
@@ -1,0 +1,266 @@
+# ActionContext
+
+## Contents
+- Shape of `ActionContext`
+- `signal` — cancellation
+- `agent` and `client` — identity
+- `agentCapabilities` — feature detection
+- `progress` and `log` — streaming updates
+- `sample` — ask the LLM mid-handler
+- `confirm` — safe yes/no
+- `elicit` — structured input
+- Capability-check patterns
+- Common mistakes
+
+## Shape of `ActionContext`
+
+Every handler receives a second argument of type `ActionContext`:
+
+```ts
+interface ActionContext {
+  signal: AbortSignal;
+  agentCapabilities: AgentCapabilities;
+  agent: InvokingAgent;
+  client: ClientContext;
+  progress(update: ProgressUpdate): void;
+  sample<T = string>(req: SampleRequest<T>): Promise<T>;
+  confirm(req: ConfirmRequest): Promise<boolean>;
+  elicit<T>(req: ElicitRequest<T>): Promise<T | null>;
+  log(entry: LogEntry): void;
+}
+
+interface AgentCapabilities {
+  sampling: boolean;
+  elicitation: boolean;
+  subscriptions: boolean;
+}
+
+interface InvokingAgent {
+  id: string;  // e.g. 'claude-ai'
+  name: string; // e.g. 'Claude'
+}
+
+interface ClientContext {
+  origin: string;
+  route?: string;
+  userAgent?: string;
+}
+
+interface ProgressUpdate {
+  message?: string;
+  percent?: number;
+  data?: unknown;
+}
+
+interface LogEntry {
+  level: 'debug' | 'info' | 'warn' | 'error';
+  message: string;
+  meta?: Record<string, unknown>;
+}
+```
+
+## `signal` — cancellation
+
+`ctx.signal` is the `AbortSignal` for this invocation. It fires when:
+- The gateway sends `actions/cancel` (agent cancelled the request, user hit escape).
+- The per-action timeout expires.
+- The session disconnects.
+
+Forward `signal` to every cancellable async operation:
+
+```ts
+.handler(async ({ query }, ctx) => {
+  const res = await fetch(`/api/search?q=${encodeURIComponent(query)}`, {
+    signal: ctx.signal,
+  });
+  return await res.json();
+});
+```
+
+For operations without native `AbortSignal` support, poll `ctx.signal.aborted` inside loops:
+
+```ts
+.handler(async ({ items }, ctx) => {
+  const results: Result[] = [];
+  for (const item of items) {
+    if (ctx.signal.aborted) throw ctx.signal.reason ?? new Error('cancelled');
+    results.push(await processItem(item));
+  }
+  return results;
+});
+```
+
+Handlers that ignore `ctx.signal` continue running after cancellation — wasting work and potentially writing stale state.
+
+## `agent` and `client` — identity
+
+`ctx.agent.id` / `.name` identify which MCP client is invoking (e.g. `claude-ai` / `Claude`). Use for:
+- Audit logging (`ctx.log({ level: 'info', message: 'action invoked', meta: { agent: ctx.agent.id } })`).
+- Permission checks on privileged actions.
+
+`ctx.client.origin` / `.route` / `.userAgent` describe the *Tesseron-connected app* (where the action is running). Use for:
+- Multi-app deployments that branch handler logic by origin.
+- Routing contextual hints into resources.
+
+## `agentCapabilities` — feature detection
+
+MCP clients advertise which capabilities they support. Before calling `ctx.sample(...)` or `ctx.elicit(...)`, check the flag:
+
+```ts
+if (!ctx.agentCapabilities.sampling) {
+  return defaultValue();
+}
+const suggestion = await ctx.sample({ prompt: '...' });
+```
+
+`ctx.confirm(...)` does not need a capability check — it collapses to `false` when elicitation is unavailable (safe default for destructive ops; see below).
+
+Common capability patterns per client (subject to change):
+
+| Client | sampling | elicitation | subscriptions |
+|---|---|---|---|
+| Claude Code | ✅ | ✅ | ✅ |
+| Claude Desktop | ✅ | ✅ | ✅ |
+| Cursor | ❌ | ❌ | ✅ |
+| VS Code Copilot | ❌ | ❌ | ✅ |
+
+Write handlers that degrade gracefully when a capability is missing.
+
+## `progress` — streaming updates
+
+Call `ctx.progress(...)` for operations longer than ~1–2 seconds so the agent can surface progress:
+
+```ts
+.handler(async ({ items }, ctx) => {
+  ctx.progress({ message: 'Processing items', percent: 0 });
+  for (const [i, item] of items.entries()) {
+    await processItem(item);
+    ctx.progress({
+      message: `Processed ${i + 1} of ${items.length}`,
+      percent: Math.round(((i + 1) / items.length) * 100),
+    });
+  }
+  return { processed: items.length };
+});
+```
+
+`ProgressUpdate` fields are all optional — emit `{ percent }` alone if you have a determinate progress bar, `{ message }` alone for indeterminate steps.
+
+## `log` — structured logs
+
+`ctx.log(...)` delivers log entries to the agent, which typically surfaces them in the MCP transcript for debugging:
+
+```ts
+ctx.log({ level: 'info', message: 'cache miss', meta: { key: id } });
+ctx.log({ level: 'error', message: 'upstream failure', meta: { status: res.status } });
+```
+
+Prefer `ctx.log` over `console.log` inside handlers — logs reach the agent and are associated with the invocation.
+
+**Do not log secrets, PII, or full user payloads.** Log entries are visible to the agent and often to the end user.
+
+## `sample` — ask the LLM mid-handler
+
+`ctx.sample(...)` asks the agent's LLM to generate a response, optionally constrained by a schema:
+
+```ts
+.handler(async ({ topic }, ctx) => {
+  if (!ctx.agentCapabilities.sampling) {
+    return { suggestion: defaultTitle(topic) };
+  }
+  const title = await ctx.sample<string>({
+    prompt: `Generate a concise, engaging title for a blog post about: ${topic}`,
+    maxTokens: 40,
+  });
+  return { suggestion: title };
+});
+```
+
+With a schema, the result is validated:
+
+```ts
+const schema = z.object({
+  titles: z.array(z.string()).min(3).max(5),
+  summary: z.string(),
+});
+
+const result = await ctx.sample({
+  prompt: `Suggest 3–5 titles and a summary for: ${topic}`,
+  schema,
+  jsonSchema: z.toJSONSchema(schema),
+});
+// result is { titles: string[]; summary: string }
+```
+
+Returns the validated value. Throws if:
+- `agentCapabilities.sampling` is false → `SamplingNotAvailableError`.
+- Schema validation fails → `HandlerError`.
+- Sampling depth exceeds limit (recursive sampling loops) → `SamplingDepthExceededError`.
+
+## `confirm` — safe yes/no
+
+`ctx.confirm(...)` asks the user a yes/no question through the agent:
+
+```ts
+const ok = await ctx.confirm({
+  question: 'Delete all completed todos? This cannot be undone.',
+});
+if (!ok) return { deleted: 0 };
+```
+
+Returns `true` only on explicit accept. All other outcomes — decline, cancel, dismissed dialog, missing elicitation capability — collapse to `false`. This is the safe default for destructive operations: **no capability check required**.
+
+## `elicit` — structured input
+
+`ctx.elicit(...)` asks for structured input from the user:
+
+```ts
+if (!ctx.agentCapabilities.elicitation) {
+  throw new Error('Cannot prompt for input: client does not support elicitation.');
+}
+const choice = await ctx.elicit({
+  question: 'Which tag should this todo have?',
+  schema: z.object({ tag: z.enum(['work', 'personal', 'urgent']) }),
+});
+if (choice === null) return { cancelled: true };
+// choice is { tag: 'work' | 'personal' | 'urgent' }
+```
+
+Returns the validated value, or `null` if the user cancels. Throws `ElicitationNotAvailableError` if the client does not support elicitation — **must capability-check first**.
+
+Unlike `confirm`, `elicit` cannot safely default (structured input has no sensible fallback), which is why it throws instead of returning `null` when unsupported.
+
+## Capability-check patterns
+
+```ts
+// sample — capability check + graceful fallback
+const summary = ctx.agentCapabilities.sampling
+  ? await ctx.sample({ prompt: `Summarize: ${text}`, maxTokens: 100 })
+  : text.slice(0, 100) + '…';
+
+// confirm — safe to call without check
+if (!(await ctx.confirm({ question: 'Really delete?' }))) return;
+
+// elicit — must capability-check or handle the throw
+let tag: string;
+if (ctx.agentCapabilities.elicitation) {
+  const r = await ctx.elicit({
+    question: 'Tag for this todo?',
+    schema: z.object({ tag: z.string() }),
+  });
+  tag = r?.tag ?? 'untagged';
+} else {
+  tag = 'untagged';
+}
+```
+
+## Common mistakes
+
+- **Not forwarding `ctx.signal` to `fetch` / child processes / timers.** Cancellation cannot propagate through the call stack.
+- **Calling `ctx.sample(...)` without a `ctx.agentCapabilities.sampling` check.** Throws `SamplingNotAvailableError` on clients that don't support sampling.
+- **Calling `ctx.elicit(...)` without a `ctx.agentCapabilities.elicitation` check.** Throws `ElicitationNotAvailableError`.
+- **Treating `ctx.confirm(...) === false` as "user declined".** It also means "dialog was dismissed" or "elicitation unavailable". If you need to distinguish, use `elicit` with a boolean-shaped schema.
+- **Using `console.log` inside handlers.** Logs don't reach the agent. Use `ctx.log({...})`.
+- **Logging secrets or PII in `ctx.log(...)`.** Log entries are visible to the agent and surfaced in the MCP transcript.
+- **Infinite sampling loops.** Handlers that call `ctx.sample(...)` → recurse are capped by `SamplingDepthExceededError`. Add explicit termination conditions.
+- **Treating `ctx.client` as agent identity.** `ctx.client` describes the *Tesseron-connected app*; `ctx.agent` is the invoking MCP client.

--- a/packages/pi/skills/framework/references/errors.md
+++ b/packages/pi/skills/framework/references/errors.md
@@ -1,0 +1,212 @@
+# Errors
+
+## Contents
+- Error code table
+- Error classes
+- Handling patterns (`instanceof`)
+- Input/output validation errors
+- Sampling and elicitation errors
+- Cancellation and timeout
+- Transport and resume errors
+- Never-swallow rules
+- Common mistakes
+
+## Error code table
+
+```ts
+const TesseronErrorCode = {
+  // JSON-RPC 2.0 reserved
+  ParseError:          -32700,
+  InvalidRequest:      -32600,
+  MethodNotFound:      -32601,
+  InvalidParams:       -32602,
+  InternalError:       -32603,
+
+  // Tesseron-specific
+  ProtocolMismatch:    -32000, // hello with wrong protocolVersion
+  Cancelled:           -32001, // gateway-initiated cancellation
+  Timeout:             -32002, // action exceeded timeoutMs
+  ActionNotFound:      -32003, // invoke on an unknown action
+  InputValidation:     -32004, // input failed schema
+  HandlerError:        -32005, // handler threw, or output failed strict validation
+  SamplingNotAvailable:-32006, // ctx.sample on a non-sampling client
+  ElicitationNotAvailable:-32007, // ctx.elicit on a non-elicitation client
+  SamplingDepthExceeded:-32008, // recursive sampling loop
+  Unauthorized:        -32009, // reserved for future auth
+  TransportClosed:     -32010, // transport closed mid-request
+  ResumeFailed:        -32011, // tesseron/resume couldn't rejoin the session
+};
+```
+
+## Error classes
+
+```ts
+class TesseronError extends Error {
+  readonly code: number;
+  readonly data?: unknown; // validation issues, client name, etc.
+}
+
+// Specific subclasses — preferred for branching
+class SamplingNotAvailableError extends TesseronError {
+  readonly clientName?: string;
+}
+class ElicitationNotAvailableError extends TesseronError {
+  readonly clientName?: string;
+}
+class SamplingDepthExceededError extends TesseronError {
+  readonly depth: number;
+}
+class CancelledError extends TesseronError {}
+class TimeoutError extends TesseronError {
+  readonly timeoutMs: number;
+}
+class TransportClosedError extends TesseronError {
+  readonly reason?: string;
+}
+class ResumeFailedError extends TesseronError {}
+```
+
+All of these extend `TesseronError`, which extends the standard `Error`. `error.name` matches the class; `error.code` maps to the table above; `error.data` carries structured metadata when relevant.
+
+Exported from both `@tesseron/core` and each SDK package (`@tesseron/web`, `/server`, `/react`).
+
+## Handling patterns (`instanceof`)
+
+Prefer `instanceof` over inspecting `error.code`:
+
+```ts
+import {
+  TesseronError,
+  SamplingNotAvailableError,
+  ElicitationNotAvailableError,
+  TimeoutError,
+  CancelledError,
+  ResumeFailedError,
+} from '@tesseron/core';
+
+try {
+  await doSomething(ctx);
+} catch (e) {
+  if (e instanceof SamplingNotAvailableError) {
+    // Fallback path — no LLM available
+  } else if (e instanceof CancelledError) {
+    // User cancelled; clean up partial work
+  } else if (e instanceof TimeoutError) {
+    // Handler exceeded timeout; log and rethrow for the agent
+    throw e;
+  } else {
+    throw e;
+  }
+}
+```
+
+Magic-number checks (`error.code === -32006`) work but silently decay as codes shift; `instanceof` stays correct even if error codes are re-numbered.
+
+## Input/output validation errors
+
+`InputValidation` (`-32004`) fires *before* the handler runs. The `error.data` field is the array of Standard Schema issues:
+
+```ts
+{
+  code: -32004,
+  message: 'Invalid input',
+  data: [
+    { path: ['text'], message: 'String must contain at least 1 character' },
+    { path: ['tag'], message: 'Invalid enum value' }
+  ]
+}
+```
+
+Handlers cannot catch `InputValidation` — it's raised by the dispatcher, not thrown inside the handler. If you need to accept more permissive input, loosen the schema.
+
+`HandlerError` (`-32005`) fires when:
+- The handler throws any uncaught error, or
+- `.strictOutput()` is set and the output fails validation.
+
+In both cases, the original error is preserved in `error.data` (when serializable) for debugging.
+
+## Sampling and elicitation errors
+
+```ts
+// Capability-check first — don't rely on the catch
+if (ctx.agentCapabilities.sampling) {
+  try {
+    return await ctx.sample({ prompt: '...' });
+  } catch (e) {
+    if (e instanceof SamplingDepthExceededError) {
+      // A recursive sample chain hit the cap — degrade to a cheaper path
+    }
+    throw e;
+  }
+}
+return fallbackSuggestion();
+```
+
+`SamplingNotAvailableError` and `ElicitationNotAvailableError` carry an optional `clientName` (the MCP client id) in `error.data.clientName` / `.clientName`, useful for surfacing a targeted error message ("Sampling is not supported by Cursor, try Claude Code instead.").
+
+`SamplingDepthExceededError` has a `depth` field equal to the depth at which the cap triggered. Use it to log recursive sampling bugs.
+
+## Cancellation and timeout
+
+`CancelledError` fires after the gateway sends `actions/cancel` and the handler completes (or aborts). It's the *promise rejection* that the handler call ultimately produces; the handler itself sees `ctx.signal.aborted` becoming true.
+
+`TimeoutError` has a `timeoutMs` field. The handler is **not** automatically aborted by the timeout — the gateway fires `actions/cancel`, which flips `ctx.signal`. If the handler ignores `ctx.signal`, it keeps running; the invocation still reports `TimeoutError` to the agent.
+
+Graceful-cleanup pattern:
+
+```ts
+.handler(async ({ file }, ctx) => {
+  const tmpPath = await startDownload(file, { signal: ctx.signal });
+  try {
+    return await finish(tmpPath, { signal: ctx.signal });
+  } catch (e) {
+    if (ctx.signal.aborted) {
+      await cleanupTmp(tmpPath); // partial work; remove it
+    }
+    throw e;
+  }
+});
+```
+
+## Transport and resume errors
+
+`TransportClosedError` fires when the transport (usually WebSocket) closes mid-request. `error.reason` is the close reason if the underlying transport reported one. All pending requests reject with this error at once.
+
+`ResumeFailedError` is raised when `tesseron/resume` fails — expired session, token mismatch, protocol version drift. The fallback is a fresh `connect()` without resume options:
+
+```ts
+async function connectWithResume(storedCredentials: ResumeCredentials | undefined) {
+  try {
+    return await tesseron.connect(undefined, { resume: storedCredentials });
+  } catch (e) {
+    if (e instanceof ResumeFailedError) {
+      clearStoredCredentials();
+      return await tesseron.connect(); // fresh claim-code flow
+    }
+    throw e;
+  }
+}
+```
+
+Never retry resume with the same stale credentials on a failure — the token is gone.
+
+## Never-swallow rules
+
+Certain errors should never be caught-and-hidden from the agent:
+
+- `CancelledError` — the user asked to stop; rethrow so the agent sees the cancellation.
+- `TimeoutError` — the user's deadline passed; don't pretend the call succeeded.
+- `InputValidation` — the input was wrong; the agent needs to know so it can rephrase.
+- `HandlerError` — something real went wrong; silent success returns incorrect state.
+
+Catch them only to clean up and rethrow.
+
+## Common mistakes
+
+- **`error.code === -32006` magic-number checks.** Use `instanceof SamplingNotAvailableError` — resilient to code renumbering.
+- **Catching `CancelledError` and returning a "default" success response.** The agent believes the work finished; it didn't. Let cancellation propagate.
+- **Calling `ctx.sample(...)` without `agentCapabilities.sampling`.** Don't rely on catching `SamplingNotAvailableError` as flow control; check the capability up front.
+- **Retrying on `TransportClosedError` in a tight loop.** The transport is dead; reconnect with exponential backoff, don't spam `send(...)`.
+- **Persisting a stale `resumeToken` after a `ResumeFailedError`.** Clear the credentials and fall back to a fresh connect.
+- **Using `throw` inside a handler to signal "not a real error, just a business outcome".** The agent sees `HandlerError` for any throw. Return a typed output shape instead (`{ ok: false, reason: '...' }`).
+- **Leaking raw errors into the agent's view.** `HandlerError.message` is visible to the agent and often the end user. Sanitize before throwing — no stack traces, no internal IDs, no secrets.

--- a/packages/pi/skills/framework/references/gateway.md
+++ b/packages/pi/skills/framework/references/gateway.md
@@ -1,0 +1,163 @@
+# Gateway (`@tesseron/mcp`)
+
+## Contents
+- What the gateway does
+- Discovery via `~/.tesseron/tabs/`
+- Environment variables
+- Tool naming convention
+- Tool surface modes
+- Meta tools (dispatcher fallback)
+- Multi-app sessions
+- Running as a plugin (default) vs standalone
+- Common mistakes
+
+## What the gateway does
+
+`@tesseron/mcp` is the bridge between Tesseron apps and MCP clients:
+
+- **SDK side**: the gateway is a WebSocket *client*. It watches `~/.tesseron/tabs/` for per-app discovery files and dials each app's loopback endpoint. Apps never need to know the gateway's address — the gateway finds them.
+- **MCP side**: exposes the joined app manifests as MCP tools and resources to a host (Claude Code, Claude Desktop, Cursor, etc.) over stdio.
+- **Routes both directions**: agent tool calls become `actions/invoke` on the SDK; SDK-side `ctx.sample` / `ctx.elicit` round-trip to the agent as MCP sampling / elicitation; `ctx.progress` and `ctx.log` become MCP notifications.
+
+When installed as a Claude Code plugin, the gateway is started automatically by the plugin's `.mcp.json` — users don't run it by hand. Running standalone is useful for development or for integrating with clients that are not auto-managed.
+
+## Discovery via `~/.tesseron/tabs/`
+
+Each app process writes a JSON file when it calls `tesseron.connect()`:
+
+```jsonc
+// ~/.tesseron/tabs/tab-mocythay-v0hh50.json
+{
+  "version": 1,
+  "tabId": "tab-mocythay-v0hh50",
+  "appName": "node-prompts",
+  "wsUrl": "ws://127.0.0.1:64872/",
+  "addedAt": 1777038462692
+}
+```
+
+The gateway polls + `fs.watch`es the directory and dials the `wsUrl` of each new tab. The app's WebSocket server only accepts upgrades on the `tesseron-gateway` subprotocol, so nothing else on loopback can impersonate a gateway.
+
+When an app disconnects (process exits, `sdk.disconnect()`), the tab file is deleted and the gateway's WebSocket client notices the socket close.
+
+## Environment variables
+
+Read at gateway startup:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `TESSERON_TOOL_SURFACE` | `both` | `dynamic` \| `meta` \| `both` (see below) |
+
+v2.0 removed `TESSERON_PORT`, `TESSERON_HOST`, `TESSERON_ORIGIN_ALLOWLIST`, `DEFAULT_GATEWAY_PORT`, and `DEFAULT_GATEWAY_HOST`. The gateway no longer binds a port or accepts inbound connections, so none of those options apply.
+
+## Tool naming convention
+
+Every Tesseron action becomes an MCP tool named:
+
+```
+<app_id>__<action_name>
+```
+
+- `todos__addTodo`
+- `shop__refundOrder`
+- `crm__createLead`
+
+This prefix makes multi-app sessions safe: `shop__refundOrder` and `crm__refundOrder` don't collide even if both apps are connected to the same gateway at the same time.
+
+Resources follow an analogous convention as MCP URIs:
+
+```
+tesseron://<app_id>/<resource_name>
+```
+
+e.g. `tesseron://todos/stats`.
+
+## Tool surface modes
+
+`TESSERON_TOOL_SURFACE` controls which tools the gateway exposes to the MCP client.
+
+```ts
+type ToolSurfaceMode = 'dynamic' | 'meta' | 'both';
+```
+
+### `dynamic` (spec-pure)
+
+Per-app tools + the claim-session tool, announced via `notifications/tools/list_changed` when apps connect/disconnect or register/remove actions. Best for agents that honor list-changed (Claude does).
+
+### `meta` (dispatcher fallback)
+
+No per-app tools. Instead, four fixed tools that mediate everything:
+
+- `tesseron__claim_session({ code })`
+- `tesseron__list_actions()` → manifests of all connected apps
+- `tesseron__invoke_action({ app_id, action, args })`
+- `tesseron__read_resource({ app_id, name })`
+
+Use this mode for clients that freeze their tool list at startup and never refresh — invocations still work, they just go through the dispatcher instead of appearing as first-class tools.
+
+### `both` (default)
+
+Per-app tools AND meta dispatcher tools. Maximum compatibility. Most users should leave this alone.
+
+## Meta tools
+
+Even in `dynamic` mode the gateway ships `tesseron__claim_session` as the entry point for the pairing handshake. When an SDK connects, it receives a 6-character claim code (`ABCD-XY`); the user tells the agent `claim session ABCD-XY` and the agent invokes:
+
+```jsonc
+{ "name": "tesseron__claim_session", "arguments": { "code": "ABCD-XY" } }
+```
+
+The gateway pairs the MCP session with the Tesseron session and the per-app tools appear (or become dispatcher-accessible).
+
+## Multi-app sessions
+
+Multiple Tesseron apps can connect to the same gateway simultaneously. Each gets its own `sessionId` and claim code. A single MCP client can pair with one or many of them — once paired, invocations route by `app_id` prefix.
+
+Use cases:
+- Developing a frontend + backend that both expose actions.
+- Claiming several sub-apps of a single product (shop + admin + CRM).
+- Running an admin dashboard alongside the app it's inspecting.
+
+Apps disconnect independently; the gateway emits `actions/list_changed` / `resources/list_changed` on each event.
+
+## Running as a plugin (default)
+
+The default install path — the Tesseron Claude Code plugin — ships `server/index.cjs` and declares `.mcp.json`:
+
+```jsonc
+{
+  "mcpServers": {
+    "tesseron": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/server/index.cjs"]
+    }
+  }
+}
+```
+
+Claude Code starts the gateway automatically on session launch. Nothing to configure — the gateway picks up tab files as apps announce themselves.
+
+## Running standalone
+
+For development or non-Claude-Code integrations:
+
+```bash
+# From the monorepo:
+pnpm --filter @tesseron/mcp start
+
+# Or launch the binary:
+npx @tesseron/mcp
+```
+
+Combined with a custom MCP client, this lets you iterate on the SDK without running through Claude Code. See `packages/mcp/src/cli.ts` for the reference bootstrap.
+
+## Common mistakes
+
+- **Expecting the gateway to accept an inbound WebSocket.** It doesn't — the architecture inverted in v2.0. Apps bind loopback WebSocket servers; the gateway dials them. Old code that connected an SDK to `ws://localhost:7475` will fail because no such server exists.
+- **Setting `TESSERON_PORT` / `TESSERON_HOST` / `TESSERON_ORIGIN_ALLOWLIST`.** These env vars no longer exist in v2.0. They're silently ignored.
+- **Changing the app `id` across releases.** Agents cache tool names `<app_id>__<action>`; renaming breaks their memory of which tool does what. Pick a stable `id` early.
+- **Relying on `TESSERON_TOOL_SURFACE=dynamic` alone with clients that don't honor list-changed.** If you know the target client freezes tools at startup, use `both` (default) or `meta`.
+- **Pasting the claim code into the terminal instead of the agent.** The claim code is consumed by the MCP client (Claude) calling `tesseron__claim_session`, not by the shell.
+- **Persisting the claim code.** It's one-shot; it expires quickly after the welcome handshake. Use the resume token for reconnection, not the claim code.
+- **Expecting a single gateway to route to SDKs on a different host.** The gateway only reads `~/.tesseron/tabs/` on the local filesystem and only dials loopback URLs. Remote apps need their own gateway or a WebSocket tunnel.

--- a/packages/pi/skills/framework/references/project-structure.md
+++ b/packages/pi/skills/framework/references/project-structure.md
@@ -1,0 +1,89 @@
+# Project structure
+
+Scoped to **Tesseron-specific** structural decisions only. Project scaffolding (`package.json`, `tsconfig.json`, bundler config, `.gitignore`, package-manager choice, framework version pins, and any framework-specific idioms) is outside Tesseron's scope — those decisions belong to the upstream scaffolder for the framework, or to a skill that specializes in that framework.
+
+For integrating Tesseron into a project, see the sibling `tesseron-dev` skill.
+
+## Contents
+
+- The three consumer packages
+- Where `tesseron.app(...)` goes
+- `app.id` rules
+- `@tesseron/*` version lockstep
+- Multi-app projects and tool-name collisions
+- Monorepo layout for shared schemas
+
+## The three consumer packages
+
+Tesseron ships three consumer packages (plus `@tesseron/core` for protocol types — not a consumer surface — and `@tesseron/mcp` for the bundled gateway binary — also not a consumer surface).
+
+| Package | Scope |
+|---|---|
+| `@tesseron/react` | React projects. Exports the hook API (`useTesseronAction`, `useTesseronResource`, `useTesseronConnection`) alongside the singleton. Tesseron ships framework-specific ergonomics here because React's hook model warrants them. |
+| `@tesseron/server` | Node processes — headless services, CLIs, long-running backends. |
+| `@tesseron/web` | Any other browser context. A framework-neutral singleton — the same API serves vanilla JS and any browser framework without a Tesseron-specific adapter. Tesseron does not ship framework-specific code for these; the singleton is called from whatever module scope or startup hook the framework provides. |
+
+Pick exactly one `@tesseron/*` package per process. They are singletons.
+
+## Where `tesseron.app(...)` goes
+
+`tesseron.app(...)` must run exactly once, at module scope, before the first `tesseron.action(...)` / `tesseron.resource(...)` / `tesseron.connect()` call. Beyond that, *which file* is the project's entry point is the framework's convention, not Tesseron's — Tesseron only asks that the call is at module scope so it runs once per process.
+
+- **React** (`@tesseron/react`): put `tesseron.app(...)` at module scope in the main entry file that bootstraps the React tree. Do not call it inside a component — re-mounting would re-register the manifest.
+- **Server** (`@tesseron/server`): put `tesseron.app(...)` at module scope in the Node entry file.
+- **Browser-non-React** (`@tesseron/web`): put `tesseron.app(...)` at module scope in whichever file the framework bootstraps from. The singleton is framework-neutral; the call runs at import time. `tesseron.connect()` can be awaited at module scope or scheduled inside whatever startup hook the framework exposes.
+
+## `app.id` rules
+
+- **Always `snake_case`** — lowercase letters, digits, and underscores. No spaces, dashes, slashes, dots.
+- **Stable.** The MCP gateway prefixes every action with `<app_id>__<action_name>` (e.g. `todos__addTodo`). Changing `app.id` breaks any saved tool lists or agent prompts that reference the prefix.
+- **Unique per connected app.** In a multi-app gateway session, two apps with the same `app.id` produce colliding tool names.
+- Derive a default from `package.json` `name`, normalized to `snake_case`.
+
+## `@tesseron/*` version lockstep
+
+All `@tesseron/*` packages — `core`, `web`, `server`, `react`, `mcp` — are released together. Within a single project, pin them to the **same minor version** or to a `^1.0.0`-style range that resolves them together. Mismatched minor versions cause subtle protocol drift:
+
+- A `@tesseron/web@^1.1.0` client speaking to a `@tesseron/mcp@^1.0.x` gateway may use protocol methods the gateway doesn't route.
+- The SDK's TypeScript types come from `@tesseron/core`, so if `@tesseron/core` resolves to a different version than the transport package, types can mismatch runtime behavior.
+
+`@tesseron/core` is not a direct dependency — the other packages re-export from it. Do not install `@tesseron/core` explicitly unless you need the low-level protocol types for a custom transport or test harness.
+
+## Multi-app projects and tool-name collisions
+
+One process, one `app.id`. If an application needs to expose multiple "surfaces" to the agent (e.g. an admin surface and a customer surface), that's two separate processes with two separate `app.id` values, each calling `tesseron.connect()` independently.
+
+When two apps connect to the same gateway session, their tools are prefixed independently: `shop_web__refundOrder` and `shop_admin__refundOrder` coexist without clashing. But if both use `app.id = "shop"`, the gateway's tool list has two `shop__refundOrder` entries and routing becomes undefined.
+
+## Monorepo layout for shared schemas
+
+Splitting a Tesseron-using project into multiple workspaces is worth doing only for these reasons:
+
+- **Shared schemas.** A frontend and a backend both need the same Zod/Valibot/Typebox input definitions. Extract them into a shared workspace package; both apps import from it.
+- **Shared handlers.** Handler logic lives in a domain package that both the HTTP API and the Tesseron surface call into.
+- **Multiple Tesseron apps** that ship independently but talk to the same gateway during development.
+
+A minimal shape:
+
+```
+my-product/
+├── apps/
+│   ├── web/              # one Tesseron app, app.id: "product_web"
+│   └── service/          # another Tesseron app, app.id: "product_service"
+└── packages/
+    └── shared/           # shared schemas, domain types, pure handlers
+```
+
+The Tesseron-specific rule is the `app.id` split (to avoid tool-name collisions) and the shared-package boundary for schemas. Workspace tooling, `tsconfig` inheritance, build orchestration, and package-manager choice are all outside Tesseron's scope.
+
+## Tesseron-specific anti-patterns
+
+- **Two `@tesseron/*` packages in the same process.** Only one singleton should register actions and connect.
+- **`tesseron.app(...)` inside a component or inside a function called per request.** It must run exactly once at module scope.
+- **`tesseron.connect()` before `tesseron.app(...)`.** Connect throws without an app manifest.
+- **Sharing `app.id` across two surfaces.** Tool-name collisions at the gateway.
+- **Pinning `@tesseron/*` packages to different minor versions.** Protocol drift.
+- **Importing from package internals (`@tesseron/core/dist/...`).** Not public API.
+- **Hardcoding `ws://127.0.0.1:7475`.** Use `DEFAULT_GATEWAY_URL` from the transport package.
+
+Beyond these, Tesseron has no opinion on project structure.

--- a/packages/pi/skills/framework/references/protocol.md
+++ b/packages/pi/skills/framework/references/protocol.md
@@ -1,0 +1,370 @@
+# Protocol (JSON-RPC 2.0 wire format)
+
+## Contents
+- Protocol version
+- Envelope
+- Handshake: `tesseron/hello` and `tesseron/resume`
+- Action methods: `actions/invoke`, `actions/cancel`
+- Notifications: `actions/progress`, `log`
+- Sampling and elicitation: `sampling/request`, `elicitation/request`
+- Resource methods: `resources/read`, `resources/subscribe`, `resources/updated`, `resources/unsubscribe`
+- Manifest changes: `actions/list_changed`, `resources/list_changed`
+- Error envelopes
+
+Most developers do not read this file — the SDK hides the protocol. Open it when debugging over the wire, writing a custom SDK in another language, or implementing a custom gateway.
+
+## Protocol version
+
+```ts
+PROTOCOL_VERSION = '1.0.0';
+JSONRPC_VERSION  = '2.0';
+```
+
+Every message is a JSON-RPC 2.0 envelope. The SDK and gateway both send and receive; methods are prefixed (`tesseron/*`, `actions/*`, `resources/*`, `sampling/*`, `elicitation/*`, `log`) to keep the surface clean.
+
+## Envelope
+
+```jsonc
+// Request (has "id", expects a reply)
+{ "jsonrpc": "2.0", "id": 1, "method": "tesseron/hello", "params": {...} }
+
+// Response (success)
+{ "jsonrpc": "2.0", "id": 1, "result": {...} }
+
+// Response (error)
+{ "jsonrpc": "2.0", "id": 1, "error": { "code": -32004, "message": "Invalid input", "data": [...] } }
+
+// Notification (no "id", no reply)
+{ "jsonrpc": "2.0", "method": "actions/progress", "params": {...} }
+```
+
+## Handshake
+
+### `tesseron/hello` (SDK → Gateway)
+
+Sent once after the transport opens. Announces the app, its actions, its resources, and the SDK's capabilities.
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tesseron/hello",
+  "params": {
+    "protocolVersion": "1.0.0",
+    "app": {
+      "id": "todos",
+      "name": "Todo App",
+      "description": "A todo app driven by Claude.",
+      "origin": "http://localhost:5173",
+      "iconUrl": "https://example.com/icon.png",
+      "version": "1.2.0"
+    },
+    "actions": [
+      {
+        "name": "addTodo",
+        "description": "Add a new todo item.",
+        "inputSchema": { "type": "object", "properties": { "text": { "type": "string" } }, "required": ["text"] },
+        "outputSchema": { "type": "object", "properties": { "id": { "type": "string" } } },
+        "annotations": { "readOnly": false, "destructive": false },
+        "timeoutMs": 60000
+      }
+    ],
+    "resources": [
+      { "name": "stats", "description": "Todo stats", "outputSchema": {...}, "subscribable": true }
+    ],
+    "capabilities": { "streaming": true, "subscriptions": true, "sampling": true, "elicitation": true }
+  }
+}
+```
+
+Response:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "sessionId": "sess_abc123",
+    "protocolVersion": "1.0.0",
+    "capabilities": {
+      "streaming": true, "subscriptions": true, "sampling": true, "elicitation": true
+    },
+    "agent": { "id": "claude-ai", "name": "Claude" },
+    "claimCode": "ABCD-EF",
+    "resumeToken": "token_xyz789"
+  }
+}
+```
+
+`claimCode` is the 6-character pairing code the user pastes into the agent (`claim session ABCD-EF`). It is one-shot — don't persist it.
+
+`resumeToken` should be persisted alongside `sessionId` for later resume.
+
+### `tesseron/resume` (SDK → Gateway)
+
+Sent in place of `tesseron/hello` when reconnecting with credentials. Payload is the same as `hello`, plus the stored credentials:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tesseron/resume",
+  "params": {
+    "sessionId": "sess_abc123",
+    "resumeToken": "token_xyz789",
+    "protocolVersion": "1.0.0",
+    "app": {...},
+    "actions": [...],
+    "resources": [...],
+    "capabilities": {...}
+  }
+}
+```
+
+On success, the response mirrors the `hello` result, with a **freshly rotated** `resumeToken` — persist the new one. On failure (expired session, token mismatch), the response is an error with code `-32011` (`ResumeFailed`). On failure, fall back to a fresh `tesseron/hello` without resume credentials.
+
+Zombie sessions — closed-but-not-yet-cleaned-up sessions retained so reconnecting SDKs can rejoin — are held for `resumeTtlMs` milliseconds (gateway default: 90s).
+
+## Action methods
+
+### `actions/invoke` (Gateway → SDK)
+
+The agent calls a tool; the gateway forwards to the SDK:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "method": "actions/invoke",
+  "params": {
+    "name": "addTodo",
+    "input": { "text": "Buy milk" },
+    "invocationId": "inv_12345",
+    "client": { "route": "/todos", "origin": "http://localhost:5173" }
+  }
+}
+```
+
+Response (success):
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "result": {
+    "invocationId": "inv_12345",
+    "output": { "id": "t1", "text": "Buy milk", "done": false }
+  }
+}
+```
+
+Response (error, e.g. input validation failure): see **Error envelopes** below.
+
+### `actions/cancel` (Gateway → SDK, notification)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "actions/cancel",
+  "params": { "invocationId": "inv_12345" }
+}
+```
+
+Fires `ctx.signal` in the handler. The SDK also responds to the original invocation with a `-32001` (`Cancelled`) error once the handler completes (or is aborted).
+
+## Notifications
+
+### `actions/progress` (SDK → Gateway)
+
+Emitted by `ctx.progress(...)`:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "actions/progress",
+  "params": {
+    "invocationId": "inv_12345",
+    "message": "Processing...",
+    "percent": 50,
+    "data": { "itemsProcessed": 5 }
+  }
+}
+```
+
+### `log` (SDK → Gateway)
+
+Emitted by `ctx.log(...)`:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "log",
+  "params": {
+    "invocationId": "inv_12345",
+    "level": "info",
+    "message": "Todo added",
+    "meta": { "count": 3 }
+  }
+}
+```
+
+## Sampling and elicitation
+
+### `sampling/request` (SDK → Gateway)
+
+Emitted by `ctx.sample(...)`:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 20,
+  "method": "sampling/request",
+  "params": {
+    "invocationId": "inv_12345",
+    "prompt": "Suggest a title for this article.",
+    "schema": { "type": "object", "properties": {...} },
+    "maxTokens": 1024
+  }
+}
+```
+
+Response:
+
+```jsonc
+{ "jsonrpc": "2.0", "id": 20, "result": { "content": "..." } }
+```
+
+Error `-32006` (`SamplingNotAvailable`) when the MCP client does not advertise sampling capability.
+
+### `elicitation/request` (SDK → Gateway)
+
+Emitted by `ctx.elicit(...)` or `ctx.confirm(...)`:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 21,
+  "method": "elicitation/request",
+  "params": {
+    "invocationId": "inv_12345",
+    "question": "Which tag?",
+    "schema": { "type": "object", "properties": { "tag": { "type": "string" } }, "required": ["tag"] }
+  }
+}
+```
+
+Response:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 21,
+  "result": { "action": "accept", "value": { "tag": "work" } }
+}
+```
+
+`action` is `"accept"` | `"decline"` | `"cancel"`. `ctx.confirm` collapses any non-accept to `false`. `ctx.elicit` returns `null` on decline/cancel.
+
+Error `-32007` (`ElicitationNotAvailable`) when the client does not advertise elicitation.
+
+## Resource methods
+
+### `resources/read` (Gateway → SDK)
+
+```jsonc
+{ "jsonrpc": "2.0", "id": 30, "method": "resources/read", "params": { "name": "stats" } }
+```
+
+Response:
+
+```jsonc
+{ "jsonrpc": "2.0", "id": 30, "result": { "value": { "total": 3, "completed": 1, "pending": 2 } } }
+```
+
+### `resources/subscribe` (Gateway → SDK)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 31,
+  "method": "resources/subscribe",
+  "params": { "name": "stats", "subscriptionId": "sub_789" }
+}
+```
+
+Response is empty. The SDK starts emitting updates.
+
+### `resources/updated` (SDK → Gateway, notification)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "resources/updated",
+  "params": { "subscriptionId": "sub_789", "value": {...} }
+}
+```
+
+### `resources/unsubscribe` (Gateway → SDK)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 32,
+  "method": "resources/unsubscribe",
+  "params": { "subscriptionId": "sub_789" }
+}
+```
+
+Triggers the subscriber's cleanup function.
+
+## Manifest change notifications
+
+When actions or resources are added or removed at runtime, the SDK notifies the gateway:
+
+### `actions/list_changed`
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "actions/list_changed",
+  "params": { "actions": [ /* ActionManifestEntry[] */ ] }
+}
+```
+
+### `resources/list_changed`
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "resources/list_changed",
+  "params": { "resources": [ /* ResourceManifestEntry[] */ ] }
+}
+```
+
+The gateway re-announces to the agent via MCP's `notifications/tools/list_changed` / `notifications/resources/list_changed`. Agents that honor these (Claude) pick up the changes live; agents that freeze their tool list at startup do not.
+
+## Error envelopes
+
+Every error is a JSON-RPC error response:
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "id": 10,
+  "error": {
+    "code": -32004,
+    "message": "Invalid input",
+    "data": [
+      { "path": ["text"], "message": "String must contain at least 1 character" }
+    ]
+  }
+}
+```
+
+See `errors.md` for the full code table and subclass mapping.
+
+## Non-misuses worth remembering
+
+- **`tesseron/hello` after `tesseron/resume` succeeds** — if resume succeeds, do NOT re-send `tesseron/hello`. The session is already in a stateful resumed state.
+- **`resources/list_changed` with the same entries as before** — emitting the notification with identical entries is a no-op; harmless, not a bug.
+- **Mixing request and notification shapes** — a request without `id` is a notification (no response), a response never has `method`. The SDK rejects malformed envelopes; don't hand-roll them unless you're writing a custom transport.

--- a/packages/pi/skills/framework/references/react.md
+++ b/packages/pi/skills/framework/references/react.md
@@ -1,0 +1,234 @@
+# React hooks (`@tesseron/react`)
+
+## Contents
+- What the hooks wrap
+- `useTesseronConnection`
+- `useTesseronAction`
+- `useTesseronResource`
+- The ref pattern for stable registration
+- Where to mount each hook
+- Common mistakes
+
+## What the hooks wrap
+
+`@tesseron/react` re-exports the `@tesseron/web` singleton and wraps it in three React hooks so actions and resources can be registered from component bodies:
+
+```ts
+import {
+  useTesseronAction,
+  useTesseronResource,
+  useTesseronConnection,
+} from '@tesseron/react';
+```
+
+Under the hood each hook calls the same `tesseron.action(...).handler(...)` / `tesseron.resource(...).read(...)` / `tesseron.connect(...)` on the singleton, with a `useEffect` for registration and another for cleanup on unmount.
+
+Every hook accepts an optional custom client as the last argument — omit it unless you're running multiple independent sessions:
+
+```ts
+useTesseronAction('addTodo', options /*, customClient */);
+```
+
+## `useTesseronConnection`
+
+Opens (and maintains) the session. Call **once**, at the app root.
+
+```ts
+interface UseTesseronConnectionOptions {
+  url?: string;      // override DEFAULT_GATEWAY_URL
+  enabled?: boolean; // default true; set false to defer connection
+}
+
+interface TesseronConnectionState {
+  status: 'idle' | 'connecting' | 'open' | 'error' | 'closed';
+  welcome?: WelcomeResult;
+  claimCode?: string;
+  error?: Error;
+}
+```
+
+```tsx
+import { useTesseronConnection } from '@tesseron/react';
+
+function App() {
+  const conn = useTesseronConnection();
+
+  if (conn.status === 'connecting') return <div>Connecting...</div>;
+  if (conn.status === 'error') return <div>Connection failed: {conn.error?.message}</div>;
+  if (conn.claimCode) {
+    return (
+      <div>
+        In Claude, say: <code>claim session {conn.claimCode}</code>
+      </div>
+    );
+  }
+  return <Todos />;
+}
+```
+
+**Register actions and resources before this hook runs.** The manifest announced in `tesseron/hello` is a snapshot at the moment of connect. Any `useTesseronAction` / `useTesseronResource` hooks that mount *after* `useTesseronConnection` are announced via `actions/list_changed` / `resources/list_changed` updates — valid, but slower to reach the agent.
+
+The simplest guarantee is mounting your action/resource-declaring components as descendants of the component that holds `useTesseronConnection`, and rendering them unconditionally.
+
+## `useTesseronAction`
+
+Registers an action for the component's lifetime.
+
+```ts
+interface UseTesseronActionOptions<I, O> {
+  description?: string;
+  input?: StandardSchemaV1<I>;
+  inputJsonSchema?: unknown;
+  output?: StandardSchemaV1<O>;
+  outputJsonSchema?: unknown;
+  annotations?: ActionAnnotations;
+  timeoutMs?: number;
+  strictOutput?: boolean;
+  handler: (input: I, ctx: ActionContext) => Promise<O> | O;
+}
+
+function useTesseronAction<I, O>(
+  name: string,
+  options: UseTesseronActionOptions<I, O>,
+  client?: WebTesseronClient,
+): void;
+```
+
+```tsx
+import { useTesseronAction } from '@tesseron/react';
+import { z } from 'zod';
+
+function TodoList() {
+  const [todos, setTodos] = useState<Todo[]>([]);
+
+  useTesseronAction('addTodo', {
+    description: 'Add a new todo item to the list. Returns the created todo.',
+    input: z.object({ text: z.string().min(1), tag: z.string().optional() }),
+    handler: ({ text, tag }) => {
+      const todo = { id: crypto.randomUUID(), text, done: false, tag };
+      setTodos((current) => [...current, todo]);
+      return todo;
+    },
+  });
+
+  useTesseronAction('completeTodo', {
+    description: 'Mark a todo as completed.',
+    input: z.object({ id: z.string() }),
+    annotations: { destructive: false },
+    handler: ({ id }) => {
+      setTodos((current) =>
+        current.map((t) => (t.id === id ? { ...t, done: true } : t)),
+      );
+      return { completed: true };
+    },
+  });
+
+  return <ul>{todos.map(/* ... */)}</ul>;
+}
+```
+
+On unmount, the hook calls `tesseron.removeAction(name)` automatically — no cleanup code in your component.
+
+## `useTesseronResource`
+
+Registers a resource for the component's lifetime. Accepts either a function (shorthand, read-only) or an options object.
+
+```ts
+interface UseTesseronResourceOptions<T> {
+  description?: string;
+  output?: StandardSchemaV1<T>;
+  outputJsonSchema?: unknown;
+  read?: () => T | Promise<T>;
+  subscribe?: (emit: (value: T) => void) => () => void;
+}
+
+function useTesseronResource<T>(
+  name: string,
+  optionsOrReader: UseTesseronResourceOptions<T> | (() => T | Promise<T>),
+  client?: WebTesseronClient,
+): void;
+```
+
+**Shorthand** (read-only resource):
+
+```tsx
+useTesseronResource('todoCount', () => todos.length);
+```
+
+**Full form** with subscribe:
+
+```tsx
+function Dashboard({ todos }: { todos: Todo[] }) {
+  const subscribers = useRef(new Set<(stats: Stats) => void>());
+
+  // Notify subscribers whenever todos change
+  useEffect(() => {
+    for (const emit of subscribers.current) emit(computeStats(todos));
+  }, [todos]);
+
+  useTesseronResource('stats', {
+    description: 'Todo statistics — total, completed, pending.',
+    output: z.object({ total: z.number(), completed: z.number(), pending: z.number() }),
+    subscribe: (emit) => {
+      emit(computeStats(todos));
+      subscribers.current.add(emit);
+      return () => subscribers.current.delete(emit);
+    },
+  });
+
+  return <StatsView />;
+}
+```
+
+The `useRef<Set<...>>(new Set())` pattern gives the subscriber closure a stable reference to a subscriber registry whose membership is edited on mount/unmount and whose entries are invoked on state change.
+
+## The ref pattern for stable registration
+
+Both `useTesseronAction` and `useTesseronResource` store the incoming handler in a `useRef` internally. Every render updates the ref; registration itself happens only on mount and is never replayed for a fresh closure.
+
+This is why **you do not need `useCallback` or `useMemo`** around the handler:
+
+```tsx
+// Both of these are equivalent from Tesseron's perspective.
+// The hook only re-registers when `name` changes.
+
+useTesseronAction('addTodo', {
+  handler: ({ text }) => { /* reads latest state */ },
+});
+
+useTesseronAction('addTodo', {
+  handler: useCallback(({ text }) => { /* same */ }, [/* deps */]),
+});
+```
+
+The handler you pass on every render closes over the latest state; the hook makes sure the action always calls the *latest* handler. This sidesteps the classic stale-closure pitfall of registering a handler once on mount and then seeing old state when it fires.
+
+## Where to mount each hook
+
+- `useTesseronConnection` — once, at the root. Multiple connection hooks create multiple sessions, each with its own claim code.
+- `useTesseronAction` — wherever the owning state lives. A component that owns `todos` state should own `addTodo` / `completeTodo`.
+- `useTesseronResource` — wherever the state being exposed lives. Usually the same component as the related actions.
+
+For app-wide actions that don't belong to a specific component (e.g. `logout`), mount them in a thin wrapper component that sits near the root:
+
+```tsx
+function TesseronActions() {
+  const { logout } = useAuth();
+  useTesseronAction('logout', {
+    description: 'Log the user out.',
+    annotations: { destructive: true, requiresConfirmation: true },
+    handler: () => logout(),
+  });
+  return null; // no UI
+}
+```
+
+## Common mistakes
+
+- **Multiple `useTesseronConnection` hooks.** Each opens its own session; only one claim code is useful. Put it at the root.
+- **`useCallback` / `useMemo` around the handler.** Unnecessary. The hook stores the handler in a ref; passing a fresh closure on every render is the intended API.
+- **Conditional hook calls.** `if (...) useTesseronAction(...)` violates the rules of hooks. Use `enabled: false` on the connection hook to defer the whole session; for per-action toggles, render or skip a dedicated wrapper component.
+- **Forgetting the cleanup function in `subscribe`.** Required. The hook's unmount path calls it — but only if you return it.
+- **Mounting action hooks conditionally under a `useTesseronConnection` that's already open.** Those actions announce via `actions/list_changed`, which Claude honors but some agents don't. Prefer mounting actions above/beside the connection hook so they're in the initial manifest.
+- **Closing over stale state without the ref pattern.** The built-in ref pattern handles this — don't manually `useRef` around the handler to "fix" it; just write the handler inline and it will see the latest state.
+- **Using `useTesseronResource` for truly static values.** If a value never changes, just pass a function returning a constant — but consider whether the resource is earning its keep.

--- a/packages/pi/skills/framework/references/resources.md
+++ b/packages/pi/skills/framework/references/resources.md
@@ -1,0 +1,158 @@
+# Resources (`ResourceBuilder` + `ResourceDefinition`)
+
+## Contents
+- Read-only vs subscribable
+- The builder chain
+- Shape of a resource definition
+- The subscribe contract (emit + cleanup)
+- Combining read and subscribe
+- Removing resources at runtime
+- Common mistakes
+
+## Read-only vs subscribable
+
+Resources expose app state to the agent in two modes:
+
+- **Read** — the agent calls `resources/read` on demand; the handler returns the current snapshot.
+- **Subscribe** — the agent registers for pushes; the handler emits whenever state changes.
+
+A resource can support one mode or both. Use read-only for expensive or rarely-changing values (user profile, static config, current auth state). Use subscribe for anything the agent benefits from seeing in real time (current selection, counters, active tab, streaming metrics).
+
+## The builder chain
+
+```ts
+import { tesseron } from '@tesseron/web';
+import { z } from 'zod';
+
+// Read-only resource
+tesseron
+  .resource('todoCount')
+  .describe('Total number of todo items.')
+  .output(z.number().int().nonnegative())
+  .read(() => todos.length);
+
+// Subscribable resource
+tesseron
+  .resource('stats')
+  .describe('Todo statistics — total, completed, pending.')
+  .output(z.object({
+    total: z.number(),
+    completed: z.number(),
+    pending: z.number(),
+  }))
+  .subscribe((emit) => {
+    emit(currentStats());
+
+    const callback = () => emit(currentStats());
+    statsSubscribers.add(callback);
+    return () => statsSubscribers.delete(callback);
+  });
+
+// Both — the agent can read on demand AND subscribe to pushes
+tesseron
+  .resource('currentUser')
+  .describe('The currently signed-in user.')
+  .output(z.object({ id: z.string(), email: z.string() }))
+  .read(() => getCurrentUser())
+  .subscribe((emit) => {
+    emit(getCurrentUser());
+    return authStore.onChange(() => emit(getCurrentUser()));
+  });
+```
+
+Unlike `ActionBuilder`, which commits only on `.handler(...)`, `ResourceBuilder` registers on the first terminal call (`.read(...)` or `.subscribe(...)`). Chaining both is explicitly supported.
+
+## Shape of a resource definition
+
+```ts
+interface ResourceDefinition<T> {
+  name: string;
+  description: string;
+  outputSchema?: StandardSchemaV1<T>;
+  reader?: ResourceReader<T>;
+  subscriber?: ResourceSubscriber<T>;
+}
+
+type ResourceReader<T> = () => T | Promise<T>;
+type ResourceSubscriber<T> = (emit: (value: T) => void) => () => void;
+```
+
+Once registered, the resource is announced in `tesseron/hello` and exposed to the agent as an MCP resource at `tesseron://<app_id>/<resource_name>`.
+
+## The subscribe contract
+
+The subscriber receives an `emit` function and **must return a cleanup function**:
+
+```ts
+(emit: (value: T) => void) => () => void
+```
+
+Canonical pattern:
+
+```ts
+.subscribe((emit) => {
+  // 1. Emit the current value immediately.
+  emit(snapshot());
+
+  // 2. Register an internal callback that emits on change.
+  const callback = (next: T) => emit(next);
+  subscribers.add(callback);
+
+  // 3. Return a cleanup that unregisters the callback.
+  return () => subscribers.delete(callback);
+});
+```
+
+**Why the initial emit matters.** The first `resources/read` that an agent performs after subscribing waits for a value. Without an initial `emit(...)`, the read hangs until some app state changes — which may be never.
+
+**Why cleanup must be idempotent.** Unsubscribe can race with session end; cleanup may be invoked more than once. Use `.delete(callback)` / check-before-remove patterns. Do not throw.
+
+**Emitting promises is not supported.** `emit(...)` takes a resolved value, not a `Promise`. Await inside the subscriber if needed:
+
+```ts
+.subscribe((emit) => {
+  let cancelled = false;
+  void (async () => {
+    const value = await loadInitialValue();
+    if (!cancelled) emit(value);
+  })();
+  store.onChange((v) => emit(v));
+  return () => { cancelled = true; };
+});
+```
+
+## Combining read and subscribe
+
+A resource with both `.read(...)` and `.subscribe(...)` is exposed as a readable resource with push updates. The agent can call `resources/read` at any time (runs the reader) and register `resources/subscribe` to get notifications (runs the subscriber).
+
+The two handlers operate independently — reads do not consume subscriber events; subscriber pushes do not trigger the reader. Both are expected to reflect the same underlying state.
+
+```ts
+tesseron
+  .resource('filter')
+  .describe('Active filter: "all" | "active" | "completed".')
+  .output(z.enum(['all', 'active', 'completed']))
+  .read(() => state.filter)
+  .subscribe((emit) => {
+    emit(state.filter);
+    return state.onFilterChange((f) => emit(f));
+  });
+```
+
+## Removing resources at runtime
+
+```ts
+tesseron.removeResource('stats');
+```
+
+Sends `resources/list_changed` so the agent can refresh, and automatically calls every active subscriber's cleanup. Useful when a resource becomes unavailable (e.g. on logout, on feature-flag change).
+
+## Common mistakes
+
+- **`.subscribe((emit) => { ... })` without a return.** The subscription runs forever. Even if the subscriber does nothing to tear down, return a no-op (`() => {}`) so the framework's cleanup path still fires.
+- **Forgetting the initial `emit(...)`.** The first agent read after subscription hangs waiting for a push that may never come. Always emit the current value before returning.
+- **Throwing from the cleanup function.** Cleanup is invoked during session teardown and must not throw; wrap disposal in `try/catch` if the underlying store can throw.
+- **Mutating shared state inside the reader.** `.read(...)` should be pure with respect to observable state; mutations break idempotency and confuse the agent.
+- **Leaking secrets or PII in resource output.** Resource values flow verbatim to the agent and are surfaced in the MCP transcript. Scrub before emitting.
+- **Emitting a `Promise` instead of a value.** `emit` expects a resolved value; wrap async work in a `(async () => { ... })()` IIFE and `emit(...)` after the await.
+- **Registering subscribers in the reader.** The reader returns a snapshot; the subscriber owns its own subscription lifecycle. Keep them separate.

--- a/packages/pi/skills/framework/references/schemas.md
+++ b/packages/pi/skills/framework/references/schemas.md
@@ -1,0 +1,163 @@
+# Schemas (Standard Schema + Zod / Valibot / Typebox)
+
+## Contents
+- Standard Schema spec
+- Zod (most common)
+- Valibot
+- Typebox
+- The optional `jsonSchema` argument
+- What the agent actually sees
+- Output schemas and `.strictOutput()`
+- Common mistakes
+
+## Standard Schema spec
+
+Tesseron does not ship its own validator. `.input(...)` and `.output(...)` accept any object implementing the [Standard Schema v1 spec](https://standardschema.dev):
+
+```ts
+type StandardSchemaV1<T> = {
+  '~standard': {
+    version: 1;
+    vendor: string;
+    validate: (value: unknown) =>
+      | { value: T }
+      | { issues: StandardSchemaV1.Issue[] };
+  };
+};
+```
+
+Zod, Valibot, and Typebox all implement this spec out of the box. So do many other validators — if your favorite does, it works.
+
+## Zod
+
+Most Tesseron code in the wild uses Zod. It's the most ergonomic option and `z.toJSONSchema(...)` produces high-quality JSON Schema for the manifest.
+
+```ts
+import { z } from 'zod';
+
+const TodoInput = z.object({
+  text: z.string().min(1).describe('The text content of the todo'),
+  tag: z.enum(['work', 'personal', 'urgent']).optional().describe('Optional tag'),
+  priority: z.number().int().min(1).max(5).default(3).describe('1 = low, 5 = high'),
+});
+
+tesseron
+  .action('addTodo')
+  .describe('Add a new todo item.')
+  .input(TodoInput, z.toJSONSchema(TodoInput))
+  .handler(({ text, tag, priority }) => { /* ... */ });
+```
+
+Use `.describe(...)` on individual fields — Zod flows those into the generated JSON Schema and Instructor-style validators surface them to the agent as argument hints.
+
+**Zod version.** `z.toJSONSchema(...)` lives on Zod 4+. On Zod 3 you can use the community `zod-to-json-schema` package or skip the second argument entirely (see below).
+
+## Valibot
+
+```ts
+import { object, string, minLength, pipe, enum as v_enum, optional } from 'valibot';
+
+const TodoInput = object({
+  text: pipe(string(), minLength(1)),
+  tag: optional(v_enum({ Work: 'work', Personal: 'personal', Urgent: 'urgent' })),
+});
+
+tesseron
+  .action('addTodo')
+  .describe('Add a todo.')
+  .input(TodoInput)
+  .handler(({ text, tag }) => { /* ... */ });
+```
+
+Valibot is smaller than Zod at the cost of a sparser DX for deriving JSON Schema. Pass the second `jsonSchema` argument manually if your agent needs rich argument hints.
+
+## Typebox
+
+```ts
+import { Type } from '@sinclair/typebox';
+
+const TodoInput = Type.Object({
+  text: Type.String({ minLength: 1, description: 'The text content' }),
+  tag: Type.Optional(Type.Union([
+    Type.Literal('work'),
+    Type.Literal('personal'),
+    Type.Literal('urgent'),
+  ])),
+});
+
+tesseron
+  .action('addTodo')
+  .describe('Add a todo.')
+  .input(TodoInput, TodoInput) // Typebox schemas ARE JSON Schema
+  .handler(({ text, tag }) => { /* ... */ });
+```
+
+Typebox is unique in that its runtime schema objects *are* valid JSON Schema — you can pass the same object as both the validator and the `jsonSchema` argument.
+
+## The optional `jsonSchema` argument
+
+`.input(schema, jsonSchema?)` and `.output(schema, jsonSchema?)` both accept a second argument: a plain JSON Schema object that is sent to the agent in the manifest.
+
+```ts
+// With explicit JSON Schema — recommended
+.input(TodoInput, z.toJSONSchema(TodoInput))
+
+// Without — the gateway falls back to a permissive schema
+.input(TodoInput)
+```
+
+**What the agent sees when you pass a JSON Schema:** a typed, constrained hint — field names, types, enums, min/max — that lets the agent generate the right call.
+
+**What the agent sees when you omit it:** a permissive fallback (`{ type: 'object', additionalProperties: true }`). Invocations still validate at runtime against your validator, but the agent has less information to work with, so it may produce inputs that validate poorly.
+
+**Rule of thumb:** always pass `jsonSchema` when you can derive it cheaply (Zod 4's `z.toJSONSchema`, Typebox's own schema, a generator library). Skip it only when deriving is painful and the action is simple enough that the description + `.describe()` per-field already makes the shape obvious.
+
+## What the agent actually sees
+
+The manifest entry for an action reaching the agent looks roughly like:
+
+```jsonc
+{
+  "name": "todos__addTodo",              // <app_id>__<action_name>
+  "description": "Add a new todo item.", // from .describe(...)
+  "inputSchema": {                        // from jsonSchema OR the fallback
+    "type": "object",
+    "properties": {
+      "text": { "type": "string", "minLength": 1, "description": "The text content of the todo" },
+      "tag":  { "type": "string", "enum": ["work", "personal", "urgent"] }
+    },
+    "required": ["text"]
+  },
+  "annotations": { "destructive": false, "readOnly": false }
+}
+```
+
+The agent builds a tool call using this schema; the SDK validates it against your validator when `actions/invoke` arrives; invalid input is rejected with `InputValidation` (`-32004`) before your handler runs.
+
+## Output schemas and `.strictOutput()`
+
+`.output(schema)` serves two purposes:
+
+1. It's published in the manifest so the agent can reason about what it will receive.
+2. It's validated at runtime (*informational* by default; *enforced* with `.strictOutput()`).
+
+```ts
+// Default — validation is advisory; output is returned to the agent even if invalid
+.output(z.object({ id: z.string() }))
+
+// Strict — validation failure throws HandlerError and the agent sees an error
+.output(z.object({ id: z.string() }))
+.strictOutput()
+```
+
+Use `.strictOutput()` when the agent's next step depends on the exact shape. Skip it when you want graceful degradation — the agent is often smart enough to handle slightly different output shapes.
+
+## Common mistakes
+
+- **Passing a plain TypeScript `interface` or `type` to `.input(...)`.** TypeScript types erase at runtime. They cannot validate anything. Use a real validator.
+- **Omitting the `jsonSchema` argument when you could derive it for free.** The permissive fallback works but gives the agent less help; an imperfect JSON Schema is better than none.
+- **Forgetting `.describe(...)` on Zod fields.** Field descriptions flow into the JSON Schema as `description` and into the agent's tool signature. The agent leans on them when picking arguments.
+- **Writing JSON Schema by hand for a Zod object.** `z.toJSONSchema(schema)` produces what you'd write anyway; hand-written versions drift. If Zod 4 is not yet in the project, use `zod-to-json-schema`.
+- **Validating output "strictly" everywhere by default.** Strict output is a hard gate — if your handler occasionally returns an extra field, the agent sees an error. Reserve `.strictOutput()` for shapes the agent must rely on.
+- **Mixing validator libraries for one action.** Stick to one library per codebase unless you have a strong reason; interop between Zod + Valibot + Typebox works but increases cognitive load.
+- **Treating schema errors as generic `Error`.** Input validation failures produce `TesseronError` with `code: -32004` (`InputValidation`) and a `data` field containing the issue path. Branch on that, not message text.

--- a/packages/pi/skills/framework/references/testing.md
+++ b/packages/pi/skills/framework/references/testing.md
@@ -1,0 +1,294 @@
+# Testing
+
+## Contents
+- Test framework (Vitest)
+- Testing action handlers directly
+- Mocking `ActionContext`
+- The capturing-registry pattern for builder tests
+- In-memory transport for round-trip tests
+- Testing resources (read + subscribe)
+- Testing session resume
+- Testing React hooks
+- Common mistakes
+
+## Test framework
+
+Tesseron itself is tested with [Vitest](https://vitest.dev). Consumer projects can use any test framework — Vitest, Jest, Node's built-in `node:test` — because the SDK does not depend on a test runner. The patterns below use Vitest syntax (`describe` / `it` / `expect` / `vi`) but port directly.
+
+```json
+// package.json
+{
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.0"
+  }
+}
+```
+
+## Testing action handlers directly
+
+The fastest and highest-leverage tests are direct handler invocations. Build the action, pull `handler` off the resulting `ActionDefinition`, and call it with a mocked `ActionContext`.
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { tesseron } from '@tesseron/web';
+import { z } from 'zod';
+import type { ActionContext } from '@tesseron/core';
+
+describe('addTodo action', () => {
+  it('adds a todo with the given text', async () => {
+    const todos: Todo[] = [];
+
+    const def = tesseron
+      .action('addTodo')
+      .describe('...')
+      .input(z.object({ text: z.string() }))
+      .handler(({ text }) => {
+        const todo = { id: '1', text, done: false };
+        todos.push(todo);
+        return todo;
+      });
+
+    const ctx: ActionContext = makeMockContext();
+
+    const result = await def.handler({ text: 'Buy milk' }, ctx);
+
+    expect(result).toEqual({ id: '1', text: 'Buy milk', done: false });
+    expect(todos).toHaveLength(1);
+  });
+});
+```
+
+Handlers are invoked with `await` regardless of whether they're sync or async, so the test always awaits the return value.
+
+## Mocking `ActionContext`
+
+A reusable helper keeps tests short:
+
+```ts
+import type { ActionContext } from '@tesseron/core';
+import { vi } from 'vitest';
+
+export function makeMockContext(overrides: Partial<ActionContext> = {}): ActionContext {
+  return {
+    signal: new AbortController().signal,
+    agentCapabilities: { sampling: true, elicitation: true, subscriptions: true },
+    agent: { id: 'test-agent', name: 'Test Agent' },
+    client: { origin: 'http://localhost' },
+    progress: vi.fn(),
+    log: vi.fn(),
+    sample: vi.fn().mockResolvedValue('mocked sample'),
+    confirm: vi.fn().mockResolvedValue(true),
+    elicit: vi.fn().mockResolvedValue({ tag: 'test' }),
+    ...overrides,
+  };
+}
+```
+
+Then override only what the specific test cares about:
+
+```ts
+it('returns the default when sampling is unavailable', async () => {
+  const ctx = makeMockContext({
+    agentCapabilities: { sampling: false, elicitation: false, subscriptions: true },
+  });
+  const result = await def.handler({ topic: 'AI' }, ctx);
+  expect(result.suggestion).toBe('AI'); // fallback path
+});
+
+it('cancels cleanly when the signal aborts', async () => {
+  const ac = new AbortController();
+  const ctx = makeMockContext({ signal: ac.signal });
+  const p = def.handler({ items: [1, 2, 3] }, ctx);
+  ac.abort();
+  await expect(p).rejects.toThrow(/cancel/i);
+});
+```
+
+## The capturing-registry pattern for builder tests
+
+To test the builder chain itself (not the handler), use a capturing registry — a lightweight stand-in for the client that records what gets registered. This is what `@tesseron/core`'s own tests do:
+
+```ts
+import type { ActionDefinition, ResourceDefinition } from '@tesseron/core';
+
+class CapturingRegistry {
+  actions: ActionDefinition[] = [];
+  resources: ResourceDefinition[] = [];
+
+  registerAction(a: ActionDefinition): void { this.actions.push(a); }
+  registerResource(r: ResourceDefinition): void { this.resources.push(r); }
+}
+
+it('records description and annotations', () => {
+  const registry = new CapturingRegistry();
+  // (In production code, ActionBuilderImpl is internal; here illustrative.)
+  const builder = /* build with registry */;
+
+  builder
+    .describe('Hello')
+    .annotate({ readOnly: true })
+    .handler(() => 'hi');
+
+  const [action] = registry.actions;
+  expect(action.name).toBe('myAction');
+  expect(action.description).toBe('Hello');
+  expect(action.annotations.readOnly).toBe(true);
+});
+```
+
+This is lower-level than most consumer projects need — typically direct handler tests (above) are enough.
+
+## In-memory transport for round-trip tests
+
+For integration tests that exercise the full handshake and message flow without a real WebSocket, pair two `InMemoryTransport` instances:
+
+```ts
+import type { Transport } from '@tesseron/core';
+
+class InMemoryTransport implements Transport {
+  peer?: InMemoryTransport;
+  private messageHandlers: Array<(m: unknown) => void> = [];
+  private closeHandlers: Array<(r?: string) => void> = [];
+
+  send(message: unknown): void {
+    queueMicrotask(() => this.peer?.deliver(message));
+  }
+  private deliver(message: unknown): void {
+    for (const h of this.messageHandlers) h(message);
+  }
+  onMessage(handler: (m: unknown) => void): void { this.messageHandlers.push(handler); }
+  onClose(handler: (r?: string) => void): void { this.closeHandlers.push(handler); }
+  close(reason?: string): void {
+    for (const h of this.closeHandlers) h(reason);
+  }
+}
+
+it('completes the hello handshake', async () => {
+  const clientT = new InMemoryTransport();
+  const serverT = new InMemoryTransport();
+  clientT.peer = serverT;
+  serverT.peer = clientT;
+
+  const fakeGateway = new FakeGateway(serverT); // your test double
+
+  tesseron.app({ id: 'test', name: 'Test' });
+  tesseron.action('ping').describe('Ping').handler(() => 'pong');
+
+  const welcome = await tesseron.connect(clientT);
+  expect(welcome.sessionId).toBeDefined();
+  expect(welcome.claimCode).toMatch(/^[A-Z]{4}-[A-Z]{2}$/);
+});
+```
+
+The `FakeGateway` responds to `tesseron/hello` with a canned `WelcomeResult` and routes `actions/invoke` as test assertions require.
+
+## Testing resources (read + subscribe)
+
+Resource reads are straightforward — call `def.reader?.()`:
+
+```ts
+it('reads current todo count', () => {
+  const todos = ['a', 'b', 'c'];
+  const def = tesseron
+    .resource('todoCount')
+    .describe('Count')
+    .read(() => todos.length);
+
+  expect(def.reader?.()).toBe(3);
+});
+```
+
+Subscribers need a bit more ceremony — capture emits into an array:
+
+```ts
+it('emits initial value and updates', () => {
+  const registry = new Set<(v: number) => void>();
+  let count = 0;
+
+  const def = tesseron
+    .resource('counter')
+    .describe('Counter')
+    .subscribe((emit) => {
+      emit(count);
+      registry.add(emit);
+      return () => registry.delete(emit);
+    });
+
+  const emits: number[] = [];
+  const cleanup = def.subscriber!((v) => emits.push(v));
+
+  expect(emits).toEqual([0]); // initial emit
+
+  count = 1;
+  for (const emit of registry) emit(count);
+
+  expect(emits).toEqual([0, 1]);
+
+  cleanup();
+  count = 2;
+  for (const emit of registry) emit(count);
+
+  expect(emits).toEqual([0, 1]); // cleanup unregistered
+});
+```
+
+## Testing session resume
+
+Resume tests need the in-memory transport round-trip. First connect, capture `{ sessionId, resumeToken }`, close the transport, reconnect with `{ resume: credentials }`, and assert the gateway response.
+
+```ts
+it('resumes a session with a valid token', async () => {
+  const welcome1 = await tesseron.connect(transport1);
+  const creds = { sessionId: welcome1.sessionId, resumeToken: welcome1.resumeToken! };
+
+  transport1.close();
+
+  const welcome2 = await tesseron.connect(transport2, { resume: creds });
+  expect(welcome2.sessionId).toBe(creds.sessionId);
+  expect(welcome2.resumeToken).not.toBe(creds.resumeToken); // rotated
+});
+
+it('falls back to fresh connect on ResumeFailed', async () => {
+  const badCreds = { sessionId: 'stale', resumeToken: 'expired' };
+  await expect(
+    tesseron.connect(transport, { resume: badCreds }),
+  ).rejects.toThrow(/resume/i);
+});
+```
+
+## Testing React hooks
+
+For React hook tests, use `@testing-library/react` and render a test component that registers the hook. The `@tesseron/react` hooks are thin wrappers around the singleton — testing the hook end-to-end usually means testing the underlying registration, which is already covered by the direct handler tests above.
+
+When you need to test hook behavior specifically (e.g. that unmount removes the action), override the optional `client` parameter with a capturing client so the registration is observable:
+
+```tsx
+import { render } from '@testing-library/react';
+import { useTesseronAction } from '@tesseron/react';
+
+it('registers on mount and removes on unmount', () => {
+  const fakeClient = new CapturingClient();
+  function Thing() {
+    useTesseronAction('ping', { handler: () => 'pong' }, fakeClient as any);
+    return null;
+  }
+  const { unmount } = render(<Thing />);
+  expect(fakeClient.actions).toContain('ping');
+
+  unmount();
+  expect(fakeClient.actions).not.toContain('ping');
+});
+```
+
+## Common mistakes
+
+- **Testing against a real gateway.** Slow, flaky, and tightly coupled to dev-server state. Use in-memory transports and direct handler calls.
+- **Not awaiting handler invocations in tests.** Handlers may be sync, but always `await` — sync handlers return the value directly, async handlers return a promise, and `await` handles both.
+- **Forgetting to abort signals in cancellation tests.** Create an `AbortController`, hand `.signal` to the mock context, and call `.abort()` at the right moment.
+- **Mocking `ActionContext` partially and casting `as ActionContext`.** Works at runtime but skips type safety. Provide all fields in the factory (`makeMockContext`) — TypeScript will tell you when the API changes.
+- **Using `console.log` to debug tests.** Vitest's snapshots and `expect` give better feedback; `console.log` spam clutters CI output.
+- **Asserting on `error.message` text.** Messages may change; assert on `error.code` or `instanceof TesseronError`.

--- a/packages/pi/skills/framework/references/transports.md
+++ b/packages/pi/skills/framework/references/transports.md
@@ -1,0 +1,250 @@
+# Transports
+
+## Contents
+- The `Transport` interface
+- `BrowserWebSocketTransport`
+- `NodeWebSocketTransport`
+- `DEFAULT_GATEWAY_URL`
+- Session resume
+- Writing a custom transport
+- In-memory transport for tests
+- Common mistakes
+
+## The `Transport` interface
+
+A transport is a bidirectional, JSON-object channel. The SDK and the gateway exchange JSON-RPC 2.0 messages; the transport shuttles them back and forth.
+
+```ts
+interface Transport {
+  send(message: unknown): void;
+  onMessage(handler: (message: unknown) => void): void;
+  onClose(handler: (reason?: string) => void): void;
+  close(reason?: string): void;
+}
+```
+
+**Contract notes.**
+
+- `send(message)` is called with a plain JavaScript object (already parsed). Implementations that ship over a wire call `JSON.stringify(message)` before writing.
+- `onMessage(handler)` / `onClose(handler)` are called **exactly once** by the client — don't re-register.
+- Messages delivered to `onMessage(...)` are expected as parsed objects, not strings. If your underlying channel delivers strings (WebSocket, stdio), call `JSON.parse(...)` inside the transport before invoking the handler.
+- `close(...)` is idempotent-safe — calling close on an already-closed transport must not throw.
+
+## `BrowserWebSocketTransport`
+
+```ts
+import { BrowserWebSocketTransport } from '@tesseron/web';
+
+const transport = new BrowserWebSocketTransport('ws://localhost:7475');
+await transport.ready(); // resolves when WebSocket.readyState === OPEN
+await tesseron.connect(transport);
+```
+
+Usually you do **not** need to construct a transport explicitly — `tesseron.connect()` with no arguments creates a `BrowserWebSocketTransport(DEFAULT_GATEWAY_URL)` for you:
+
+```ts
+await tesseron.connect(); // equivalent to connect(new BrowserWebSocketTransport(DEFAULT_GATEWAY_URL))
+```
+
+Pass a string to override the URL without constructing the transport yourself:
+
+```ts
+await tesseron.connect('ws://staging.internal:7475');
+```
+
+## `NodeWebSocketTransport`
+
+```ts
+import { NodeWebSocketTransport } from '@tesseron/server';
+
+const transport = new NodeWebSocketTransport('ws://localhost:7475');
+await transport.ready();
+await tesseron.connect(transport);
+```
+
+Wraps the `ws` npm package. Handles `Buffer`/`ArrayBuffer` incoming messages by decoding to UTF-8 before parsing JSON. Same no-arg + string-URL shortcuts apply:
+
+```ts
+await tesseron.connect();              // default gateway
+await tesseron.connect('ws://host:7475'); // override URL
+```
+
+## `DEFAULT_GATEWAY_URL`
+
+```ts
+import { DEFAULT_GATEWAY_URL } from '@tesseron/web'; // or '@tesseron/server'
+
+console.log(DEFAULT_GATEWAY_URL); // 'ws://localhost:7475'
+```
+
+Exported from both `@tesseron/web` and `@tesseron/server`. Use this constant rather than hardcoding the URL — when the gateway ships on a different port in the future (or you need to swap for HTTPS/WSS), one import site changes.
+
+## Session resume
+
+`ConnectOptions.resume` carries the credentials from a previous session:
+
+```ts
+import type { ResumeCredentials } from '@tesseron/core';
+
+interface ConnectOptions {
+  resume?: ResumeCredentials;
+}
+
+interface ResumeCredentials {
+  sessionId: string;
+  resumeToken: string;
+}
+```
+
+Typical flow:
+
+```ts
+// First connect — store credentials
+const welcome = await tesseron.connect();
+localStorage.setItem('tesseron-session', JSON.stringify({
+  sessionId: welcome.sessionId,
+  resumeToken: welcome.resumeToken,
+}));
+
+// Later (page reload, network drop) — reconnect
+try {
+  const stored = localStorage.getItem('tesseron-session');
+  const resume = stored ? JSON.parse(stored) as ResumeCredentials : undefined;
+  const newWelcome = await tesseron.connect(undefined, { resume });
+
+  // Token rotates on every successful resume — write back the fresh one
+  localStorage.setItem('tesseron-session', JSON.stringify({
+    sessionId: newWelcome.sessionId,
+    resumeToken: newWelcome.resumeToken,
+  }));
+} catch (e) {
+  if (e instanceof ResumeFailedError) {
+    localStorage.removeItem('tesseron-session');
+    await tesseron.connect(); // fresh claim-code flow
+  } else {
+    throw e;
+  }
+}
+```
+
+Resume semantics are covered in depth in `protocol.md`.
+
+## Writing a custom transport
+
+Any object implementing `Transport` works. The SDK only interacts with the four methods.
+
+**postMessage transport** (iframe ↔ parent):
+
+```ts
+import type { Transport } from '@tesseron/core';
+
+class PostMessageTransport implements Transport {
+  private messageHandlers: Array<(m: unknown) => void> = [];
+  private closeHandlers: Array<(r?: string) => void> = [];
+  private listener: (e: MessageEvent) => void;
+  private closed = false;
+
+  constructor(private target: Window, private targetOrigin: string) {
+    this.listener = (e) => {
+      if (e.origin !== this.targetOrigin) return;
+      if (this.closed) return;
+      for (const h of this.messageHandlers) h(e.data);
+    };
+    window.addEventListener('message', this.listener);
+  }
+
+  send(message: unknown): void {
+    if (this.closed) return;
+    this.target.postMessage(message, this.targetOrigin);
+  }
+  onMessage(handler: (m: unknown) => void): void { this.messageHandlers.push(handler); }
+  onClose(handler: (r?: string) => void): void { this.closeHandlers.push(handler); }
+  close(reason?: string): void {
+    if (this.closed) return;
+    this.closed = true;
+    window.removeEventListener('message', this.listener);
+    for (const h of this.closeHandlers) h(reason);
+  }
+}
+```
+
+**stdio transport** (Node child process):
+
+```ts
+import type { Transport } from '@tesseron/core';
+import { createInterface } from 'node:readline';
+
+class StdioTransport implements Transport {
+  private messageHandlers: Array<(m: unknown) => void> = [];
+  private closeHandlers: Array<(r?: string) => void> = [];
+  private rl = createInterface({ input: process.stdin });
+
+  constructor() {
+    this.rl.on('line', (line) => {
+      try {
+        const msg = JSON.parse(line);
+        for (const h of this.messageHandlers) h(msg);
+      } catch {
+        // Ignore malformed lines
+      }
+    });
+    this.rl.on('close', () => {
+      for (const h of this.closeHandlers) h('stdin closed');
+    });
+  }
+
+  send(message: unknown): void {
+    process.stdout.write(JSON.stringify(message) + '\n');
+  }
+  onMessage(handler: (m: unknown) => void): void { this.messageHandlers.push(handler); }
+  onClose(handler: (r?: string) => void): void { this.closeHandlers.push(handler); }
+  close(reason?: string): void {
+    this.rl.close();
+    for (const h of this.closeHandlers) h(reason);
+  }
+}
+```
+
+## In-memory transport for tests
+
+Paired transports that deliver to each other — useful for integration tests that exercise the full handshake without a real WebSocket:
+
+```ts
+import type { Transport } from '@tesseron/core';
+
+class InMemoryTransport implements Transport {
+  peer?: InMemoryTransport;
+  private messageHandlers: Array<(m: unknown) => void> = [];
+  private closeHandlers: Array<(r?: string) => void> = [];
+
+  send(message: unknown): void {
+    setTimeout(() => this.peer?.deliver(message), 0);
+  }
+  private deliver(message: unknown): void {
+    for (const h of this.messageHandlers) h(message);
+  }
+  onMessage(handler: (m: unknown) => void): void { this.messageHandlers.push(handler); }
+  onClose(handler: (r?: string) => void): void { this.closeHandlers.push(handler); }
+  close(reason?: string): void {
+    for (const h of this.closeHandlers) h(reason);
+  }
+}
+
+// Usage:
+const clientSide = new InMemoryTransport();
+const serverSide = new InMemoryTransport();
+clientSide.peer = serverSide;
+serverSide.peer = clientSide;
+```
+
+Feed one to `tesseron.connect(...)` and the other to your fake gateway.
+
+## Common mistakes
+
+- **Calling `send(...)` with a string instead of an object.** The SDK hands the transport the parsed message — transports call `JSON.stringify(...)` *themselves* before writing to the wire.
+- **Calling `onMessage(...)` with an unparsed string.** Transports deliver parsed objects — call `JSON.parse(...)` inside the transport before invoking the handler.
+- **Registering `onMessage` / `onClose` handlers more than once.** The client calls each exactly once. If a transport accumulates handlers, message delivery skews.
+- **Forgetting `transport.close()` on teardown.** Leaks the underlying resource (WebSocket, child process, message listener). The TesseronClient calls `close()` on `disconnect()`.
+- **Mixing `BrowserWebSocketTransport` in Node or `NodeWebSocketTransport` in the browser.** Runtime error — one expects the `WebSocket` global, the other uses the `ws` package.
+- **Hardcoding `ws://localhost:7475` instead of importing `DEFAULT_GATEWAY_URL`.** A future gateway move requires changing every import site.
+- **Retrying `send(...)` in a tight loop after a `onClose` fires.** The transport is dead; reject pending requests and reconnect.

--- a/packages/pi/skills/tesseron-dev/SKILL.md
+++ b/packages/pi/skills/tesseron-dev/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: tesseron-dev
+description: Set up and maintain Tesseron integration in a JS/TS project. Picks the right consumer package (`@tesseron/react` for React, `@tesseron/server` for Node, `@tesseron/web` for any other browser context), installs it with the project's existing package manager, ensures a Standard-Schema validator is present, and inserts the canonical Tesseron API — `tesseron.app(...)`, at least one action, at least one resource, `tesseron.connect(...)` — at module scope of the entry point. Also handles integration maintenance: switching consumer packages, upgrading `@tesseron/*` versions in lockstep, splitting a multi-surface app into multiple `app.id` values, or removing Tesseron. Strictly scoped to Tesseron concerns — does not create projects, scaffold build tooling, pick framework versions, or template framework-specific integration code (reactive primitives, component patterns, lifecycle hooks). Use when the user says "add tesseron", "integrate tesseron", "wire up @tesseron/web" / "/react" / "/server", "upgrade tesseron", "switch to @tesseron/react", "split this into two tesseron apps", or opens a project without `@tesseron/*` yet and wants to start using it.
+---
+
+# Tesseron dev
+
+The go-to skill for getting Tesseron into a project and keeping it cleanly wired as the project evolves. It is the *integration* skill — not the *API tutorial* skill (that is the sibling `framework` skill, which covers how to design actions, resources, handlers, and so on). If the question is "how do I use Tesseron's API?", load `framework`. If the question is "how do I wire Tesseron into this project, switch to a different consumer package, or adjust the integration shape?", you are in the right place.
+
+This skill does not create projects, pick build tooling, or template framework-specific code. Project creation is someone else's job (upstream scaffolders, framework-specific skills, or the user's own hand). Once the project exists, this skill gets Tesseron correctly integrated with it.
+
+## What Tesseron officially supports
+
+Tesseron ships five consumer packages plus one build-tool plugin. Everything else — package managers, TypeScript configs, framework-specific idioms — is outside Tesseron's responsibility.
+
+| Package | Scope |
+|---|---|
+| `@tesseron/react` | React projects — exports `useTesseronAction`, `useTesseronResource`, `useTesseronConnection`. |
+| `@tesseron/svelte` | Svelte 5 projects — exports `tesseronAction`, `tesseronResource`, `tesseronConnection` runes-style helpers with lifecycle-scoped registration. |
+| `@tesseron/vue` | Vue 3 projects — Composition API equivalents of the Svelte helpers with the same lifecycle-scoped semantics. |
+| `@tesseron/server` | Node processes — headless services, CLIs, backend adapters. |
+| `@tesseron/web` | **Any other browser context.** A framework-neutral singleton — the same singleton API serves vanilla JS and any browser framework Tesseron does not officially ship a dedicated adapter for. |
+| `@tesseron/vite` | Vite dev-server plugin. **Required for every browser app in v2** — exposes the `/@tesseron/ws` bridge the gateway dials into. Add it to `vite.config.ts` alongside the consumer package. |
+
+`@tesseron/core` (protocol types) and `@tesseron/mcp` (the gateway binary) are not consumer packages; ignore them here.
+
+## Phase 1 — Pick the package
+
+Detect from the project's `package.json` + file layout:
+
+- `svelte` in dependencies → `@tesseron/svelte`.
+- `vue` in dependencies → `@tesseron/vue`.
+- `react` and `react-dom` in dependencies → `@tesseron/react`.
+- Node process without a browser bundle (no `index.html`, no Vite/webpack/etc., `@types/node` present) → `@tesseron/server`.
+- Anything else that runs in a browser → `@tesseron/web`.
+
+For browser apps, ALSO install `@tesseron/vite` as a dev dependency and register it in `vite.config.ts` — v2 relies on the plugin to bridge the browser WebSocket to the gateway.
+
+If the signals conflict (e.g. a React app embedded in a Node workspace — which package applies is usually about where the `tesseron.connect()` will run), ask the user which process needs the agent surface. Only one consumer `@tesseron/*` package per process.
+
+If the project is on a non-JS/TS stack (Rails, Django, Go, raw PHP, etc.), stop. Tesseron consumes the SDK from JS/TS only.
+
+## Phase 2 — Ensure a validator is available
+
+Every action needs a Standard-Schema-compatible validator for its `.input(...)`. Check `dependencies` + `devDependencies` for one of (preference order): `zod`, `valibot`, `@sinclair/typebox`. If none is present, install `zod`. Do not install a second validator if the project already has one.
+
+## Phase 3 — Install
+
+Detect the package manager from the lockfile (`pnpm-lock.yaml` → pnpm, `yarn.lock` → yarn, `bun.lockb` → bun, `package-lock.json` or none → npm) and use it. Never swap managers.
+
+Install the chosen `@tesseron/*` package (+ the validator if missing, + `@tesseron/vite` as a devDependency for browser apps) pinned as `^2.0.0`. All `@tesseron/*` packages release in lockstep, so this range resolves them compatibly as new minors land. If an older project is still on `^1.0.0`, upgrade it to `^2.0.0` — v2 is a breaking reverse-connection migration and mixing majors will fail at connect time.
+
+## Phase 4 — Insert the canonical Tesseron API
+
+The Tesseron API is framework-neutral. Every integration has the same four calls:
+
+### 1. App manifest — exactly once, at module scope, before any action/resource
+
+```ts
+tesseron.app({
+  id: '<snake_case>',
+  name: '<Human Readable Name>',
+  description: '<one-line purpose>',
+});
+```
+
+`app.id` is snake_case and stable — it's the prefix the MCP gateway applies to every tool name (`<app_id>__<action_name>`). Derive a default from `package.json` `name` normalized to snake_case; ask the user only if that clashes.
+
+### 2. At least one action
+
+```ts
+tesseron
+  .action('<name>')
+  .describe('<what it does, written for the LLM>')
+  .input(<validator schema>)
+  .handler((input, ctx) => { /* mutate state, return a result */ });
+```
+
+Always include `.describe(...)` — it is the LLM's only signal for when to call this action.
+
+### 3. At least one resource
+
+```ts
+tesseron
+  .resource('<name>')
+  .describe('<what it exposes>')
+  .output(<validator schema>)
+  .read(() => <current value>);
+```
+
+A resource exposes state to the agent. The minimal scaffold should include one so the user sees the full shape; they can remove it later if they only need actions.
+
+### 4. Connect
+
+```ts
+const welcome = await tesseron.connect();
+// welcome.claimCode is the 6-character code the user pastes into Claude.
+```
+
+### Where these calls live
+
+The canonical calls are framework-neutral. *Where* they go in the project is the framework's convention, not Tesseron's:
+
+- **React** (`@tesseron/react`): `tesseron.app(...)` at module scope in the main entry file (`src/main.tsx` or equivalent). Actions and resources can be registered either at module scope via `tesseron.action(...)` / `tesseron.resource(...)` or — when they need to close over component state — inside components via `useTesseronAction(...)` / `useTesseronResource(...)`. `useTesseronConnection()` surfaces the connection object (including `claimCode`) to whichever component renders the pairing UI.
+- **Server** (`@tesseron/server`): all four calls at module scope of the Node entry file. For Express/Fastify/Koa hybrids, put the Tesseron block in the same file as `app.listen(...)` so they share process state.
+- **Browser-non-React** (`@tesseron/web`): all four calls at module scope of the framework's entry file (whichever file the framework bootstraps from). The singleton does not care about framework lifecycle — `tesseron.app(...)` runs at import time; `tesseron.connect()` can be awaited at module scope or scheduled inside a framework-provided startup hook.
+
+**Do not template framework-specific code.** Reactive primitives, component patterns, and lifecycle idioms of any non-React framework belong to the framework — not to Tesseron. If the user is working in such a framework, they already know how to wire a module-scope import; if another skill is active that specializes in that framework, let it handle idiomatic placement.
+
+If you don't know the project's framework well enough to place calls idiomatically, put them at module scope of the main entry file. That is the lowest-common-denominator placement and will work. Tell the user it's a safe default, not an idiomatic one, and invite them to relocate if their framework prefers a different hook.
+
+## Phase 5 — Surface the claim code
+
+`tesseron.connect()` returns a `WelcomeResult` whose `claimCode` is a 6-character string the user pastes into Claude to pair the session. Make it visible:
+
+- **Headless**: `console.log(\`Claim code: ${welcome.claimCode}\`)`.
+- **React** (`@tesseron/react`): `useTesseronConnection()` exposes `claimCode` — render it in whichever component owns the pairing UI.
+- **Browser-non-React** (`@tesseron/web`): feed the resolved `claimCode` into the framework's own reactivity primitive (state, ref, signal, observable) and render it. Do not template this — it is the framework's UI concern, not Tesseron's.
+
+## Phase 6 — Hand off
+
+1. Start the app with whatever dev command the project already has — do not invent new scripts.
+2. When the claim code appears, the user says `claim session <code>` in Claude and the app's actions become typed MCP tools.
+3. The `framework` skill is auto-triggered for further Tesseron work (more actions, subscribable resources, `ActionContext` methods, session resume, tests). The `tesseron-reviewer` skill runs before commit.
+
+## Other integration changes
+
+Beyond first-time setup, this skill also covers:
+
+- **Switching consumer packages.** A project originally using `@tesseron/web` that now wants React's hook ergonomics: uninstall `@tesseron/web`, install `@tesseron/react`, rewrite the module-scope registrations into hook calls where component-scoped state requires it. Only one consumer package per process at the end.
+- **Upgrading `@tesseron/*` versions.** All `@tesseron/*` packages ship in lockstep. Upgrade them together. Bump every `@tesseron/*` dep in `package.json` to the same new version, run the project's install, re-run typecheck. A matching `@tesseron/mcp` gateway version lives in the plugin — users who installed the plugin at the same version are already aligned; users on older plugin installs may need to reinstall the plugin after a major bump.
+- **Splitting one Tesseron app into two `app.id` values.** When a single process is exposing two logically distinct surfaces to the agent, they should be two separate processes with two `app.id` values. See `framework/references/project-structure.md` for the multi-app section and tool-name collision rules.
+- **Removing Tesseron.** Uninstall the `@tesseron/*` package and the validator if it was installed by this skill (check whether the project uses it elsewhere first). Delete the `tesseron.app(...)` / action / resource / `tesseron.connect()` block. Leave bundler config, tsconfig, and framework code untouched.
+
+For each of these, apply the same rules as the install flow: use the project's existing package manager, do not touch framework config, do not template framework-specific code. The `framework` skill's references are the source of truth for what the Tesseron API is — consult them if you need to verify current shapes before editing.
+
+## Constraints
+
+- Never create `package.json`, `tsconfig.json`, or any framework config file.
+- Never swap the package manager or touch framework version pins.
+- Never register more than one `@tesseron/*` package per process.
+- Never template framework-specific integration code. The canonical Tesseron API is framework-neutral; framework-specific idioms are outside this skill's scope.
+- Never import from package internals (`@tesseron/core/dist/...` or cross-package relative paths). Only the top-level exports are public API.
+- Always include `.describe(...)` on every action and resource.
+- Always use a Standard-Schema validator on `.input(...)` — never a plain TypeScript type.
+- Use `crypto.randomUUID()` for ids. It's available in all supported runtimes.
+
+## When to stop and ask
+
+- Detection is ambiguous (multiple processes could reasonably host the Tesseron surface).
+- The entry point already contains a `tesseron.app(...)` call (inserting a second one throws).
+- The project uses a layout where module scope isn't obvious (Electron main+renderer split, Webview host, custom bundler with an unusual entry).
+- The project's framework is non-JS/TS (Tesseron does not apply).

--- a/packages/pi/skills/tesseron-docs/SKILL.md
+++ b/packages/pi/skills/tesseron-docs/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: tesseron-docs
+description: Authoritative Tesseron documentation lookup via the `@tesseron/docs-mcp` MCP server. Calls `search_docs` to find relevant pages and `read_doc` to fetch the full markdown body when the user asks precision questions about Tesseron protocol or SDK behaviour. Triggers on requests that need an exact spec, not an overview — wire format (JSON-RPC envelopes, `tesseron/hello`, `tesseron/welcome`, `tesseron/resume`, `actions/progress`, `actions/cancel`), transport framing, handshake and claim-code flow, session resume and resumeToken, lifecycle transitions, sampling contract, elicitation contract (`ctx.confirm`, `ctx.elicit`), progress + cancellation via `AbortSignal`, error codes (`TesseronErrorCode`, `SamplingNotAvailableError`, `ElicitationNotAvailableError`, `TimeoutError`, `CancelledError`, `ResumeFailedError`), capability negotiation, origin allowlist, multi-app namespacing, MCP gateway config, Standard Schema (Zod, Valibot, Typebox) integration, action-builder steps, resource read/subscribe, React hook semantics. Use phrases like "what error code does X return", "what does tesseron/hello look like", "exact handshake shape", "resumeToken flow", "gateway origin allowlist", "show me the spec for", "what fields does X accept". The `framework` skill handles orientation and the mental model; `tesseron-docs` handles chapter-and-verse questions.
+---
+
+# Tesseron docs
+
+This skill is the on-demand, authoritative lookup path for Tesseron documentation. Whenever precision matters (exact wire-format envelope, specific error code, fields a handshake carries, structural contract of resume) prefer calling the MCP tools below over recalling from memory or the `framework` skill's cheat sheet.
+
+## How to use
+
+The plugin bundles `@tesseron/docs-mcp` at install time, so these tools are normally already connected in Claude Code as `mcp__plugin_tesseron_tesseron-docs__*`:
+
+1. **Search first.** Call `search_docs({ query, limit })` with the user's question as-is (or a short paraphrase that keeps the load-bearing nouns). It returns ranked hits with `slug`, `title`, `description`, `score`, and a ~240-char `snippet`. `limit` defaults to 8 and caps at 20; 4-8 is the sweet spot.
+
+2. **Read the top hit.** Call `read_doc({ slug })` on the first promising hit. It returns the full markdown body plus structured frontmatter (`title`, `description`, `section`, `related`). Quote the exact spec text into your answer instead of paraphrasing it.
+
+3. **Walk the graph if the answer is cross-cutting.** The `related` field in `read_doc`'s response is a slug list. Follow those edges with more `read_doc` calls when a single page does not cover the question. Typical example: `protocol/resume` is incomplete without `protocol/handshake` and `protocol/transport`.
+
+4. **Fall back to `list_docs` only** when the user wants the full catalogue ("what are all the protocol pages?") or when `search_docs` keeps missing the page you expect.
+
+## When *not* to use this skill
+
+- For orientation or mental-model questions ("what is Tesseron?", "how does the SDK fit together?", "which consumer package should I use?") — load the `framework` skill. That skill is a cheat sheet; this one is a manual.
+- For project-integration tasks ("add Tesseron to this app", "switch to `@tesseron/react`", "upgrade versions") — load the `tesseron-dev` skill.
+- For codebase mapping or review — load the `tesseron-explorer` or `tesseron-reviewer` skill. They read the project, not the docs.
+
+## Fallbacks when the MCP server is not configured
+
+If calls to `mcp__plugin_tesseron_tesseron-docs__*` fail (e.g. the user has disabled the MCP server) fall back in order:
+
+1. Read directly from `docs/src/content/docs/**/*.{md,mdx}` if the workspace is the Tesseron monorepo itself.
+2. Fetch the deployed site: `https://brainblend-ai.github.io/tesseron/llms-full.txt` has the complete docs as plain text; `https://brainblend-ai.github.io/tesseron/<section>/<slug>/` serves the rendered page.
+3. Defer to the `framework` skill's bundled reference files (`plugin/skills/framework/references/*.md`).
+
+Never answer precision questions from training data alone without noting that you could not retrieve the current spec.
+
+## Citing sources
+
+When you read a page via `read_doc`, cite it by slug and link the hosted URL so the user can verify. Example:
+
+> Per `protocol/handshake` (https://brainblend-ai.github.io/tesseron/protocol/handshake/), the welcome frame carries `sessionId`, `claimCode`, `resumeToken`, and the negotiated `capabilities`.
+
+The slug is stable; the published URL tracks the same path.

--- a/packages/pi/skills/tesseron-explorer/SKILL.md
+++ b/packages/pi/skills/tesseron-explorer/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: tesseron-explorer
+description: Maps existing Tesseron TypeScript codebases — catalogs apps, actions, resources, context-method usage, transports, React hooks, and session-lifecycle wiring; traces how agent invocations flow through handlers into app state; returns a compact architecture summary with file:line references. Use PROACTIVELY when the user asks to "explore", "map", "understand", "analyze", "trace", or "explain how this works" in a project that imports from `@tesseron/core`, `@tesseron/web`, `@tesseron/server`, `@tesseron/react`, or `@tesseron/mcp`, or before extending a non-trivial Tesseron codebase. The caller should pass the scope (project root, package, or specific feature) in the invocation prompt.
+---
+
+# Tesseron explorer
+
+Map an existing Tesseron TypeScript application — its app manifests, actions, resources, context-method usage, transports, React hooks, and session lifecycle — and return a compact summary the caller can act on without re-reading the files themselves.
+
+## Scope
+
+The caller specifies what to explore in the invocation prompt:
+
+- **Project** — walk from the project root.
+- **Package** — scope to a package or directory (e.g. `packages/core`, `examples/react-todo`).
+- **Feature** — trace a specific capability end-to-end (e.g. "how does session resume flow through the client").
+
+If the caller does not specify, start from the directory the parent thread is operating in and locate every file that imports from `@tesseron/*`.
+
+## Discovery order
+
+1. **Project shape.** Read `package.json` (root and workspace packages) for workspace layout, dependency versions, and `scripts`. Grep for `"@tesseron/` in all `package.json` files to identify which packages are consumers (`@tesseron/web`, `/server`, `/react`) and which are the SDK itself. Identify entry points (`src/main.ts`, `src/main.tsx`, `src/app.tsx`, `src/index.ts`, `vite.config.ts`, `tsconfig.json`).
+
+2. **SDK surface.** Grep for framework anchors:
+   - `from '@tesseron/web'` / `from '@tesseron/server'` / `from '@tesseron/react'` / `from '@tesseron/core'` — consumer imports.
+   - `tesseron.app(` — app manifest registration.
+   - `tesseron.action(` / `.action(` — action builder chains.
+   - `tesseron.resource(` / `.resource(` — resource builder chains.
+   - `tesseron.connect(` — session handshake sites.
+   - `useTesseronAction(` / `useTesseronResource(` / `useTesseronConnection(` — React hook sites.
+   - `ctx.sample(` / `ctx.confirm(` / `ctx.elicit(` / `ctx.progress(` / `ctx.log(` / `ctx.signal` — context method use.
+   - `ResumeCredentials` / `resumeToken` / `sessionId` — resume-flow persistence.
+   - `BrowserWebSocketTransport` / `NodeWebSocketServerTransport` / `@tesseron/vite` plugin / `implements Transport` — transport wiring.
+   - `TesseronError` / `SamplingNotAvailableError` / `ElicitationNotAvailableError` / `TimeoutError` / `ResumeFailedError` — error handling.
+
+3. **Component mapping.** For each match, open just enough of the file to capture the component's shape. Do not read the whole file if a targeted span will do.
+
+4. **Data-flow.** Trace how invocations propagate:
+   - Gateway → SDK: `actions/invoke` → handler → state mutation → subscribers → `resources/updated` notifications.
+   - SDK → Gateway: `tesseron/hello` or `tesseron/resume` → welcome → ongoing invocations.
+   - Handler → Agent: `ctx.sample` / `ctx.confirm` / `ctx.elicit` round-trips.
+   - React lifecycle: registration via hooks → ref updates → handler closures over fresh state → cleanup on unmount.
+   - Multi-channel state (e.g. Express + Tesseron sharing a store): pub/sub hookup between channels.
+
+## What to capture for each component
+
+**App**
+
+- `id` and `name` — file:line of `tesseron.app(...)` call.
+- `description`, `origin`, `version`.
+- Whether a session is established in the same file (`tesseron.connect(...)`) or elsewhere (e.g. React `useTesseronConnection` at app root).
+- Whether resume credentials are persisted (localStorage, sessionStorage, IndexedDB, server-side store).
+
+**Action**
+
+- Name and one-sentence purpose.
+- File:line of the builder chain.
+- Input schema (validator + shape), output schema (if any), whether `.strictOutput()` is set.
+- Annotations (`readOnly` / `destructive` / `requiresConfirmation`).
+- Timeout override.
+- Handler sync vs async, side effects (state mutation, HTTP calls, DB writes, subscriber notify).
+- Context-method use: `sample` / `confirm` / `elicit` / `progress` / `log` / `signal` forwarding.
+
+**Resource**
+
+- Name and one-sentence purpose.
+- File:line of the builder chain.
+- Output schema.
+- `read()` reader (pure vs impure), `subscribe()` wiring (initial emit, callback registry, cleanup function).
+- Subscribers: where the app signals updates (state setters, pub/sub callbacks, `$effect` / `watch`).
+
+**Transport**
+
+- Which transport implementation: `BrowserWebSocketTransport` (client, dials a `/@tesseron/ws` bridge), `NodeWebSocketServerTransport` (server, hosts a loopback endpoint and writes a tab file), custom postMessage, in-memory for tests.
+- For browser apps: whether `@tesseron/vite` is configured (required in v2.0 — it bridges browser tabs to the gateway via `/@tesseron/ws`).
+- Resume usage — whether `ConnectOptions.resume` is wired.
+
+**React hook site**
+
+- Component path + hook call.
+- For `useTesseronAction`: action name, closure captures, whether handler uses fresh state via refs.
+- For `useTesseronResource`: shorthand (function) vs full options, subscribe pattern.
+- For `useTesseronConnection`: where it mounts (root vs nested), connection state consumer (claim-code UI, error banner, etc.).
+
+**Session lifecycle**
+
+- How claim code is surfaced to the user (inline text, toast, modal).
+- How welcome is stored and read.
+- How resume credentials are persisted and refreshed (remember: `resumeToken` rotates on every successful resume).
+
+## Output format
+
+```
+## Codebase Map: <project or feature name>
+
+### Overview
+
+<two or three sentences on what the app exposes to Claude, which stack it uses, and which transport/gateway pattern is in play>
+
+### Entry points
+
+- `<path>:<line>` — <role>
+
+### Apps
+
+- **<AppId>** (`<path>:<line>`). <one-sentence purpose>. Description=<...>. Connects via <transport + URL>. Resume: <persisted? where?>.
+
+### Actions
+
+- **<actionName>** — `<path>:<line>`. <one-sentence purpose>. Input=<shape>, Output=<shape or "none">, Strict=<yes/no>, Annotations=<readOnly/destructive/confirm>, Timeout=<default or override>. Context use: <sample/confirm/elicit/progress/log/signal>. Side effects: <...>.
+
+### Resources
+
+- **<resourceName>** — `<path>:<line>`. <one-sentence purpose>. Read=<pure/impure>, Subscribe=<yes/no>. Emitter wiring: <where the app triggers updates>.
+
+### Transports
+
+- `<path>:<line>` — <implementation>. Target: <URL>. Options: <resume? allowlist? timeout?>.
+
+### React hooks (if applicable)
+
+- `<path>:<line>` — `useTesseronAction('<name>', ...)` / `useTesseronResource(...)` / `useTesseronConnection(...)`. Closure pattern: <fresh state via ref / stable closure / other>.
+
+### Session lifecycle
+
+<how hello/resume happens, where claim code surfaces, how credentials persist, where disconnect is handled>
+
+### Data flow
+
+<ASCII / short prose: Gateway → handler → state → subscribers, plus any sample/elicit round-trips>
+
+### Essential reading list
+
+Prioritized files the caller should open to understand the system further, with a one-line reason per file.
+
+### Observations (optional)
+
+Flag notable patterns, risks, or anomalies. Do not review — just point out what seems structurally interesting. Hand detailed review off to the `tesseron-reviewer` skill.
+```
+
+Keep the total map focused. Token ceiling: aim for one or two screens of Markdown plus the essential-reading list. For larger codebases, produce a two-level map: a top-level shape + one level of detail per component, and dive deeper only where the user asks.
+
+## Exploration principles
+
+1. **Read narrowly.** Use targeted greps with `-n` and small `Read` offsets. Reading entire files when a 30-line span is enough wastes context and delays the summary.
+2. **Cite file:line everywhere.** Every claim needs a reference the user can verify.
+3. **Describe what exists, do not design.** Design questions ("how should we extend this?") are a separate task. Your output is a factual map.
+4. **Note anomalies, do not fix.** Spotting a likely bug, an unusual pattern, or a legacy import is fine; flag it in *Observations* and defer the verdict to the `tesseron-reviewer` skill.
+5. **Stop when the map is complete.** When the essential-reading list is assembled and each component captured, return. Over-reading past that point wastes context.

--- a/packages/pi/skills/tesseron-reviewer/SKILL.md
+++ b/packages/pi/skills/tesseron-reviewer/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: tesseron-reviewer
+description: Reviews Tesseron TypeScript code for framework- and protocol-specific correctness — app manifest hygiene, action/resource builder invariants, ActionContext capability checks, handler async/signal forwarding, subscriber cleanup, session resume flow, React hook registration patterns, gateway origin-allowlist sanity — using confidence-based filtering. Use PROACTIVELY after any change to Tesseron code, before commit or PR, and whenever the user asks to review, audit, check, or validate code that imports from `@tesseron/core`, `@tesseron/web`, `@tesseron/server`, `@tesseron/react`, or `@tesseron/mcp`. Complements generic code review by focusing only on Tesseron-specific concerns. The caller should pass the scope (diff, file paths, or module) in the invocation prompt.
+---
+
+# Tesseron reviewer
+
+Find framework- and protocol-specific defects in code written against the [Tesseron](https://github.com/BrainBlend-AI/tesseron) protocol and SDK with high precision. False positives destroy reviewer trust. Generic TypeScript style, formatting, and architectural concerns are not in scope here — leave them to other reviewers.
+
+## Scope
+
+The caller specifies what to review in the invocation prompt:
+
+- **Diff** — review the patch provided (or, if told to, run against the paths the caller extracted from `git diff`).
+- **Paths** — review the files or directories listed.
+- **Module** — review everything that imports from `@tesseron/*` under the given path.
+
+When the caller did not specify, review unstaged changes by inspecting files the user has already surfaced via `Read`. Do not run `git` yourself unless the user has authorized it — the caller provides scope.
+
+Skip any issue that is not specific to Tesseron:
+
+- General TypeScript style (naming, formatting, lint rules) — not in scope.
+- Algorithmic or architectural critiques unrelated to the protocol or SDK — not in scope.
+- Pre-existing issues outside the reviewed scope — not in scope.
+
+## Checklist
+
+Work through the categories below in order. Raise an issue only at ≥75% confidence (≥50% for security). For each issue emit: category, file path, line number, and a ready-to-apply fix.
+
+### 1. App manifest (`tesseron.app(...)`)
+
+- `tesseron.app({...})` is called **before** `tesseron.connect(...)`. Otherwise connect throws.
+- `id` is stable across releases (agents cache tool names `<app_id>__<action>`). Changing it breaks cached agent memory. Typically snake_case or kebab-case.
+- `name` and `description` are user-facing (appear in the MCP tool-list UI) — present, concise, and accurate.
+- `origin` is present for non-browser apps (server, embedded); browsers default to `location.origin`.
+
+### 2. Actions (`.action(...)` builder chain)
+
+- `.describe(...)` is set. The LLM reads this to decide when to call the action — an undescribed action is effectively unusable. Write for the model, not the developer.
+- `.input(schema)` set when the action takes arguments. Zero-arg "click-to-invoke" actions can omit input.
+- Input validator implements `StandardSchemaV1` (Zod, Valibot, Typebox). Plain TypeScript interfaces do not validate at runtime.
+- `.output(schema)` used when the agent branches on the response shape. Pair with `.strictOutput()` if output correctness is a hard requirement — without it, invalid output is logged but still returned.
+- `.annotate({ destructive: true })` set on destructive actions (deletes, resets, external side effects). `requiresConfirmation: true` when a user-facing confirmation should be surfaced by the agent. `readOnly: true` on pure getters.
+- `.handler(fn)` is the **terminal** method. Nothing chained after it. Anything after `.handler(...)` is operating on `ActionDefinition`, not the builder — silent bug.
+- Handler is `async` when it does I/O, calls `ctx.sample`/`confirm`/`elicit`, or awaits subscribers. Synchronous handlers are fine for pure state mutations.
+- Handler forwards `ctx.signal` to `fetch`, child-process, DB, or other cancellable calls. Otherwise cancellation from the gateway does not propagate through the call stack.
+- Handler calls `ctx.progress(...)` when the operation exceeds ~1–2 seconds so the agent can surface progress.
+
+### 3. Resources (`.resource(...)` builder chain)
+
+- `.describe(...)` set. Same rationale as actions.
+- At least one of `.read(...)` or `.subscribe(...)` present. A resource with neither is not registered.
+- `.subscribe(emit)` returns a **cleanup function**. Missing the return is a leak — the subscription runs forever.
+- Subscriber emits at least one initial value before returning. Without an initial emit, the agent's first read blocks waiting for a push.
+- Cleanup is **idempotent** — it may be called more than once when multiple unsubscribes race, and must not throw.
+- No secrets or PII in resource output. Resource reads flow to the agent verbatim.
+
+### 4. `ActionContext` usage
+
+- `ctx.agentCapabilities.sampling` checked before `ctx.sample(...)`. Calling `sample` without support throws `SamplingNotAvailableError` — handlers must branch explicitly.
+- `ctx.agentCapabilities.elicitation` checked before `ctx.elicit(...)`. Calling without support throws `ElicitationNotAvailableError`.
+- `ctx.confirm(...)` may be called without a capability check — it returns `false` on any non-accept (decline, cancel, or missing elicitation capability), which is the safe default for destructive operations.
+- `ctx.signal` forwarded to every cancellable async op in the handler (see section 2).
+- `ctx.log({...})` used instead of `console.log` inside handlers — log entries are delivered to the agent and surfaced in the MCP transcript.
+
+### 5. React hooks (`@tesseron/react`)
+
+- `useTesseronAction` / `useTesseronResource` called at the top level of the component (not inside conditionals or loops). Standard rules-of-hooks.
+- `useTesseronConnection` called **once** at the app root, not per component. Multiple connection hooks create multiple sessions.
+- Passing a fresh handler on every render is fine — the hook stores the handler in a ref and updates it without re-registering. Do not add memoization (`useCallback`/`useMemo`) around the handler; it's unnecessary.
+- Registration happens **before** connection: all `useTesseronAction` / `useTesseronResource` hooks should mount in ancestor components or earlier in the tree than `useTesseronConnection`. Otherwise the first manifest announced in `tesseron/hello` is incomplete.
+- `useTesseronResource` shorthand (`useTesseronResource('count', () => state.count)`) is fine for read-only resources.
+
+### 6. Session lifecycle & resume
+
+- `tesseron.connect(...)` awaited — it returns a `WelcomeResult`. Firing and forgetting drops the claim code.
+- Claim code (`welcome.claimCode`) surfaced to the user (so they can paste it into the agent). Failing to surface it leaves the session unclaimable.
+- Resume credentials (`{ sessionId, resumeToken }`) persisted from `WelcomeResult` after a successful connect — with the understanding that `resumeToken` **rotates on every successful resume**. Always persist the freshest token from the latest `WelcomeResult`.
+- Resume failures handled: on `ResumeFailedError` (code `-32011`), fall back to a fresh `connect()` without resume options. Do not keep retrying the same stale token.
+- Don't persist claim codes — they're one-shot pairing tokens, not authentication.
+
+### 7. Transports
+
+- `BrowserWebSocketTransport` used in browser code (dials `/@tesseron/ws`, provided by `@tesseron/vite`), `NodeWebSocketServerTransport` used in Node (hosts a loopback endpoint and writes a tab file). Mixing causes runtime errors (one expects `WebSocket` global, the other uses the `ws` package).
+- Browser apps register the `@tesseron/vite` plugin in `vite.config.ts`. Without it there's no `/@tesseron/ws` endpoint and `tesseron.connect()` fails with a connect error.
+- Custom transports implement the full `Transport` interface: `send`, `onMessage`, `onClose`, `close`. Missing `close` leaks resources.
+
+### 8. Gateway (`@tesseron/mcp`) configuration
+
+- `TESSERON_TOOL_SURFACE` left as `both` (default) unless there is a concrete reason to restrict. `meta` drops per-app tools and breaks dynamic tool-list-changed updates for Claude.
+- No code should rely on `TESSERON_PORT` / `TESSERON_HOST` / `TESSERON_ORIGIN_ALLOWLIST` / `DEFAULT_GATEWAY_PORT` / `DEFAULT_GATEWAY_HOST`. Those were removed in v2.0 along with the inbound WebSocket server; the gateway now dials apps via `~/.tesseron/tabs/`.
+
+### 9. Errors
+
+- `instanceof TesseronError` (or subclass) used when branching on Tesseron errors, not `error.code === -32006`. Magic numbers decay; subclasses stay correct.
+- `SamplingNotAvailableError` / `ElicitationNotAvailableError` caught or pre-empted by capability check (see section 4).
+- `ResumeFailedError` caught with a fallback path (see section 6).
+- `TransportClosedError` treated as terminal — no automatic retry loop without exponential backoff and a ceiling.
+
+### 10. Security (framework-specific)
+
+- No secrets, credentials, or PII in action `.describe(...)` strings, resource output, or `ctx.log(...)` entries. All of these are read by the agent and, at minimum, surfaced in the MCP transcript.
+- Handlers that mutate privileged state validate caller identity via `ctx.agent.id` / `ctx.client.origin` when identity matters. Open handlers on privileged actions are a trust bug.
+- No `eval(...)` / `new Function(...)` on `ctx.sample(...)` results. Treat model output as untrusted.
+- Stored `resumeToken` treated as sensitive — not logged, not serialized to telemetry, not surfaced in URL query strings.
+- Origin allowlist present when gateway is not localhost-only (see section 8).
+
+### 11. Testing
+
+- Unit tests use an in-memory `Transport` or capturing registry, not a real WebSocket to a running gateway.
+- Handler tests invoke `action.handler(input, mockCtx)` directly — no end-to-end round trip for pure logic.
+- `mockCtx` supplies `agentCapabilities`, `agent`, `client`, and stubs for `progress` / `log` / `sample` / `confirm` / `elicit` as needed — missing fields cause TypeScript errors.
+
+**Methods that are NOT misuses** — do not flag these; this checklist has historically confabulated bugs here that do not exist:
+
+- Chaining both `.read(...)` **and** `.subscribe(...)` on the same resource. Unlike `ActionBuilder` (which commits only on `.handler()`), `ResourceBuilder` registers on the first terminal call; calling both is supported and exposes the resource as readable *and* subscribable.
+- Passing a fresh handler closure to `useTesseronAction` / `useTesseronResource` on every render. The hooks use a ref internally, so this does not cause re-registration and does not need `useCallback`/`useMemo`.
+- Omitting the second `jsonSchema` argument to `.input(schema)` / `.output(schema)`. The gateway falls back to a permissive schema — not ideal for agent reasoning, but not a bug.
+- Calling `ctx.confirm(...)` without a prior `ctx.agentCapabilities.elicitation` check. `confirm` is designed to collapse to `false` when elicitation is unavailable.
+
+## Confidence scoring
+
+Score each finding 0–100:
+
+- **0–50** — probable false positive, pre-existing, or style nitpick. Discard.
+- **51–75** — valid but low-impact. Report only if security-related or the caller asked for suggestions.
+- **76–90** — important. Report.
+- **91–100** — critical correctness or security issue. Report.
+
+Report only ≥75 by default. Report security issues from 50 upward.
+
+## Output format
+
+```
+## Tesseron Review
+
+**Scope**: <what was reviewed>
+**Issues**: <N critical>, <M important>, <K suggestions>
+
+### Critical (91–100)
+
+- <category> · `<path>:<line>` · <confidence>
+  <one-sentence problem>
+  **Fix**
+  ```ts
+  <ready-to-apply patch>
+  ```
+
+### Important (76–90)
+<same shape>
+
+### Suggestions (51–75, security or requested)
+<same shape>
+
+### Passed
+
+- <one-line invariants the code honors — keep this section short>
+```
+
+Keep every issue short. Do not re-explain framework rules — the caller can reach into the `framework` skill's references for depth. Point there when a finding merits it:
+
+- Actions → `framework/references/actions.md`
+- Resources → `framework/references/resources.md`
+- ActionContext → `framework/references/context.md`
+- Transports → `framework/references/transports.md`
+- React hooks → `framework/references/react.md`
+- Protocol wire format → `framework/references/protocol.md`
+- Schemas → `framework/references/schemas.md`
+- Errors → `framework/references/errors.md`
+- Gateway → `framework/references/gateway.md`
+- Testing → `framework/references/testing.md`
+
+## Review principles
+
+1. **Quality over quantity.** Fewer, sharper findings beat an exhaustive list.
+2. **Framework focus.** If the issue would apply to any TypeScript project, drop it.
+3. **Confidence floor.** ≥75 by default, ≥50 for security. Unsure → do not report.
+4. **Diff-only by default.** Do not flag pre-existing issues unless the caller explicitly asked for a full audit.
+5. **Every finding has a fix.** If the fix is not obvious, raise the confidence bar before reporting.
+6. **Close fast.** When the code passes, say so in one paragraph and stop. A clean review is a real answer.

--- a/packages/pi/tsconfig.json
+++ b/packages/pi/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["extensions"]
+}

--- a/plugin/README.md
+++ b/plugin/README.md
@@ -29,7 +29,7 @@ Restart Claude Code. The plugin's MCP server (`tesseron`) starts automatically. 
 **Windows note**: if `npx` fails to resolve through `node`'s child-process spawn, swap the command in `plugin/.mcp.json` for the `cmd /c npx ...` form:
 
 ```jsonc
-{ "command": "cmd", "args": ["/c", "npx", "-y", "@tesseron/mcp@2.6.0"] }
+{ "command": "cmd", "args": ["/c", "npx", "-y", "@tesseron/mcp@2.6.1"] }
 ```
 
 This is a known shim quirk in some Node-on-Windows setups, not Tesseron-specific.
@@ -54,12 +54,12 @@ OpenCode does not consume Claude/Codex plugin manifests, but it does natively re
   "mcp": {
     "tesseron": {
       "type": "local",
-      "command": ["npx", "-y", "@tesseron/mcp@2.6.0"],
+      "command": ["npx", "-y", "@tesseron/mcp@2.6.1"],
       "enabled": true
     },
     "tesseron-docs": {
       "type": "local",
-      "command": ["npx", "-y", "@tesseron/docs-mcp@2.6.0"],
+      "command": ["npx", "-y", "@tesseron/docs-mcp@2.6.1"],
       "enabled": true
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,6 +319,30 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
+  packages/pi:
+    devDependencies:
+      '@mariozechner/pi-agent-core':
+        specifier: ^0.70.6
+        version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai':
+        specifier: ^0.70.6
+        version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-coding-agent':
+        specifier: ^0.70.6
+        version: 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui':
+        specifier: ^0.70.6
+        version: 0.70.6
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.17
+      typebox:
+        specifier: ^1.1.24
+        version: 1.1.35
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/react:
     dependencies:
       '@standard-schema/spec':
@@ -440,6 +464,15 @@ packages:
   '@antfu/install-pkg@1.1.0':
     resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
+  '@anthropic-ai/sdk@0.90.0':
+    resolution: {integrity: sha512-MzZtPabJF1b0FTDl6Z6H5ljphPwACLGP13lu8MTiB8jXaW/YXlpOp+Po2cVou3MPM5+f5toyLnul9whKCy7fBg==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
@@ -510,6 +543,155 @@ packages:
 
   '@astrojs/yaml2ts@0.2.3':
     resolution: {integrity: sha512-PJzRmgQzUxI2uwpdX2lXSHtP4G8ocp24/t+bZyf5Fy0SZLSF9f9KXZoMlFM/XCGue+B0nH/2IZ7FpBYQATBsCg==}
+
+  '@aws-crypto/crc32@5.2.0':
+    resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    resolution: {integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==}
+
+  '@aws-crypto/sha256-js@5.2.0':
+    resolution: {integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==}
+    engines: {node: '>=16.0.0'}
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    resolution: {integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==}
+
+  '@aws-crypto/util@5.2.0':
+    resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
+
+  '@aws-sdk/client-bedrock-runtime@3.1040.0':
+    resolution: {integrity: sha512-tFCqtci1gVGIRwgK3tmv2DV2EawXjBIQgwM/7KaeL4wHUMhNMUA+POUw6vGowtQb51ZaSDjK3KzI3MaQskOyuw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.974.7':
+    resolution: {integrity: sha512-YhRC90ofz5oolTJZlA8voU/oUrCB2azi8Usx51k8hhB5LpWbYQMMXKUqSqkoL0Cru+RQJgWTHpAfEDDIwfUhJw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.33':
+    resolution: {integrity: sha512-bJV7eViSJV6GSuuN+VIdNVPdwPsNSf75BiC2v5alPrjR/OCcqgKwSZInKbDFz9mNeizldsyf67jt6YSIiv53Cw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    resolution: {integrity: sha512-x/BQGEIdq0oI+4WxLjKmnQvT7CnF9r8ezdGt7wXwxb7ckHXQz0Zmgxt8v3Ne0JaT3R5YefmuybHX6E8EnsDXyA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    resolution: {integrity: sha512-eUTpmWfd/BKsq9medhCRcu+GRAhFP2Zrn7/2jKDHHOOjCkhrMoTp/t4cEthqFoG7gE0VGp5wUxrXTdvBCmSmJg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    resolution: {integrity: sha512-Ty68y8ISSC+g5Q3D0K8uAaoINwvfaOslnNpsF/LgVUxyosYXHawcK2yV4HLXDVugiTTYLQfJfcw0ce5meAGkKw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.38':
+    resolution: {integrity: sha512-BQ9XYnBDVxR2HuV5huXYQYF/PZMTsY+EnwfGnCU2cA8Zw63XpkOtPY8WqiMIZMQCrKPQQEiFURS/o9CIolRLqg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    resolution: {integrity: sha512-yfjGksI9WQbdMObb0VeLXqzTLI+a0qXLJT9gCDiv0+X/xjPpI3mTz6a5FibrhpuEKIe0gSgvs3MaoFZy5cx4WA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    resolution: {integrity: sha512-fpwE+20ntpp3i9Xb9vUuQfXLDKYHH+5I2V+ZG96SX1nBzrruhy10RXDgmN7t1etOz3c55stlA3TeQASUA451NQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    resolution: {integrity: sha512-aryawqyebf+3WhAFNHfF62rekFpYtVcVN7dQ89qnAWsa4n5hJst8qBG6gXC24WHtW7Nnhkf9ScYnjwo0Brn3bw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/eventstream-handler-node@3.972.14':
+    resolution: {integrity: sha512-m4X56gxG76/CKfxNVbOFuYwnAZcHgS6HOH8lgp15HoGHIAVTcZfZrXvcYzJFOMLEJgVn+JHBu6EiNV+xSNXXFg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-eventstream@3.972.10':
+    resolution: {integrity: sha512-QUqLs7Af1II9X4fCRAu+EGHG3KHyOp4RkuLhRKoA3NuFlh6TL8i+zXBl8w2LUxqm44B/Kom45hgSlwA1SpTsXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    resolution: {integrity: sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    resolution: {integrity: sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    resolution: {integrity: sha512-YhPix+0x/MdQrb1Ug1GDKeS5fqylIy+naz800asX8II4jqfTk2KY2KhmmYCwZcky8YWtRQQwWCGdoqeAnip8Uw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    resolution: {integrity: sha512-N1oNpdiLoVAWYD3WFBnUi3LlfoDA06ZHo4ozyjbsJNLvILzvt//0CnR8N+CZ0NWeYgVB/5V59ivixHCWCx2ALw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-websocket@3.972.16':
+    resolution: {integrity: sha512-86+S9oCyRVGzoMRpQhxkArp7kD2K75GPmaNevd9B6EyNhWoNvnCZZ3WbgN4j7ZT+jvtvBCGZvI2XHsWZJ+BRIg==}
+    engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.5':
+    resolution: {integrity: sha512-jGFr6DxtcMTmzOkG/a0jCZYv4BBDmeNYVeO+/memSoDkYCJu4Y58xviYmzwJfYyIVSts+X/BVjJm1uGBnwHEMg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    resolution: {integrity: sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    resolution: {integrity: sha512-amP7tLikppN940wbBFISYqiuzVmpzMS9U3mcgtmVLjX4fdWI/SNCvrXv6ZxfVzTT4cT0rPKOLhFah2xLwzREWw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1039.0':
+    resolution: {integrity: sha512-NMSFL2HwkAOoCeLCQiqoOq5pT3vVbSjww2QZTuYgYknVwhhv125PSDzZIcL5EYnlxuPWjEOdauZK+FspkZDVdw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1040.0':
+    resolution: {integrity: sha512-0KTpz2KqASQwzLOywV1bS2TX6Su0bARkATgpSu236BDM/D/6cMQ2EPiFwoRYwwvXsWSDn8KkKp9NV2ZWWA53Xw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.973.8':
+    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    resolution: {integrity: sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    resolution: {integrity: sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-format-url@3.972.10':
+    resolution: {integrity: sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    resolution: {integrity: sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    resolution: {integrity: sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==}
+
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    resolution: {integrity: sha512-gGwq8L2Euw0aNG6Ey4EktiAo3fSCVoDy1CaBIthd+oeaKHPXUrNaApMewQ6La5Hv0lcznOtECZaNvYyc5LXXfA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/xml-builder@3.972.22':
+    resolution: {integrity: sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -650,6 +832,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@borewit/text-codec@0.2.2':
+    resolution: {integrity: sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==}
 
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
@@ -1252,6 +1437,15 @@ packages:
   '@expressive-code/plugin-text-markers@0.41.7':
     resolution: {integrity: sha512-Ewpwuc5t6eFdZmWlFyeuy3e1PTQC0jFvw2Q+2bpcWXbOZhPLsT7+h8lsSIJxb5mS7wZko7cKyQ2RLYDyK6Fpmw==}
 
+  '@google/genai@1.51.0':
+    resolution: {integrity: sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@modelcontextprotocol/sdk': ^1.25.2
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
@@ -1537,6 +1731,91 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    resolution: {integrity: sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==}
+    engines: {node: '>= 10'}
+    os: [darwin]
+
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    resolution: {integrity: sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@mariozechner/clipboard@0.3.5':
+    resolution: {integrity: sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA==}
+    engines: {node: '>= 10'}
+
+  '@mariozechner/jiti@2.6.5':
+    resolution: {integrity: sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==}
+    hasBin: true
+
+  '@mariozechner/pi-agent-core@0.70.6':
+    resolution: {integrity: sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg==}
+    engines: {node: '>=20.0.0'}
+
+  '@mariozechner/pi-ai@0.70.6':
+    resolution: {integrity: sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+
+  '@mariozechner/pi-coding-agent@0.70.6':
+    resolution: {integrity: sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ==}
+    engines: {node: '>=20.6.0'}
+    hasBin: true
+
+  '@mariozechner/pi-tui@0.70.6':
+    resolution: {integrity: sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw==}
+    engines: {node: '>=20.0.0'}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
 
@@ -1548,6 +1827,9 @@ packages:
   '@mermaid-js/parser@1.1.0':
     resolution: {integrity: sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==}
 
+  '@mistralai/mistralai@2.2.1':
+    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -1557,6 +1839,9 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@nodable/entities@2.1.0':
+    resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -1610,6 +1895,36 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.5':
+    resolution: {integrity: sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.1':
+    resolution: {integrity: sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.1':
+    resolution: {integrity: sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1797,6 +2112,197 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@silvia-odwyer/photon-node@0.3.4':
+    resolution: {integrity: sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==}
+
+  '@smithy/config-resolver@4.4.17':
+    resolution: {integrity: sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.23.17':
+    resolution: {integrity: sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.2.14':
+    resolution: {integrity: sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-codec@4.2.14':
+    resolution: {integrity: sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    resolution: {integrity: sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    resolution: {integrity: sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    resolution: {integrity: sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    resolution: {integrity: sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.3.17':
+    resolution: {integrity: sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.2.14':
+    resolution: {integrity: sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.2.14':
+    resolution: {integrity: sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/is-array-buffer@2.2.0':
+    resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/is-array-buffer@4.2.2':
+    resolution: {integrity: sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-content-length@4.2.14':
+    resolution: {integrity: sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.4.32':
+    resolution: {integrity: sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.5.7':
+    resolution: {integrity: sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.2.20':
+    resolution: {integrity: sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.2.14':
+    resolution: {integrity: sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.3.14':
+    resolution: {integrity: sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.6.1':
+    resolution: {integrity: sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/property-provider@4.2.14':
+    resolution: {integrity: sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.3.14':
+    resolution: {integrity: sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-builder@4.2.14':
+    resolution: {integrity: sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/querystring-parser@4.2.14':
+    resolution: {integrity: sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/service-error-classification@4.3.1':
+    resolution: {integrity: sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    resolution: {integrity: sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.3.14':
+    resolution: {integrity: sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.12.13':
+    resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.14.1':
+    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/url-parser@4.2.14':
+    resolution: {integrity: sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.3.2':
+    resolution: {integrity: sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.2.2':
+    resolution: {integrity: sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.2.3':
+    resolution: {integrity: sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-buffer-from@2.2.0':
+    resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-buffer-from@4.2.2':
+    resolution: {integrity: sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-config-provider@4.2.2':
+    resolution: {integrity: sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    resolution: {integrity: sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    resolution: {integrity: sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.4.2':
+    resolution: {integrity: sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-hex-encoding@4.2.2':
+    resolution: {integrity: sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.2.14':
+    resolution: {integrity: sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.3.6':
+    resolution: {integrity: sha512-p6/FO1n2KxMeQyna067i0uJ6TSbb165ZhnRtCpWh4Foxqbfc6oW+XITaL8QkFJj3KFnDe2URt4gOhgU06EP9ew==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-stream@4.5.25':
+    resolution: {integrity: sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-uri-escape@4.2.2':
+    resolution: {integrity: sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-utf8@2.3.0':
+    resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
+    engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.2.2':
+    resolution: {integrity: sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/uuid@1.1.2':
+    resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1838,6 +2344,16 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
 
   '@turbo/darwin-64@2.9.6':
     resolution: {integrity: sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg==}
@@ -2022,6 +2538,9 @@ packages:
   '@types/micromatch@4.0.10':
     resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
 
+  '@types/mime-types@2.1.4':
+    resolution: {integrity: sha512-lfU4b34HOri+kAY5UheuFMWPDOI+OPceBSHZKp69gEyTL/mmJ4cnU6Y/rlme3UL3GyOn6Y42hyIEw0/q8sWx5w==}
+
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
 
@@ -2057,6 +2576,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/retry@0.12.0':
+    resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -2080,6 +2602,9 @@ packages:
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -2316,6 +2841,10 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
   astring@1.9.0:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
@@ -2343,13 +2872,24 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.20:
     resolution: {integrity: sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
 
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
@@ -2360,6 +2900,9 @@ packages:
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
@@ -2372,12 +2915,19 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
+
   boxen@8.0.1:
     resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
     engines: {node: '>=18'}
 
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2387,6 +2937,12 @@ packages:
     resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  buffer-equal-constant-time@1.0.1:
+    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -2423,6 +2979,10 @@ packages:
   chai@5.3.3:
     resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
     engines: {node: '>=18'}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -2471,6 +3031,14 @@ packages:
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
+
+  cli-highlight@2.1.11:
+    resolution: {integrity: sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==}
+    engines: {node: '>=8.0.0', npm: '>=5.0.0'}
+    hasBin: true
+
+  cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -2770,6 +3338,14 @@ packages:
   dagre-d3-es@7.0.14:
     resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
   data-urls@5.0.0:
     resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
     engines: {node: '>=18'}
@@ -2816,6 +3392,10 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
 
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
@@ -2903,6 +3483,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  ecdsa-sig-formatter@1.0.11:
+    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -2927,6 +3510,9 @@ packages:
   encodeurl@2.0.0:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
@@ -2998,6 +3584,11 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
+
   esm-env@1.2.2:
     resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
 
@@ -3013,6 +3604,10 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/types':
         optional: true
+
+  estraverse@5.3.0:
+    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
+    engines: {node: '>=4.0'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -3037,6 +3632,10 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  esutils@2.0.3:
+    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
+    engines: {node: '>=0.10.0'}
 
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
@@ -3084,6 +3683,11 @@ packages:
   extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
 
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3094,8 +3698,18 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  fast-xml-builder@1.1.5:
+    resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
+
+  fast-xml-parser@5.7.2:
+    resolution: {integrity: sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==}
+    hasBin: true
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3105,6 +3719,14 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  file-type@21.3.4:
+    resolution: {integrity: sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==}
+    engines: {node: '>=20'}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -3140,6 +3762,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -3168,6 +3794,14 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -3188,8 +3822,16 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -3198,9 +3840,21 @@ packages:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -3218,6 +3872,10 @@ packages:
 
   hachure-fill@0.5.2:
     resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3298,9 +3956,16 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
 
+  highlight.js@10.7.3:
+    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+
   hono@4.12.14:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
+
+  hosted-git-info@9.0.2:
+    resolution: {integrity: sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   html-encoding-sniffer@4.0.0:
     resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
@@ -3349,8 +4014,15 @@ packages:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
+    engines: {node: '>= 4'}
+
+  ignore@7.0.5:
+    resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
   import-meta-resolve@4.2.0:
@@ -3371,6 +4043,10 @@ packages:
 
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+    engines: {node: '>= 12'}
+
+  ip-address@10.1.1:
+    resolution: {integrity: sha512-1FMu8/N15Ck1BL551Jf42NYIoin2unWjLQ2Fze/DXryJRl5twqtwNHlO39qERGbIOcKYWHdgRryhOC+NG4eaLw==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -3485,6 +4161,13 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
+  json-schema-to-ts@3.1.1:
+    resolution: {integrity: sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==}
+    engines: {node: '>=16'}
+
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
@@ -3504,6 +4187,12 @@ packages:
 
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
+
+  jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+
+  jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
   katex@0.16.45:
     resolution: {integrity: sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==}
@@ -3527,6 +4216,9 @@ packages:
   klona@2.0.6:
     resolution: {integrity: sha512-dhG34DXATL5hSxJbIexCft8FChFXtmskoZYnoPWjXQuebWYCNkVeV3KkGegCK9CP1oswI/vQibS2GY7Em/sJJA==}
     engines: {node: '>= 8'}
+
+  koffi@2.16.1:
+    resolution: {integrity: sha512-0Ie6CfD026dNfWSosDw9dPxPzO9Rlyo0N8m5r05S8YjytIpuilzMFDMY4IDy/8xQsTwpuVinhncD+S8n3bcYZQ==}
 
   langium@4.2.2:
     resolution: {integrity: sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==}
@@ -3562,6 +4254,9 @@ packages:
   lodash.startcase@4.4.0:
     resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -3582,6 +4277,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -3598,6 +4297,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   marked@16.4.2:
     resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
@@ -3827,8 +4531,16 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@9.0.9:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minisearch@7.2.0:
@@ -3874,8 +4586,17 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-fetch-native@1.6.7:
     resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
@@ -3888,6 +4609,10 @@ packages:
     peerDependenciesMeta:
       encoding:
         optional: true
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
@@ -3932,6 +4657,18 @@ packages:
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
+  openai@6.26.0:
+    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
 
@@ -3959,6 +4696,10 @@ packages:
     resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
     engines: {node: '>=18'}
 
+  p-retry@4.6.2:
+    resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
+    engines: {node: '>=8'}
+
   p-timeout@6.1.4:
     resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
     engines: {node: '>=14.16'}
@@ -3966,6 +4707,14 @@ packages:
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
+
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
 
   package-manager-detector@0.2.11:
     resolution: {integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==}
@@ -3983,12 +4732,24 @@ packages:
   parse-latin@7.0.0:
     resolution: {integrity: sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==}
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    resolution: {integrity: sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==}
+
+  parse5@5.1.1:
+    resolution: {integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==}
+
+  parse5@6.0.1:
+    resolution: {integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
+
+  partial-json@0.1.7:
+    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
@@ -4000,9 +4761,17 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
 
   path-to-regexp@0.1.13:
     resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
@@ -4023,6 +4792,9 @@ packages:
   pathval@2.0.1:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
+
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
@@ -4113,12 +4885,29 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  proper-lockfile@4.1.2:
+    resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
+
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
+  protobufjs@7.5.6:
+    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+    engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
+
+  proxy-agent@6.5.0:
+    resolution: {integrity: sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -4286,6 +5075,14 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -4412,6 +5209,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4431,12 +5231,28 @@ packages:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
   smol-toml@1.6.1:
     resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.8:
+    resolution: {integrity: sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
@@ -4498,6 +5314,13 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strnum@2.2.3:
+    resolution: {integrity: sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==}
+
+  strtok3@10.3.5:
+    resolution: {integrity: sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==}
+    engines: {node: '>=18'}
+
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
 
@@ -4511,6 +5334,10 @@ packages:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
     engines: {node: '>=16 || 14 >=14.17'}
     hasBin: true
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
 
   svelte-check@4.4.6:
     resolution: {integrity: sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==}
@@ -4587,6 +5414,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  token-types@6.1.2:
+    resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
+    engines: {node: '>=14.16'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -4610,6 +5441,9 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-algebra@2.0.0:
+    resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
 
   ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
@@ -4671,6 +5505,9 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
+  typebox@1.1.35:
+    resolution: {integrity: sha512-kB3HoCOAE+cJ+xMCBKDsnlRJ5Fh39cIXBQ29vcqsN9+AVxCKa0qA84SDkDM51hrBOAkmAyYTpfFBdi6RzbfATA==}
+
   typesafe-path@0.2.2:
     resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
 
@@ -4685,6 +5522,10 @@ packages:
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -4696,6 +5537,10 @@ packages:
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
@@ -4821,6 +5666,10 @@ packages:
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   vary@1.1.2:
@@ -5058,6 +5907,10 @@ packages:
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -5153,13 +6006,24 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
 
+  yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+
   yargs@17.7.2:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yocto-queue@1.2.2:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
@@ -5202,6 +6066,12 @@ snapshots:
     dependencies:
       package-manager-detector: 1.6.0
       tinyexec: 1.1.1
+
+  '@anthropic-ai/sdk@0.90.0(zod@4.3.6)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.3.6
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -5408,6 +6278,427 @@ snapshots:
     dependencies:
       yaml: 2.8.3
 
+  '@aws-crypto/crc32@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-browser@5.2.0':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-crypto/supports-web-crypto': 5.2.0
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-locate-window': 3.965.5
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-crypto/sha256-js@5.2.0':
+    dependencies:
+      '@aws-crypto/util': 5.2.0
+      '@aws-sdk/types': 3.973.8
+      tslib: 2.8.1
+
+  '@aws-crypto/supports-web-crypto@5.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-crypto/util@5.2.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/util-utf8': 2.3.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-bedrock-runtime@3.1040.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-node': 3.972.38
+      '@aws-sdk/eventstream-handler-node': 3.972.14
+      '@aws-sdk/middleware-eventstream': 3.972.10
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/middleware-websocket': 3.972.16
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/token-providers': 3.1040.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/eventstream-serde-config-resolver': 4.3.14
+      '@smithy/eventstream-serde-node': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/core@3.974.7':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.22
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.35':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-login': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-login@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-node@3.972.38':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.33
+      '@aws-sdk/credential-provider-http': 3.972.35
+      '@aws-sdk/credential-provider-ini': 3.972.37
+      '@aws-sdk/credential-provider-process': 3.972.33
+      '@aws-sdk/credential-provider-sso': 3.972.37
+      '@aws-sdk/credential-provider-web-identity': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-process@3.972.33':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/token-providers': 3.1039.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/eventstream-handler-node@3.972.14':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-eventstream@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-host-header@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.11':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.36':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-arn-parser': 3.972.3
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.37':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.6
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-websocket@3.972.16':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-format-url': 3.972.10
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/eventstream-serde-browser': 4.2.14
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.5':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/region-config-resolver': 3.972.13
+      '@aws-sdk/signature-v4-multi-region': 3.996.24
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.8
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.23
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/core': 3.23.17
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-retry': 4.5.7
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.49
+      '@smithy/util-defaults-mode-node': 4.2.54
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/region-config-resolver@3.972.13':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.24':
+    dependencies:
+      '@aws-sdk/middleware-sdk-s3': 3.972.36
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1039.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/token-providers@3.1040.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.7
+      '@aws-sdk/nested-clients': 3.997.5
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/types@3.973.8':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-arn-parser@3.972.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-endpoints@3.996.8':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.2
+      tslib: 2.8.1
+
+  '@aws-sdk/util-format-url@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-locate-window@3.965.5':
+    dependencies:
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-browser@3.972.10':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.23':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.37
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.22':
+    dependencies:
+      '@nodable/entities': 2.1.0
+      '@smithy/types': 4.14.1
+      fast-xml-parser: 5.7.2
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.2.4': {}
+
   '@babel/code-frame@7.29.0':
     dependencies:
       '@babel/helper-validator-identifier': 7.28.5
@@ -5556,6 +6847,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@borewit/text-codec@0.2.2': {}
 
   '@braintree/sanitize-url@7.1.2': {}
 
@@ -6036,6 +7329,19 @@ snapshots:
     dependencies:
       '@expressive-code/core': 0.41.7
 
+  '@google/genai@1.51.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))':
+    dependencies:
+      google-auth-library: 10.6.2
+      p-retry: 4.6.2
+      protobufjs: 7.5.6
+      ws: 8.20.0
+    optionalDependencies:
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   '@hono/node-server@1.19.14(hono@4.12.14)':
     dependencies:
       hono: 4.12.14
@@ -6262,6 +7568,134 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mariozechner/clipboard-darwin-arm64@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-universal@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-darwin-x64@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-arm64-musl@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-gnu@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-linux-x64-musl@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-win32-arm64-msvc@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard-win32-x64-msvc@0.3.2':
+    optional: true
+
+  '@mariozechner/clipboard@0.3.5':
+    optionalDependencies:
+      '@mariozechner/clipboard-darwin-arm64': 0.3.2
+      '@mariozechner/clipboard-darwin-universal': 0.3.2
+      '@mariozechner/clipboard-darwin-x64': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-arm64-musl': 0.3.2
+      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-gnu': 0.3.2
+      '@mariozechner/clipboard-linux-x64-musl': 0.3.2
+      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.2
+      '@mariozechner/clipboard-win32-x64-msvc': 0.3.2
+    optional: true
+
+  '@mariozechner/jiti@2.6.5':
+    dependencies:
+      std-env: 3.10.0
+      yoctocolors: 2.1.2
+
+  '@mariozechner/pi-agent-core@0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/pi-ai': 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      typebox: 1.1.35
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-ai@0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.90.0(zod@4.3.6)
+      '@aws-sdk/client-bedrock-runtime': 3.1040.0
+      '@google/genai': 1.51.0(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))
+      '@mistralai/mistralai': 2.2.1
+      chalk: 5.6.2
+      openai: 6.26.0(ws@8.20.0)(zod@4.3.6)
+      partial-json: 0.1.7
+      proxy-agent: 6.5.0
+      typebox: 1.1.35
+      undici: 7.25.0
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-coding-agent@0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)':
+    dependencies:
+      '@mariozechner/jiti': 2.6.5
+      '@mariozechner/pi-agent-core': 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-ai': 0.70.6(@modelcontextprotocol/sdk@1.29.0(zod@4.3.6))(ws@8.20.0)(zod@4.3.6)
+      '@mariozechner/pi-tui': 0.70.6
+      '@silvia-odwyer/photon-node': 0.3.4
+      chalk: 5.6.2
+      cli-highlight: 2.1.11
+      diff: 8.0.4
+      extract-zip: 2.0.1
+      file-type: 21.3.4
+      glob: 13.0.6
+      hosted-git-info: 9.0.2
+      ignore: 7.0.5
+      marked: 15.0.12
+      minimatch: 10.2.5
+      proper-lockfile: 4.1.2
+      strip-ansi: 7.2.0
+      typebox: 1.1.35
+      undici: 7.25.0
+      uuid: 14.0.0
+      yaml: 2.8.3
+    optionalDependencies:
+      '@mariozechner/clipboard': 0.3.5
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - aws-crt
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+      - ws
+      - zod
+
+  '@mariozechner/pi-tui@0.70.6':
+    dependencies:
+      '@types/mime-types': 2.1.4
+      chalk: 5.6.2
+      get-east-asian-width: 1.5.0
+      marked: 15.0.12
+      mime-types: 3.0.2
+    optionalDependencies:
+      koffi: 2.16.1
+
   '@mdx-js/mdx@3.1.1':
     dependencies:
       '@types/estree': 1.0.8
@@ -6301,6 +7735,15 @@ snapshots:
   '@mermaid-js/parser@1.1.0':
     dependencies:
       langium: 4.2.2
+
+  '@mistralai/mistralai@2.2.1':
+    dependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
@@ -6346,6 +7789,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@nodable/entities@2.1.0': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -6382,6 +7827,29 @@ snapshots:
 
   '@pagefind/windows-x64@1.5.2':
     optional: true
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.5': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.1
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.1': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.1': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -6539,6 +8007,308 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@silvia-odwyer/photon-node@0.3.4': {}
+
+  '@smithy/config-resolver@4.4.17':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      '@smithy/util-endpoints': 3.4.2
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/core@3.23.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.25
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.2.14':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/eventstream-codec@4.2.14':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-browser@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-config-resolver@4.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-node@4.2.14':
+    dependencies:
+      '@smithy/eventstream-serde-universal': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/eventstream-serde-universal@4.2.14':
+    dependencies:
+      '@smithy/eventstream-codec': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.3.17':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      tslib: 2.8.1
+
+  '@smithy/hash-node@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@2.2.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/is-array-buffer@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.2.14':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.4.32':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-serde': 4.2.20
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.5.7':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.6
+      '@smithy/uuid': 1.1.2
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.2.20':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.3.14':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.6.1':
+    dependencies:
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/querystring-builder': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/property-provider@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.3.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/querystring-builder@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      '@smithy/util-uri-escape': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/querystring-parser@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/service-error-classification@4.3.1':
+    dependencies:
+      '@smithy/types': 4.14.1
+
+  '@smithy/shared-ini-file-loader@4.4.9':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.3.14':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-uri-escape': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.12.13':
+    dependencies:
+      '@smithy/core': 3.23.17
+      '@smithy/middleware-endpoint': 4.4.32
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.25
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/url-parser@4.2.14':
+    dependencies:
+      '@smithy/querystring-parser': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.3.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.2.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@2.2.0':
+    dependencies:
+      '@smithy/is-array-buffer': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-buffer-from@4.2.2':
+    dependencies:
+      '@smithy/is-array-buffer': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-config-provider@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-browser@4.3.49':
+    dependencies:
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.2.54':
+    dependencies:
+      '@smithy/config-resolver': 4.4.17
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/smithy-client': 4.12.13
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.4.2':
+    dependencies:
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-hex-encoding@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.2.14':
+    dependencies:
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.3.6':
+    dependencies:
+      '@smithy/service-error-classification': 4.3.1
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-stream@4.5.25':
+    dependencies:
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.6.1
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-buffer-from': 4.2.2
+      '@smithy/util-hex-encoding': 4.2.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/util-uri-escape@4.2.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@2.3.0':
+    dependencies:
+      '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.2.2':
+    dependencies:
+      '@smithy/util-buffer-from': 4.2.2
+      tslib: 2.8.1
+
+  '@smithy/uuid@1.1.2':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
@@ -6587,6 +8357,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
 
   '@turbo/darwin-64@2.9.6':
     optional: true
@@ -6801,6 +8582,8 @@ snapshots:
     dependencies:
       '@types/braces': 3.0.5
 
+  '@types/mime-types@2.1.4': {}
+
   '@types/mime@1.3.5': {}
 
   '@types/ms@2.1.0': {}
@@ -6834,6 +8617,8 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/retry@0.12.0': {}
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 22.19.17
@@ -6862,6 +8647,11 @@ snapshots:
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 22.19.17
+    optional: true
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -7153,6 +8943,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
   astring@1.9.0: {}
 
   astro-expressive-code@0.41.7(astro@5.18.1(@types/node@24.12.2)(rollup@4.60.2)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)):
@@ -7270,9 +9064,15 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   base-64@1.0.0: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.20: {}
+
+  basic-ftp@5.3.1: {}
 
   bcp-47-match@2.0.3: {}
 
@@ -7285,6 +9085,8 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bignumber.js@9.3.1: {}
 
   body-parser@1.20.4:
     dependencies:
@@ -7319,6 +9121,8 @@ snapshots:
 
   boolbase@1.0.0: {}
 
+  bowser@2.14.1: {}
+
   boxen@8.0.1:
     dependencies:
       ansi-align: 3.0.1
@@ -7334,6 +9138,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -7345,6 +9153,10 @@ snapshots:
       electron-to-chromium: 1.5.340
       node-releases: 2.0.37
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer-crc32@0.2.13: {}
+
+  buffer-equal-constant-time@1.0.1: {}
 
   bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
@@ -7378,6 +9190,11 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.1
       pathval: 2.0.1
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
 
   chalk@5.6.2: {}
 
@@ -7417,6 +9234,21 @@ snapshots:
   ci-info@4.4.0: {}
 
   cli-boxes@3.0.0: {}
+
+  cli-highlight@2.1.11:
+    dependencies:
+      chalk: 4.1.2
+      highlight.js: 10.7.3
+      mz: 2.7.0
+      parse5: 5.1.1
+      parse5-htmlparser2-tree-adapter: 6.0.1
+      yargs: 16.2.0
+
+  cliui@7.0.4:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   cliui@8.0.1:
     dependencies:
@@ -7726,6 +9558,10 @@ snapshots:
       d3: 7.9.0
       lodash-es: 4.18.1
 
+  data-uri-to-buffer@4.0.1: {}
+
+  data-uri-to-buffer@6.0.2: {}
+
   data-urls@5.0.0:
     dependencies:
       whatwg-mimetype: 4.0.0
@@ -7756,6 +9592,12 @@ snapshots:
   deepmerge@4.3.1: {}
 
   defu@6.1.7: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
 
   delaunator@5.1.0:
     dependencies:
@@ -7829,6 +9671,10 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  ecdsa-sig-formatter@1.0.11:
+    dependencies:
+      safe-buffer: 5.2.1
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.340: {}
@@ -7847,6 +9693,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   encodeurl@2.0.0: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   enquirer@2.4.1:
     dependencies:
@@ -7982,6 +9832,14 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
+
   esm-env@1.2.2: {}
 
   esprima@4.0.1: {}
@@ -7989,6 +9847,8 @@ snapshots:
   esrap@2.2.5:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  estraverse@5.3.0: {}
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -8024,6 +9884,8 @@ snapshots:
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
+
+  esutils@2.0.3: {}
 
   etag@1.8.1: {}
 
@@ -8126,6 +9988,16 @@ snapshots:
 
   extendable-error@0.1.7: {}
 
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -8138,13 +10010,42 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  fast-xml-builder@1.1.5:
+    dependencies:
+      path-expression-matcher: 1.5.0
+
+  fast-xml-parser@5.7.2:
+    dependencies:
+      '@nodable/entities': 2.1.0
+      fast-xml-builder: 1.1.5
+      path-expression-matcher: 1.5.0
+      strnum: 2.2.3
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  file-type@21.3.4:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.5
+      token-types: 6.1.2
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   fill-range@7.1.1:
     dependencies:
@@ -8202,6 +10103,10 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -8224,6 +10129,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   gensync@1.0.0-beta.2: {}
 
@@ -8249,15 +10170,33 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-tsconfig@4.14.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   github-slugger@2.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   globby@11.1.0:
     dependencies:
@@ -8267,6 +10206,19 @@ snapshots:
       ignore: 5.3.2
       merge2: 1.4.1
       slash: 3.0.0
+
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
 
   gopd@1.2.0: {}
 
@@ -8292,6 +10244,8 @@ snapshots:
       uncrypto: 0.1.3
 
   hachure-fill@0.5.2: {}
+
+  has-flag@4.0.0: {}
 
   has-symbols@1.1.0: {}
 
@@ -8511,7 +10465,13 @@ snapshots:
 
   he@1.2.0: {}
 
+  highlight.js@10.7.3: {}
+
   hono@4.12.14: {}
+
+  hosted-git-info@9.0.2:
+    dependencies:
+      lru-cache: 11.3.5
 
   html-encoding-sniffer@4.0.0:
     dependencies:
@@ -8565,7 +10525,11 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  ieee754@1.2.1: {}
+
   ignore@5.3.2: {}
+
+  ignore@7.0.5: {}
 
   import-meta-resolve@4.2.0: {}
 
@@ -8578,6 +10542,8 @@ snapshots:
   internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
+
+  ip-address@10.1.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -8681,6 +10647,15 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
+  json-schema-to-ts@3.1.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      ts-algebra: 2.0.0
+
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
@@ -8695,6 +10670,17 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jwa@2.0.1:
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+
+  jws@4.0.1:
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+
   katex@0.16.45:
     dependencies:
       commander: 8.3.0
@@ -8708,6 +10694,9 @@ snapshots:
   kleur@4.1.5: {}
 
   klona@2.0.6: {}
+
+  koffi@2.16.1:
+    optional: true
 
   langium@4.2.2:
     dependencies:
@@ -8738,6 +10727,8 @@ snapshots:
 
   lodash.startcase@4.4.0: {}
 
+  long@5.3.2: {}
+
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -8754,6 +10745,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lru-cache@7.18.3: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.21:
@@ -8769,6 +10762,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@15.0.12: {}
 
   marked@16.4.2: {}
 
@@ -9290,9 +11285,15 @@ snapshots:
 
   mime@1.6.0: {}
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@9.0.9:
     dependencies:
       brace-expansion: 2.1.0
+
+  minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
 
@@ -9327,15 +11328,25 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  netmask@2.1.1: {}
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
+
+  node-domexception@1.0.0: {}
 
   node-fetch-native@1.6.7: {}
 
   node-fetch@2.7.0:
     dependencies:
       whatwg-url: 5.0.0
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-mock-http@1.0.4: {}
 
@@ -9377,6 +11388,11 @@ snapshots:
       regex: 6.1.0
       regex-recursion: 6.0.2
 
+  openai@6.26.0(ws@8.20.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.20.0
+      zod: 4.3.6
+
   outdent@0.5.0: {}
 
   p-filter@2.1.0:
@@ -9402,9 +11418,32 @@ snapshots:
       eventemitter3: 5.0.4
       p-timeout: 6.1.4
 
+  p-retry@4.6.2:
+    dependencies:
+      '@types/retry': 0.12.0
+      retry: 0.13.1
+
   p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
+
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
 
   package-manager-detector@0.2.11:
     dependencies:
@@ -9441,11 +11480,21 @@ snapshots:
       unist-util-visit-children: 3.0.0
       vfile: 6.0.3
 
+  parse5-htmlparser2-tree-adapter@6.0.1:
+    dependencies:
+      parse5: 6.0.1
+
+  parse5@5.1.1: {}
+
+  parse5@6.0.1: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
 
   parseurl@1.3.3: {}
+
+  partial-json@0.1.7: {}
 
   path-browserify@1.0.1: {}
 
@@ -9453,7 +11502,14 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-key@3.1.1: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
 
   path-to-regexp@0.1.13: {}
 
@@ -9466,6 +11522,8 @@ snapshots:
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
+
+  pend@1.2.0: {}
 
   piccolore@0.1.3: {}
 
@@ -9535,12 +11593,53 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  proper-lockfile@4.1.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      retry: 0.12.0
+      signal-exit: 3.0.7
+
   property-information@7.1.0: {}
+
+  protobufjs@7.5.6:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.5
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.1
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.1
+      '@types/node': 22.19.17
+      long: 5.3.2
 
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
       ipaddr.js: 1.9.1
+
+  proxy-agent@6.5.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -9786,6 +11885,10 @@ snapshots:
       retext-latin: 4.0.0
       retext-stringify: 4.0.0
       unified: 11.0.5
+
+  retry@0.12.0: {}
+
+  retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
@@ -10046,6 +12149,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-swizzle@0.2.4:
@@ -10063,9 +12168,27 @@ snapshots:
 
   slash@3.0.0: {}
 
+  smart-buffer@4.2.0: {}
+
   smol-toml@1.6.1: {}
 
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.8
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.8:
+    dependencies:
+      ip-address: 10.1.1
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1:
+    optional: true
 
   source-map@0.7.6: {}
 
@@ -10134,6 +12257,12 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strnum@2.2.3: {}
+
+  strtok3@10.3.5:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -10153,6 +12282,10 @@ snapshots:
       pirates: 4.0.7
       tinyglobby: 0.2.16
       ts-interface-checker: 0.1.13
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
 
   svelte-check@4.4.6(picomatch@4.0.4)(svelte@5.55.4)(typescript@5.9.3):
     dependencies:
@@ -10240,6 +12373,12 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  token-types@6.1.2:
+    dependencies:
+      '@borewit/text-codec': 0.2.2
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
   tough-cookie@5.1.2:
     dependencies:
       tldts: 6.1.86
@@ -10258,6 +12397,8 @@ snapshots:
 
   trough@2.2.0: {}
 
+  ts-algebra@2.0.0: {}
+
   ts-dedent@2.2.0: {}
 
   ts-interface-checker@0.1.13: {}
@@ -10266,8 +12407,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsup@8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
@@ -10326,6 +12466,8 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
+  typebox@1.1.35: {}
+
   typesafe-path@0.2.2: {}
 
   typescript-auto-import-cache@0.3.6:
@@ -10336,6 +12478,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   ultrahtml@1.6.0: {}
 
   uncrypto@0.1.3: {}
@@ -10343,6 +12487,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.16.0: {}
+
+  undici@7.25.0: {}
 
   unified@11.0.5:
     dependencies:
@@ -10438,6 +12584,8 @@ snapshots:
   utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
+
+  uuid@14.0.0: {}
 
   vary@1.1.2: {}
 
@@ -10723,6 +12871,8 @@ snapshots:
 
   web-namespaces@2.0.1: {}
 
+  web-streams-polyfill@3.3.3: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -10802,7 +12952,19 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yargs-parser@20.2.9: {}
+
   yargs-parser@21.1.1: {}
+
+  yargs@16.2.0:
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
 
   yargs@17.7.2:
     dependencies:
@@ -10813,6 +12975,11 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yocto-queue@1.2.2: {}
 

--- a/scripts/sync-plugin-version.mjs
+++ b/scripts/sync-plugin-version.mjs
@@ -7,13 +7,18 @@
  * part of `pnpm version-packages` so changesets-driven bumps automatically
  * carry through to the manifest.
  *
- * Six fields move together:
+ * Ten surfaces and one mirror tree move together:
  *   - plugin/.claude-plugin/plugin.json#version  (the plugin's own manifest)
  *   - .claude-plugin/marketplace.json#metadata.version  (Claude marketplace version)
  *   - .claude-plugin/marketplace.json#plugins[0].version  (Claude marketplace listing)
  *   - .agents/plugins/marketplace.json#plugins[0].version  (Codex marketplace listing)
  *   - plugin/.mcp.json#mcpServers.tesseron.args  (npx -y @tesseron/mcp@<version>)
  *   - plugin/.mcp.json#mcpServers.tesseron-docs.args  (npx -y @tesseron/docs-mcp@<version>)
+ *   - packages/pi/package.json#version  (Pi extension package version)
+ *   - packages/pi/extensions/tesseron.ts#TESSERON_MCP_VERSION  (Pi extension's pinned npx target)
+ *   - README.md  (every literal `@tesseron/{mcp,docs-mcp}@<semver>` in install snippets)
+ *   - plugin/README.md  (same)
+ *   - packages/pi/skills/**  (byte-identical mirror of plugin/skills/**)
  *
  * Bumping only one leaves the other surfaces stale and users running an older
  * gateway under a fresh manifest. That's issue #38.
@@ -23,8 +28,10 @@
  *   1  --check mode and drift detected (CI guard)
  *   2  unrecoverable: a manifest is missing, malformed, or structurally wrong
  */
+import { createHash } from 'node:crypto';
+import { cpSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
@@ -33,6 +40,13 @@ const PLUGIN_MANIFEST = resolve(repoRoot, 'plugin/.claude-plugin/plugin.json');
 const MARKETPLACE_MANIFEST = resolve(repoRoot, '.claude-plugin/marketplace.json');
 const CODEX_MARKETPLACE_MANIFEST = resolve(repoRoot, '.agents/plugins/marketplace.json');
 const PLUGIN_MCP_JSON = resolve(repoRoot, 'plugin/.mcp.json');
+const PI_PKG = resolve(repoRoot, 'packages/pi/package.json');
+const PI_EXTENSION = resolve(repoRoot, 'packages/pi/extensions/tesseron.ts');
+const PLUGIN_SKILLS_DIR = resolve(repoRoot, 'plugin/skills');
+const PI_SKILLS_DIR = resolve(repoRoot, 'packages/pi/skills');
+// READMEs whose install snippets pin literal `@tesseron/{mcp,docs-mcp}@<semver>`
+// strings. These are not JSON, so the script rewrites them as text via regex.
+const README_TARGETS = [resolve(repoRoot, 'README.md'), resolve(repoRoot, 'plugin/README.md')];
 
 // `<bin-package>@<version>` arg slots in plugin/.mcp.json. The script pins both
 // MCP servers to the same version as @tesseron/mcp so users always run a
@@ -69,6 +83,44 @@ async function readJson(path) {
 /** Stringify with 2-space indent + trailing newline (matches the repo's Biome formatter). */
 function serialize(data) {
   return `${JSON.stringify(data, null, 2)}\n`;
+}
+
+/**
+ * Walk a skill tree, returning a map of POSIX-relative path -> sha256(content).
+ * Returns an empty map if the root doesn't exist (the directory is created on
+ * first sync). The traversal is sorted at each level so the resulting map has
+ * deterministic key ordering, which keeps `--check` output stable across runs.
+ */
+function walkSkillTree(root) {
+  const files = new Map();
+  function walk(absDir) {
+    let entries;
+    try {
+      entries = readdirSync(absDir, { withFileTypes: true });
+    } catch (err) {
+      if (err.code === 'ENOENT') return;
+      throw err;
+    }
+    entries.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const entry of entries) {
+      const abs = resolve(absDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(abs);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      // POSIX-style relative path so Win/Linux produce identical map keys.
+      const rel = relative(root, abs).split('\\').join('/');
+      // readFileSync returns a Buffer, so byte-level CRLF differences are
+      // visible to the hash (a text-mode read on Windows would normalise them
+      // away and false-negative on real drift).
+      const buf = readFileSync(abs);
+      const hash = createHash('sha256').update(buf).digest('hex');
+      files.set(rel, hash);
+    }
+  }
+  walk(root);
+  return files;
 }
 
 const { data: mcpPkg } = await readJson(MCP_PKG);
@@ -203,6 +255,117 @@ const drift = [];
   }
 }
 
+// 7. packages/pi/package.json — `@tesseron/pi` ships in lockstep with the rest
+//    of the SDK fixed group (changesets handles the bump). Catch drift here in
+//    case anyone hand-edits one without the other.
+{
+  const { data, raw } = await readJson(PI_PKG);
+  if (data.version !== target) {
+    drift.push({
+      file: PI_PKG,
+      from: data.version,
+      to: target,
+      next: serialize({ ...data, version: target }),
+      currentRaw: raw,
+    });
+  }
+}
+
+// 8. packages/pi/extensions/tesseron.ts — pinned `npx -y @tesseron/mcp@<v>`
+//    target lives in a single `TESSERON_MCP_VERSION` constant. Rewrite as
+//    text (not JSON) so we don't have to parse TypeScript.
+{
+  let raw;
+  try {
+    raw = await readFile(PI_EXTENSION, 'utf8');
+  } catch (err) {
+    console.error(`[sync-plugin-version] failed to read ${PI_EXTENSION}: ${err.message}`);
+    process.exit(2);
+  }
+  const pinPattern = /(const TESSERON_MCP_VERSION = ')([^']+)(';)/;
+  const match = raw.match(pinPattern);
+  if (!match) {
+    console.error(
+      `[sync-plugin-version] ${PI_EXTENSION}: could not find \`const TESSERON_MCP_VERSION = '<version>';\` pin`,
+    );
+    process.exit(2);
+  }
+  const current = match[2];
+  if (current !== target) {
+    const next = raw.replace(pinPattern, `$1${target}$3`);
+    drift.push({
+      file: PI_EXTENSION,
+      from: `TESSERON_MCP_VERSION (${current} → ${target})`,
+      to: target,
+      next,
+      currentRaw: raw,
+    });
+  }
+}
+
+// 9 + 10. README install snippets — match every literal
+// `@tesseron/{mcp,docs-mcp}@<semver>` and rewrite. The placeholder
+// `@tesseron/mcp@<version>` (with literal `<version>` text) is intentionally
+// not matched because the regex requires digits.
+const README_PIN_PATTERN = /@tesseron\/(mcp|docs-mcp)@(\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)/g;
+for (const file of README_TARGETS) {
+  let raw;
+  try {
+    raw = await readFile(file, 'utf8');
+  } catch (err) {
+    console.error(`[sync-plugin-version] failed to read ${file}: ${err.message}`);
+    process.exit(2);
+  }
+  const driftedPins = [];
+  const next = raw.replace(README_PIN_PATTERN, (match, pkg, current) => {
+    const wanted = `@tesseron/${pkg}@${target}`;
+    if (current !== target) driftedPins.push(`${match} → ${wanted}`);
+    return wanted;
+  });
+  if (driftedPins.length > 0) {
+    drift.push({
+      file,
+      from: driftedPins.length === 1 ? driftedPins[0] : `${driftedPins.length} pin(s) drifted`,
+      to: target,
+      next,
+      currentRaw: raw,
+    });
+  }
+}
+
+// 11. Skill tree mirror: plugin/skills/ → packages/pi/skills/
+//
+// The five Tesseron skills are edited under plugin/skills/ and ship from
+// packages/pi/ as well. Pi has no idiomatic primitive that lets two consumer
+// packages reference one on-disk source (bundledDependencies works for nested
+// pi packages but not for a sibling Claude plugin; pnpm doesn't bundle
+// `workspace:*` deps; Pi's pi.skills paths can't escape the package root).
+// So we mirror the tree, hash-compare every file, and fail --check on drift.
+{
+  const sourceFiles = walkSkillTree(PLUGIN_SKILLS_DIR);
+  const targetFiles = walkSkillTree(PI_SKILLS_DIR);
+  const driftedPaths = [];
+
+  for (const [relPath, hash] of sourceFiles) {
+    const targetHash = targetFiles.get(relPath);
+    if (targetHash === undefined) driftedPaths.push(`+ ${relPath}`);
+    else if (targetHash !== hash) driftedPaths.push(`~ ${relPath}`);
+  }
+  for (const relPath of targetFiles.keys()) {
+    if (!sourceFiles.has(relPath)) driftedPaths.push(`- ${relPath}`);
+  }
+
+  if (driftedPaths.length > 0) {
+    drift.push({
+      file: PI_SKILLS_DIR,
+      from: `${driftedPaths.length} skill file(s) drifted: ${driftedPaths.slice(0, 5).join(', ')}${driftedPaths.length > 5 ? `, +${driftedPaths.length - 5} more` : ''}`,
+      to: 'mirror of plugin/skills/',
+      // Marker handled by the writer at the bottom of the script.
+      mirror: true,
+    });
+  }
+}
+
 if (drift.length === 0) {
   // Log on both paths: in check mode the green check is the only signal CI
   // emits, and a positive confirmation makes the guard's success auditable.
@@ -220,6 +383,14 @@ if (checkMode) {
 }
 
 for (const d of drift) {
-  await writeFile(d.file, d.next);
+  if (d.mirror) {
+    // Full directory mirror: blow away the target and re-copy from source.
+    // This is the simplest way to make deletions propagate (file removed from
+    // plugin/skills/ should also disappear from packages/pi/skills/).
+    rmSync(d.file, { recursive: true, force: true });
+    cpSync(PLUGIN_SKILLS_DIR, d.file, { recursive: true });
+  } else {
+    await writeFile(d.file, d.next);
+  }
   console.log(`[sync-plugin-version] ${d.file}: ${d.from} → ${d.to}`);
 }


### PR DESCRIPTION
## Summary

Closes #81. Ships `@tesseron/pi` — a Pi coding-agent extension package that mirrors what `plugin/` does for Claude Code / Codex.

- New workspace package at `packages/pi/`, published as `@tesseron/pi`.
- One Pi extension file (`extensions/tesseron.ts`) registers eight typed Pi tools (`tesseron_claim_session`, `tesseron_list_actions`, `tesseron_list_pending_claims`, `tesseron_invoke_action`, `tesseron_read_resource`, `tesseron_docs_list`, `tesseron_docs_search`, `tesseron_docs_read`) and one `/tesseron` slash command.
- Hand-rolled stdio JSON-RPC client (~110 LOC, no `@modelcontextprotocol/sdk` dep) spawns `npx -y @tesseron/mcp@<v>` and `npx -y @tesseron/docs-mcp@<v>` as child processes and forwards `tools/call` requests.
- Same five-skill bundle the Claude/Codex plugin ships (`framework`, `tesseron-dev`, `tesseron-docs`, `tesseron-explorer`, `tesseron-reviewer`), kept byte-identical via a content-hash mirror in `scripts/sync-plugin-version.mjs`.
- `@tesseron/pi` joins the existing changesets `fixed` lockstep group so it always ships at the same version as `@tesseron/{core,web,server,react,mcp,docs-mcp}`.

## Why a copy of skills, not a shared package?

Pi has no idiomatic primitive for sharing skills across packages:

- `bundledDependencies` works for nested Pi packages but pnpm doesn't bundle `workspace:*` deps ([pnpm/pnpm#1643](https://github.com/pnpm/pnpm/issues/1643)).
- `pi.skills` paths can't escape the package root, so `["../plugin/skills"]` works in dev but breaks in the published tarball.
- The PR that would have allowed it ([pi-mono#751 — `skills_discover` extension hook](https://github.com/badlogic/pi-mono/pull/751)) was closed unmerged.
- Even the most cross-harness-aware Pi package (`@heart-of-gold/toolkit`) literally `cpSync`s skills at install time.

So `plugin/skills/` is the editable source, `packages/pi/skills/` is a byte-identical mirror, and `pnpm sync-plugin-version --check` (already a CI guard) catches any drift loudly.

## Sync script extension

Three new surfaces + one mirror tree added to `scripts/sync-plugin-version.mjs`:

- `packages/pi/package.json#version` — version pin.
- `packages/pi/extensions/tesseron.ts#TESSERON_MCP_VERSION` — pinned `npx` target inside the extension.
- `README.md` and `plugin/README.md` — every literal `@tesseron/{mcp,docs-mcp}@<semver>` in install snippets (regex rewrite; the `@tesseron/mcp@<version>` placeholder is intentionally not matched). This run caught and fixed three pre-existing 2.6.0 → 2.6.1 drift pins in `plugin/README.md`.
- `packages/pi/skills/**` — full-tree sha256 hash compare; default mode does a destructive re-mirror so deletions propagate.

`AGENTS.md` updated with the new contract.

## Root README de-Claudification

The root README was framed as Claude-Code-first with everything else pushed to `examples/README.md`. Cleaned up:

- `## Install` section has first-class subsections for Claude Code, Codex, OpenCode, and Pi instead of one Claude command and a "for other clients see…" footnote.
- Packages table now lists `@tesseron/{svelte,vue,vite,docs-mcp,pi}` (which were all missing).
- Status section drops the stale `v1.0.1` version claim and the "Svelte/Vue adapters on the roadmap" line (they exist at 2.1.11).
- Development section drops the broken `pnpm --filter @tesseron/mcp build:plugin` reference (per AGENTS.md, that script no longer exists since v2.0).
- Diagram alt text updated for the v2.0 reverse-connection architecture (no fixed port, gateway dials via `~/.tesseron/instances/`).
- Test count badge bumped from 65 → 98 (matches `pnpm test` reality).

## Test plan

- [x] `pnpm install --frozen-lockfile=false` — lockfile updated for new Pi peer/dev deps.
- [x] `pnpm typecheck` — 27/27 successful.
- [x] `pnpm test` — same green/skip count as pre-change (98 passed, 5 skipped).
- [x] `pnpm lint` — biome clean across 130 files.
- [x] `pnpm sync-plugin-version --check` — clean.
- [x] Drift round-trip: perturb a skill file → `--check` exits 1 with the file path → default rewrite → `--check` clean.
- [x] Drift round-trip: change `@tesseron/mcp@2.6.1` → `2.6.0` in `README.md` → `--check` exits 1 → rewrite → clean.
- [x] `npm pack --dry-run` for `@tesseron/pi` — 20 files, 56 kB packed / 172 kB unpacked. Includes `LICENSE`, `README.md`, `extensions/tesseron.ts`, all 16 skill files. No build artifacts, no node_modules.
- [x] `pnpm changeset status` — `@tesseron/pi` in the lockstep `fixed` minor-bump set with `@tesseron/{core,web,server,react,mcp,docs-mcp}`.
- [ ] Smoke test from a fresh dir: `pi install -l npm:@tesseron/pi@<published-version>` (pending publish).

## Out of scope

- Publishing to Pi's package gallery beyond the `pi-package` keyword (gallery is auto-populated).
- Migrating consumer repos (e.g., `KennyVaneetvelde/ai-video-editor`'s local `.pi/extensions/tesseron.ts`) to consume the published package — follow-up in the consumer repo.
- `@tesseron/pi` is not added to `.claude-plugin/marketplace.json` or `.agents/plugins/marketplace.json` because Pi has its own gallery at `pi.dev/packages`.

## Notes for review

The two-physical-copies-on-disk situation for skills (`plugin/skills/` + `packages/pi/skills/`) is the same shape of risk the existing version-sync script already accepts — a contributor could in principle edit either side. Mitigation is the same: `AGENTS.md` says edit only `plugin/skills/`, `--check` in CI catches the inverse case loudly. If/when Anthropic ships path traversal allowance or pnpm fixes #1643, this can be revisited.
