### PR TITLE
fix(core): free wire on timeout/cancel when handler ignores ctx.signal

### DIFF
--- a/.changeset/un-cancellable-handler-timeout-reaper.md
+++ b/.changeset/un-cancellable-handler-timeout-reaper.md
@@ -1,0 +1,16 @@
+---
+"@tesseron/core": minor
+---
+
+fix: free the wire on action timeout/cancel even when the handler ignores `ctx.signal` (closes #85)
+
+The SDK now races the handler against the abort signal, so a handler stuck inside a non-`AbortSignal`-aware promise (`modern-screenshot.domToPng`, `<canvas>.toBlob`, `<img>.decode`, `document.fonts.ready`, `Audio.play`, `MediaRecorder`, ...) no longer pins the agent's `tools/call` indefinitely. When the per-action `.timeout({ ms })` elapses or the agent sends `actions/cancel`, the SDK responds with `-32002 Timeout` or `-32001 Cancelled` immediately. The orphaned handler keeps running until it settles (still the app's job to clean up), but the agent is no longer held hostage.
+
+Adds `ctx.withTimeout(value, ms)` for the in-handler companion: bound a single stuck inner call without giving the whole action a tighter outer timeout than it actually needs. Resolves on success, rejects with `TimeoutError` on the local deadline, and rejects with the abort reason if `ctx.signal` aborts first.
+
+```ts
+.handler(async (_input, ctx) => {
+  const dataUrl = await ctx.withTimeout(domToPng(document.body), 8_000);
+  return { dataUrl };
+});
+```

--- a/docs/src/content/docs/protocol/progress-cancellation.mdx
+++ b/docs/src/content/docs/protocol/progress-cancellation.mdx
@@ -105,6 +105,7 @@ tesseron.action('generateReport')
 - `ctx.signal` is a standard [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal). Pass it to `fetch`, `setTimeout`, database drivers, or anything else that accepts one.
 - Cancellation fires for **two reasons**: the agent explicitly cancelled, or the action's timeout expired. Your handler treats them the same way - yield as fast as you can.
 - After abort, the SDK returns an error response with code `-32001 Cancelled` (explicit) or `-32002 Timeout` (timer).
+- **The wire is freed at the deadline regardless of the handler.** The SDK races the handler against the abort signal, so a handler stuck inside a non-signal-aware promise (`modern-screenshot.domToPng`, `<canvas>.toBlob`, `<img>.decode`, `document.fonts.ready`, `Audio.play`, `MediaRecorder`, ...) doesn't pin the agent's `tools/call` indefinitely - the orphaned handler keeps running, but the agent has already received its error response. To bound an individual stuck call from inside the handler, use [`ctx.withTimeout(p, ms)`](/sdk/typescript/context/#ctxwithtimeout-drop-stuck-inner-promises).
 
 Wire format - notification from gateway to app:
 

--- a/docs/src/content/docs/sdk/typescript/action-builder.md
+++ b/docs/src/content/docs/sdk/typescript/action-builder.md
@@ -86,6 +86,8 @@ Per-invocation timeout. Default 60 000 ms. When exceeded, the handler's `ctx.sig
 .timeout({ ms: 5 * 60 * 1000 })   // big report, 5 minutes
 ```
 
+The SDK races the handler against the deadline, so the agent receives the timeout response even if the handler is stuck in a non-`AbortSignal`-aware promise. To bound a single inner call from inside the handler, use [`ctx.withTimeout(p, ms)`](/sdk/typescript/context/#ctxwithtimeout-drop-stuck-inner-promises).
+
 ## `.strictOutput()`
 
 Turns `.output(schema)` from documentation into enforcement. Validation failure becomes `-32005 HandlerError` with `issues` in `error.data`.

--- a/docs/src/content/docs/sdk/typescript/context.md
+++ b/docs/src/content/docs/sdk/typescript/context.md
@@ -24,6 +24,7 @@ interface ActionContext {
 
   // Lifecycle
   readonly signal: AbortSignal;
+  withTimeout<T>(value: Promise<T> | T, ms: number): Promise<T>;
 
   // Messaging
   progress(update: { message?: string; percent?: number; data?: unknown }): void;
@@ -51,6 +52,21 @@ Standard [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortS
 ```
 
 Pass `ctx.signal` to everything that accepts one: `fetch`, `setTimeout`, database drivers, nested `ctx.sample` calls.
+
+The SDK guarantees the wire is freed at the deadline regardless of whether the handler observes `ctx.signal`. Once the timer fires, the agent receives `-32002 Timeout` (or `-32001 Cancelled` on agent cancellation) immediately. A handler stuck in a non-signal-aware promise keeps running orphaned — that's the app's problem to clean up, but the agent isn't held hostage. See [`ctx.withTimeout`](#ctxwithtimeout-drop-stuck-inner-promises) for the in-handler companion.
+
+## `ctx.withTimeout(value, ms)` - drop stuck inner promises
+
+A small race helper for handlers that wrap browser APIs which don't accept an `AbortSignal` — `modern-screenshot.domToPng`, `<canvas>.toBlob`, `<img>.decode`, `document.fonts.ready`, `Audio.play`, `MediaRecorder`. Resolves with `value` if it settles within `ms`, otherwise rejects with `TimeoutError`. Also rejects if `ctx.signal` aborts first (with the abort reason — `TimeoutError` or `CancelledError`).
+
+```ts
+.handler(async (_input, ctx) => {
+  const dataUrl = await ctx.withTimeout(domToPng(document.body), 8_000);
+  return { dataUrl };
+});
+```
+
+The original promise keeps running orphaned; the handler moves on. Use this to bound a single problematic call without giving the whole action a tighter `.timeout({ ms })` than it actually needs.
 
 ## `ctx.progress(update)` - streaming updates
 

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -414,6 +414,8 @@ export class TesseronClient implements BuilderRegistry {
 
     const ctx: ActionContext = {
       signal: controller.signal,
+      withTimeout: <T>(value: Promise<T> | T, ms: number): Promise<T> =>
+        withTimeoutAgainstSignal(value, ms, controller.signal),
       agentCapabilities: this.welcome?.capabilities ?? {
         sampling: false,
         elicitation: false,
@@ -533,8 +535,20 @@ export class TesseronClient implements BuilderRegistry {
       },
     };
 
+    // Race the handler against the abort signal so a handler stuck inside a
+    // non-AbortSignal-aware Promise (e.g. `modern-screenshot.domToPng`,
+    // `<img>.decode`, `document.fonts.ready`, `Audio.play`) doesn't pin the
+    // wire indefinitely. When the timeout or an `actions/cancel` aborts the
+    // controller, the reaper rejects, we send the error response, and the
+    // orphaned handler keeps running on its own — that's the app's problem to
+    // clean up, but the agent isn't held hostage.
+    const handlerPromise = Promise.resolve().then(() => action.handler(input, ctx));
+    // Belt-and-suspenders: even though Promise.race attaches a rejection
+    // listener to handlerPromise, attach our own so a late rejection from the
+    // orphaned handler can never surface as an unhandledrejection.
+    handlerPromise.catch(() => {});
     try {
-      const output = await action.handler(input, ctx);
+      const output = await Promise.race([handlerPromise, abortReaper(controller.signal)]);
       if (action.outputSchema && action.strictOutput) {
         const result = await standardValidate(action.outputSchema, output);
         if (!result.ok) {
@@ -600,6 +614,70 @@ export class TesseronClient implements BuilderRegistry {
     sub.unsubscribe();
     this.subscriptions.delete(params.subscriptionId);
   }
+}
+
+/**
+ * Promise that rejects when `signal` aborts. Mirrors the abort-reason mapping
+ * used by `handleInvoke`'s catch block: a `TimeoutError` reason propagates as
+ * itself, anything else collapses to `CancelledError`.
+ */
+function abortReaper(signal: AbortSignal): Promise<never> {
+  return new Promise<never>((_, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason instanceof TimeoutError ? signal.reason : new CancelledError());
+      return;
+    }
+    signal.addEventListener(
+      'abort',
+      () => {
+        reject(signal.reason instanceof TimeoutError ? signal.reason : new CancelledError());
+      },
+      { once: true },
+    );
+  });
+}
+
+/**
+ * Implementation of `ctx.withTimeout`. Resolves on inner success, rejects with
+ * `TimeoutError(ms)` if the local deadline elapses, or with the abort reason
+ * if `signal` aborts first.
+ */
+function withTimeoutAgainstSignal<T>(
+  value: Promise<T> | T,
+  ms: number,
+  signal: AbortSignal,
+): Promise<T> {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return Promise.reject(new Error('ctx.withTimeout: ms must be a non-negative finite number'));
+  }
+  return new Promise<T>((resolve, reject) => {
+    let settled = false;
+    const settle = (action: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      action();
+    };
+    const onAbort = (): void => {
+      settle(() => {
+        const reason = signal.reason;
+        reject(reason instanceof TimeoutError ? reason : new CancelledError());
+      });
+    };
+    const timer = setTimeout(() => {
+      settle(() => reject(new TimeoutError(ms)));
+    }, ms);
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+    Promise.resolve(value).then(
+      (resolved) => settle(() => resolve(resolved)),
+      (err) => settle(() => reject(err)),
+    );
+  });
 }
 
 function resolveOrigin(): string {

--- a/packages/core/src/context.ts
+++ b/packages/core/src/context.ts
@@ -110,6 +110,26 @@ export interface ActionContext {
   elicit<T>(req: ElicitRequest<T>): Promise<T | null>;
   /** Emits a structured log entry forwarded over MCP `notifications/message`. */
   log(entry: LogEntry): void;
+  /**
+   * Race a promise against a fixed deadline while honouring `ctx.signal`.
+   *
+   * Resolves with `value` if it settles within `ms`. Otherwise rejects with
+   * a `TimeoutError`. If `ctx.signal` aborts (outer action timeout or agent
+   * cancellation) before either fires, rejects with the abort reason
+   * (`TimeoutError` or `CancelledError`).
+   *
+   * Use this to drop a stuck inner promise that doesn't accept an
+   * `AbortSignal` — common with browser DOM/canvas/font/media APIs like
+   * `modern-screenshot.domToPng`, `<canvas>.toBlob`, `<img>.decode`,
+   * `document.fonts.ready`, `Audio.play`, `MediaRecorder`. The original
+   * promise keeps running orphaned; the handler can move on.
+   *
+   * @example
+   * ```ts
+   * const dataUrl = await ctx.withTimeout(domToPng(document.body), 8_000);
+   * ```
+   */
+  withTimeout<T>(value: Promise<T> | T, ms: number): Promise<T>;
 }
 
 /** Payload for {@link ActionContext.log}. */

--- a/packages/core/test/client.test.ts
+++ b/packages/core/test/client.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { PROTOCOL_VERSION, TesseronClient, type Transport } from '../src/index.js';
+import {
+  type ActionContext,
+  PROTOCOL_VERSION,
+  TesseronClient,
+  TesseronErrorCode,
+  TimeoutError,
+  type Transport,
+} from '../src/index.js';
 import { JsonRpcDispatcher } from '../src/internal.js';
 
 interface PairedSetup {
@@ -242,5 +249,148 @@ describe('TesseronClient end-to-end', () => {
     expect(observed).toEqual([{ agentId: 'claude-code', claimCode: undefined }]);
     expect(client.getWelcome()?.claimCode).toBeUndefined();
     expect(client.getWelcome()?.agent).toEqual({ id: 'claude-code', name: 'Claude Code' });
+  });
+
+  it('frees the wire with -32002 Timeout when the handler ignores ctx.signal', async () => {
+    // Regression for #85: a handler awaiting a non-AbortSignal-aware promise
+    // (modern-screenshot.domToPng, <img>.decode, etc.) used to hang the wire
+    // forever — the agent's pending tools/call sat indefinitely because
+    // `await action.handler(...)` never resolved. Now the SDK races the
+    // handler against the abort signal so the timeout response always fires.
+    const client = new TesseronClient();
+    client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+    client
+      .action('hangs')
+      .timeout({ ms: 30 })
+      // Intentionally ignore ctx.signal — represents a third-party promise
+      // that doesn't accept an AbortSignal.
+      .handler(() => new Promise<never>(() => {}));
+
+    let clientMessageHandler: ((m: unknown) => void) | undefined;
+    const gateway = new JsonRpcDispatcher((m) => {
+      queueMicrotask(() => clientMessageHandler?.(m));
+    });
+    gateway.on('tesseron/hello', () => ({
+      sessionId: 'test',
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+      agent: { id: 'a', name: 'a' },
+    }));
+
+    const transport: Transport = {
+      send: (m) => queueMicrotask(() => gateway.receive(m)),
+      onMessage: (h) => {
+        clientMessageHandler = h;
+      },
+      onClose: () => {},
+      close: () => {},
+    };
+
+    await client.connect(transport);
+
+    await expect(
+      gateway.request('actions/invoke', {
+        name: 'hangs',
+        input: {},
+        invocationId: 'inv-timeout',
+      }),
+    ).rejects.toMatchObject({ code: TesseronErrorCode.Timeout });
+  });
+
+  it('frees the wire with -32001 Cancelled when actions/cancel arrives on a stuck handler', async () => {
+    // Companion to the timeout case: actions/cancel from the agent must also
+    // free the wire even when the handler doesn't observe ctx.signal.
+    const client = new TesseronClient();
+    client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+    client
+      .action('hangs')
+      .timeout({ ms: 60_000 })
+      .handler(() => new Promise<never>(() => {}));
+
+    let clientMessageHandler: ((m: unknown) => void) | undefined;
+    const gateway = new JsonRpcDispatcher((m) => {
+      queueMicrotask(() => clientMessageHandler?.(m));
+    });
+    gateway.on('tesseron/hello', () => ({
+      sessionId: 'test',
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+      agent: { id: 'a', name: 'a' },
+    }));
+
+    const transport: Transport = {
+      send: (m) => queueMicrotask(() => gateway.receive(m)),
+      onMessage: (h) => {
+        clientMessageHandler = h;
+      },
+      onClose: () => {},
+      close: () => {},
+    };
+
+    await client.connect(transport);
+
+    const pending = gateway.request('actions/invoke', {
+      name: 'hangs',
+      input: {},
+      invocationId: 'inv-cancel',
+    });
+    // Let the SDK pick up the invoke before we cancel.
+    await new Promise((r) => setImmediate(r));
+    gateway.notify('actions/cancel', { invocationId: 'inv-cancel' });
+
+    await expect(pending).rejects.toMatchObject({ code: TesseronErrorCode.Cancelled });
+  });
+
+  it('ctx.withTimeout resolves on success and rejects with TimeoutError on the inner deadline', async () => {
+    const client = new TesseronClient();
+    client.app({ id: 'shop', name: 'Shop', origin: 'http://localhost' });
+    const captured: { resolved?: unknown; rejected?: unknown } = {};
+    client
+      .action('inner')
+      .timeout({ ms: 5_000 })
+      .handler(async (_input: unknown, ctx: ActionContext) => {
+        // Fast inner promise resolves within the deadline.
+        const ok = await ctx.withTimeout(Promise.resolve('ok'), 50);
+        captured.resolved = ok;
+        // Slow inner promise misses the deadline; helper rejects with TimeoutError.
+        try {
+          await ctx.withTimeout(new Promise<never>(() => {}), 20);
+        } catch (err) {
+          captured.rejected = err;
+        }
+        return 'done';
+      });
+
+    let clientMessageHandler: ((m: unknown) => void) | undefined;
+    const gateway = new JsonRpcDispatcher((m) => {
+      queueMicrotask(() => clientMessageHandler?.(m));
+    });
+    gateway.on('tesseron/hello', () => ({
+      sessionId: 'test',
+      protocolVersion: PROTOCOL_VERSION,
+      capabilities: { streaming: false, subscriptions: false, sampling: false, elicitation: false },
+      agent: { id: 'a', name: 'a' },
+    }));
+
+    const transport: Transport = {
+      send: (m) => queueMicrotask(() => gateway.receive(m)),
+      onMessage: (h) => {
+        clientMessageHandler = h;
+      },
+      onClose: () => {},
+      close: () => {},
+    };
+
+    await client.connect(transport);
+
+    const result = await gateway.request('actions/invoke', {
+      name: 'inner',
+      input: {},
+      invocationId: 'inv-with-timeout',
+    });
+    expect(result).toEqual({ invocationId: 'inv-with-timeout', output: 'done' });
+    expect(captured.resolved).toBe('ok');
+    expect(captured.rejected).toBeInstanceOf(TimeoutError);
+    expect((captured.rejected as TimeoutError).code).toBe(TesseronErrorCode.Timeout);
   });
 });


### PR DESCRIPTION
## Summary

- Race the action handler against `ctx.signal` in `handleInvoke` so a handler stuck inside a non-`AbortSignal`-aware promise (`modern-screenshot.domToPng`, `<canvas>.toBlob`, `<img>.decode`, `document.fonts.ready`, `Audio.play`, `MediaRecorder`, ...) no longer pins the agent's `tools/call` indefinitely. When the per-action `.timeout({ ms })` elapses or `actions/cancel` arrives, the SDK responds with `-32002 Timeout` / `-32001 Cancelled` immediately. The orphaned handler keeps running on its own; the agent isn't held hostage.
- Add `ctx.withTimeout(value, ms)` as the in-handler companion: bound a single stuck inner call without giving the whole action a tighter outer timeout than it actually needs. Resolves on success, rejects with `TimeoutError` on the local deadline, rejects with the abort reason (`TimeoutError` / `CancelledError`) if `ctx.signal` aborts first.
- Update `protocol/progress-cancellation`, `sdk/typescript/context`, and `sdk/typescript/action-builder` docs to match.

Closes #85.

## Why

`@tesseron/core` advertises `.timeout({ ms })` and an `actions/cancel` path that delivers `ctx.signal`, but `await action.handler(input, ctx)` was a single sequential await. If the handler was stuck inside a promise that ignored the signal, neither timer nor cancel could free the wire — the dispatcher's response was gated on the await that never settled. Issue #85 hit this with `modern-screenshot.domToPng` waiting on a Vite-HMR-orphaned `<img>.decode` / `document.fonts.ready` loop. The agent's pending `tools/call` sat indefinitely.

The fix races handler against an abort-driven reaper. Wire freed at the deadline regardless of handler responsiveness; orphan rejection is swallowed via `.catch(() => {})` so a late handler reject can never surface as `unhandledrejection`.

## What changed

- `packages/core/src/client.ts` — `handleInvoke` now races the handler against `abortReaper(controller.signal)`. Adds the `withTimeoutAgainstSignal` helper that backs `ctx.withTimeout`.
- `packages/core/src/context.ts` — `withTimeout<T>(value, ms)` added to the `ActionContext` interface.
- `packages/core/test/client.test.ts` — three new regression tests:
  - timeout frees the wire on a handler that never yields,
  - `actions/cancel` frees the wire on a handler that never yields,
  - `ctx.withTimeout` resolves on success and rejects with `TimeoutError` on its local deadline.
- `docs/src/content/docs/sdk/typescript/context.md` — documents `ctx.withTimeout` and the wire-freeing guarantee.
- `docs/src/content/docs/sdk/typescript/action-builder.md` — note next to `.timeout({ ms })` linking to `ctx.withTimeout`.
- `docs/src/content/docs/protocol/progress-cancellation.mdx` — bullet on the wire being freed regardless of handler responsiveness.
- `.changeset/un-cancellable-handler-timeout-reaper.md` — minor bump for `@tesseron/core` (the lockstep `fixed` group pulls along `web`/`server`/`react`/`mcp`/`docs-mcp`).

Note: the issue body cites `-32008 Timeout`. The actual error code is `-32002`; `-32008` is `SamplingDepthExceeded`. Implementation uses the correct `-32002`.

## Test plan

- [x] `pnpm typecheck` — 26/26 packages pass
- [x] `pnpm test` — `@tesseron/core` 52/52 (3 new), full monorepo green
- [x] `pnpm lint` — clean
- [x] `pnpm sync-plugin-version --check` — manifests already at 2.7.0
- [ ] Verify in CI that the changesets workflow opens a release PR with the minor bump on `@tesseron/core` (and lockstep siblings) once this lands.
